### PR TITLE
feat(ledger-json): upload DAR vetAllPackages and synchronizerId query params

### DIFF
--- a/src/clients/ledger-json-api/operations/v2/packages/post.ts
+++ b/src/clients/ledger-json-api/operations/v2/packages/post.ts
@@ -9,6 +9,13 @@ export const UploadDarFileParamsSchema = z.object({
   filePath: z.string(),
   /** Optional submission ID for deduplication */
   submissionId: z.string().optional(),
+  /**
+   * When true (default), Canton vets all packages after upload and runs upgrade-compatibility checks.
+   * Set false to upload into the package store only; vet separately (e.g. with force flags) if needed.
+   */
+  vetAllPackages: z.boolean().optional(),
+  /** Synchronizer id for vetting when vetAllPackages is true (optional; Canton may auto-detect). */
+  synchronizerId: z.string().optional(),
 });
 
 export type UploadDarFileParams = z.infer<typeof UploadDarFileParamsSchema>;
@@ -36,6 +43,12 @@ export const UploadDarFile = createApiOperation<UploadDarFileParams, UploadDarFi
 
     if (params.submissionId) {
       queryParams.append('submission_id', params.submissionId);
+    }
+    if (params.vetAllPackages === false) {
+      queryParams.append('vetAllPackages', 'false');
+    }
+    if (params.synchronizerId) {
+      queryParams.append('synchronizerId', params.synchronizerId);
     }
 
     const queryString = queryParams.toString();


### PR DESCRIPTION
## Summary
Adds optional `vetAllPackages` and `synchronizerId` to `uploadDarFile` so clients can call Canton`s `POST /v2/packages` with `vetAllPackages=false` (skips upgrade checks at upload) and optionally pass a synchronizer id when vetting is enabled.

## Why
When a DAR is valid LF but not a valid upgrade of an existing vetted package (e.g. different embedded splice-amulet lineage), default upload vetting returns `NOT_VALID_UPGRADE_PACKAGE`. Uploading without vetting is the supported split: store the DAR, then vet via `/v2/package-vetting` with operator force flags if appropriate.

## Consumer
`@fairmint/open-captable-protocol-daml-js` can pass these through `LedgerJsonApiClient.uploadDarFile` once this version is published (scripts may also POST manually until upgraded).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `POST /v2/packages` URLs are constructed and can alter server-side vetting behavior (skipping checks or targeting a synchronizer) for package uploads.
> 
> **Overview**
> Adds two optional parameters to `uploadDarFile` (`vetAllPackages` and `synchronizerId`) and forwards them as query params when calling `POST /v2/packages`.
> 
> `vetAllPackages=false` is now explicitly sent to allow uploading a DAR without automatic vetting/upgrade checks, and `synchronizerId` can be provided to influence vetting when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5626209e37f766de72bb71e4eaad466d85bdb204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced package upload API with new optional parameters: control whether packages undergo vetting during or after upload, and specify additional vetting context for the upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->