### PR TITLE
Add http client retry logic

### DIFF
--- a/src/core/http/HttpClient.ts
+++ b/src/core/http/HttpClient.ts
@@ -15,7 +15,8 @@ export class HttpClient {
 
   public async makeGetRequest<T>(
     url: string,
-    config: RequestConfig = {}
+    config: RequestConfig = {},
+    _isRetry = false
   ): Promise<T> {
     try {
       const headers = await this.buildHeaders(config);
@@ -24,6 +25,12 @@ export class HttpClient {
       await this.logRequestResponse(url, { method: 'GET', headers }, response.data);
       return response.data;
     } catch (error) {
+      // Attempt one automatic retry for transient errors
+      if (!_isRetry && this.isRetryableError(error)) {
+        // Optionally, add custom retry logging here if desired
+        return this.makeGetRequest(url, config, true);
+      }
+
       // Log the error response before throwing
       if (axios.isAxiosError(error)) {
         await this.logRequestResponse(url, { method: 'GET' }, error.response?.data || error.message);
@@ -35,7 +42,8 @@ export class HttpClient {
   public async makePostRequest<T>(
     url: string,
     data: unknown,
-    config: RequestConfig = {}
+    config: RequestConfig = {},
+    _isRetry = false
   ): Promise<T> {
     try {
       const headers = await this.buildHeaders(config);
@@ -44,6 +52,10 @@ export class HttpClient {
       await this.logRequestResponse(url, { method: 'POST', headers, data }, response.data);
       return response.data;
     } catch (error) {
+      if (!_isRetry && this.isRetryableError(error)) {
+        return this.makePostRequest(url, data, config, true);
+      }
+
       // Log the error response before throwing
       if (axios.isAxiosError(error)) {
         await this.logRequestResponse(url, { method: 'POST', data }, error.response?.data || error.message);
@@ -54,7 +66,8 @@ export class HttpClient {
 
   public async makeDeleteRequest<T>(
     url: string,
-    config: RequestConfig = {}
+    config: RequestConfig = {},
+    _isRetry = false
   ): Promise<T> {
     try {
       const headers = await this.buildHeaders(config);
@@ -63,6 +76,10 @@ export class HttpClient {
       await this.logRequestResponse(url, { method: 'DELETE', headers }, response.data);
       return response.data;
     } catch (error) {
+      if (!_isRetry && this.isRetryableError(error)) {
+        return this.makeDeleteRequest(url, config, true);
+      }
+
       // Log the error response before throwing
       if (axios.isAxiosError(error)) {
         await this.logRequestResponse(url, { method: 'DELETE' }, error.response?.data || error.message);
@@ -74,7 +91,8 @@ export class HttpClient {
   public async makePatchRequest<T>(
     url: string,
     data: unknown,
-    config: RequestConfig = {}
+    config: RequestConfig = {},
+    _isRetry = false
   ): Promise<T> {
     try {
       const headers = await this.buildHeaders(config);
@@ -83,6 +101,10 @@ export class HttpClient {
       await this.logRequestResponse(url, { method: 'PATCH', headers, data }, response.data);
       return response.data;
     } catch (error) {
+      if (!_isRetry && this.isRetryableError(error)) {
+        return this.makePatchRequest(url, data, config, true);
+      }
+
       // Log the error response before throwing
       if (axios.isAxiosError(error)) {
         await this.logRequestResponse(url, { method: 'PATCH', data }, error.response?.data || error.message);
@@ -139,5 +161,16 @@ export class HttpClient {
     return new NetworkError(
       `Request failed: ${error instanceof Error ? error.message : String(error)}`
     );
+  }
+
+  /** Determines whether a request error is retryable (HTTP 5xx or network error) */
+  private isRetryableError(error: unknown): boolean {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      // Retry on 5xx server errors and undefined status (network error)
+      return status === undefined || (status >= 500 && status < 600);
+    }
+    // Non-Axios errors are likely network-related; allow retry
+    return true;
   }
 } 


### PR DESCRIPTION
Add automatic single-retry logic to `HttpClient` for transient network and 5xx errors.

This change addresses intermittent API failures, such as the reported HTTP 503 error, by automatically retrying the request once before propagating the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f4558f5-fba9-4c9f-acce-cade923d9610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f4558f5-fba9-4c9f-acce-cade923d9610">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

