### PR TITLE
ci: npm Trusted Publisher (OIDC) for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          # Trusted publishing requires Node >= 22.14.0 (npm docs)
+          node-version: '22.14'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm
+        # Trusted publishing requires npm CLI >= 11.5.1
         run: npm install --global npm@^11.10.0
 
       - name: Install dependencies
@@ -45,10 +47,9 @@ jobs:
       - name: Prepare release
         run: npm run prepare-release
 
+      # Publishes via npm Trusted Publisher (OIDC); do not set NODE_AUTH_TOKEN here.
       - name: Publish to NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create and push git tag
         run: |
@@ -63,8 +64,6 @@ jobs:
           git config --local user.name "GitHub Action"
           git tag -a "v$NEW_VERSION" -m "$CHANGELOG"
           git push origin "v$NEW_VERSION"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate documentation
         run: npm run docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fairmint/canton-node-sdk",
-  "version": "0.0.192",
+  "version": "0.0.196",
   "description": "Canton Node SDK",
   "keywords": [
     "canton",
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Fairmint/canton-node-sdk.git"
+    "url": "https://github.com/Fairmint/canton-node-sdk.git"
   },
   "license": "MIT",
   "author": "Fairmint",


### PR DESCRIPTION
Switches `publish.yml` to **npm Trusted Publishing** so `npm publish` uses GitHub OIDC instead of `secrets.NPM_TOKEN`.

### Changes
- Remove `NODE_AUTH_TOKEN` from the **Publish to NPM** step.
- **Node 22.14+** and **npm ^11.10** (meets npm’s **11.5.1+** requirement for trusted publishing). Replaces Node 18 for the publish job.
- Remove the **Create and push git tag** step’s `NODE_AUTH_TOKEN` env (git uses `actions/checkout` credentials; that variable was npm-specific and confusing).
- `repository.url` → `https://github.com/Fairmint/canton-node-sdk.git` for npm’s GitHub repository match.

### Prerequisite
On [npmjs.com](https://www.npmjs.com/) → package **@fairmint/canton-node-sdk** → **Settings** → **Trusted Publisher**, connect **Fairmint/canton-node-sdk** and workflow **publish.yml** (same pattern as `@open-captable-protocol/canton`).

### After merge
1. Confirm the next `main` publish run succeeds.
2. Remove the `NPM_TOKEN` repo secret and revoke the old npm automation token if unused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release/publish pipeline authentication from `NPM_TOKEN` to OIDC, so misconfiguration could block npm releases. Runtime is also upgraded to Node 22/npm 11 for publishing, which may surface tooling incompatibilities in CI.
> 
> **Overview**
> Switches the `publish.yml` workflow to publish via **npm Trusted Publisher (OIDC)** by removing `NODE_AUTH_TOKEN` usage and relying on `id-token: write` permissions.
> 
> Upgrades the publish job to **Node 22.14** and **npm ^11.10** to meet trusted publishing requirements, and updates `package.json` metadata (version bump and `repository.url` to an `https://...` form) to align with npm’s GitHub repository matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c9f1fcd9d77dc0e99028e0c749dda7c5cfefec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->