### PR TITLE
docs: TSDoc/JSDoc improvements for public surfaces

### DIFF
--- a/src/Canton.ts
+++ b/src/Canton.ts
@@ -29,7 +29,7 @@ export interface CantonConfig {
   readonly managedParties?: readonly string[];
   /** OAuth2 auth URL (if different from default). */
   readonly authUrl?: string;
-  /** Override API configurations per client type. */
+  /** Override API endpoints or timeouts per service (`ledgerJsonApi`, `validatorApi`, `scanApi`). */
   readonly apis?: ClientConfig['apis'];
 }
 
@@ -71,9 +71,12 @@ export class Canton {
   /**
    * Creates a new Canton unified client.
    *
+   * @param config - Connection targets (`network`, optional `provider`) plus identity/logging/API overrides.
+   *
    * @example
    *   const canton = new Canton({ network: 'localnet' });
    *
+   * @example
    *   const canton = new Canton({
    *     network: 'devnet',
    *     provider: '5n',

--- a/src/clients/ledger-json-api/completion-stream.ts
+++ b/src/clients/ledger-json-api/completion-stream.ts
@@ -1,11 +1,22 @@
 import { type LedgerJsonApiClient } from './index';
 import { type CompletionsWsMessage } from './operations/v2/commands/subscribe-to-completions';
 
+/**
+ * Arguments for {@link waitForCompletion} / {@link waitForCompletionWithMetadata}.
+ *
+ * Use the same `submissionId` you passed when submitting the command, `partyId` / `userId` matching the subscription,
+ * and `beginExclusive` set from ledger-offset bookkeeping used when subscribing (typically before submit offset).
+ */
 export interface WaitForCompletionParams {
+  /** Submission identifier returned by the submit/prepare flow for this command. */
   readonly submissionId: string;
+  /** Party whose completions stream should include this submission. */
   readonly partyId: string;
+  /** Ledger user id used when subscribing to completions (must match authenticated stream user). */
   readonly userId: string;
+  /** Exclusive lower bound for the completions stream (`beginExclusive` / checkpoint offset semantics). */
   readonly beginExclusive: number;
+  /** Max wait before rejecting with a timeout error (default 10 minutes). */
   readonly timeoutMs?: number;
 }
 
@@ -138,7 +149,28 @@ async function waitForCompletionCore<T>(
   });
 }
 
-/** Wait for a specific completion using the ledger's WebSocket completions stream. */
+/**
+ * Waits until the completions WebSocket delivers the completion for `submissionId`, then returns the ledger `updateId`.
+ *
+ * Prefer this over polling HTTP completions when you already submitted async/interactive commands and need to block on
+ * one submission.
+ *
+ * @param ledgerClient - Client used to open `subscribeToCompletions`
+ * @param params - Submission identity, party/user, offset cursor, optional timeout
+ * @returns The canonical update id string for the completed submission
+ * @throws Error if the completion reports non-zero status, omits `updateId`, the stream errors/closes early, or time runs out
+ *
+ * @example
+ * ```ts
+ * const submissionId = '…'; // from your submit response
+ * await waitForCompletion(ledger, {
+ *   submissionId,
+ *   partyId,
+ *   userId,
+ *   beginExclusive,
+ * });
+ * ```
+ */
 export async function waitForCompletion(
   ledgerClient: LedgerJsonApiClient,
   params: WaitForCompletionParams
@@ -147,8 +179,11 @@ export async function waitForCompletion(
 }
 
 /**
- * Like {@link waitForCompletion}, but also surfaces `paidTrafficCost` when the Ledger API includes it on the completion
- * (recent Canton versions).
+ * Same as {@link waitForCompletion}, but returns `{ updateId, paidTrafficCost? }` when the Ledger API attaches traffic
+ * cost metadata to the completion (supported Canton versions).
+ *
+ * @param ledgerClient - Client used to open `subscribeToCompletions`
+ * @param params - Same as {@link waitForCompletion}
  */
 export async function waitForCompletionWithMetadata(
   ledgerClient: LedgerJsonApiClient,

--- a/src/clients/ledger-json-api/operations/v2/commands/async/submit.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/async/submit.ts
@@ -13,6 +13,9 @@ export type AsyncSubmitParams = z.infer<typeof AsyncSubmitParamsSchema>;
 
 export type AsyncSubmitResponse = paths[typeof endpoint]['post']['responses']['200']['content']['application/json'];
 
+/**
+ * Submits commands without blocking (`async-submit`). Pair with completion polling/stream for confirmation.
+ */
 export const AsyncSubmit = createApiOperation<AsyncSubmitParams, AsyncSubmitResponse>({
   paramsSchema: AsyncSubmitParamsSchema,
   method: 'POST',

--- a/src/clients/ledger-json-api/operations/v2/commands/completions.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/completions.ts
@@ -16,6 +16,12 @@ export type CompletionsParams = z.infer<typeof CompletionsParamsSchema>;
 export type CompletionsRequest = paths[typeof endpoint]['post']['requestBody']['content']['application/json'];
 export type CompletionsResponse = paths[typeof endpoint]['post']['responses']['200']['content']['application/json'];
 
+/**
+ * Polls command completions over **HTTP** POST `/v2/commands/completions` (cursor batch).
+ *
+ * For waiting on a **specific submission**, prefer `waitForCompletion` / `subscribeToCompletions`
+ * streaming instead.
+ */
 export const Completions = createApiOperation<CompletionsParams, CompletionsResponse>({
   paramsSchema: CompletionsParamsSchema,
   method: 'POST',

--- a/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait.ts
@@ -13,6 +13,11 @@ export type SubmitAndWaitParams = z.infer<typeof SubmitAndWaitParamsSchema>;
 
 export type SubmitAndWaitResponse = paths[typeof endpoint]['post']['responses']['200']['content']['application/json'];
 
+/**
+ * Submits commands synchronously and blocks until completion (`submit-and-wait`).
+ *
+ * `commandId` defaults when omitted; `actAs` defaults to the client's configured party when omitted.
+ */
 export const SubmitAndWait = createApiOperation<SubmitAndWaitParams, SubmitAndWaitResponse>({
   paramsSchema: SubmitAndWaitParamsSchema,
   method: 'POST',

--- a/src/clients/ledger-json-api/operations/v2/commands/subscribe-to-completions.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/subscribe-to-completions.ts
@@ -15,6 +15,11 @@ export type CompletionsWsMessage =
   | z.infer<typeof JsCantonErrorSchema>
   | z.infer<typeof WsCantonErrorSchema>;
 
+/**
+ * WebSocket stream of completions (`/v2/commands/completions`), exposed as `LedgerJsonApiClient.subscribeToCompletions`.
+ *
+ * `userId` can come from params or the client's configured user id (otherwise subscribe fails fast).
+ */
 export const SubscribeToCompletions = createWebSocketOperation<
   CompletionsWsParams,
   CompletionStreamRequest,

--- a/src/utils/amulet/get-amulets-for-transfer.ts
+++ b/src/utils/amulet/get-amulets-for-transfer.ts
@@ -89,11 +89,18 @@ function extractOwner(payload: Record<string, unknown>, templateId: string): str
 }
 
 /**
- * Gets unlocked amulets owned by the sender party that can be used for transfers. Optionally returns all valid transfer
- * inputs (Amulet, AppRewardCoupon, ValidatorRewardCoupon).
+ * Gets unlocked Amulet contracts owned by the selected sender (`readAs[0]`) plus reward coupons when enabled.
  *
- * @param params - Parameters for getting transfer inputs
- * @returns Promise resolving to array of transfer inputs suitable for transfer
+ * @param params - Ledger client for ACS snapshots plus viewer scopes (`readAs`)
+ * @returns Contracts sorted largest-first so greedy transfers consume highest denominations first
+ *
+ * @example
+ * ```ts
+ * const inputs = await getAmuletsForTransfer({
+ *   jsonApiClient,
+ *   readAs: [senderPartyId],
+ * });
+ * ```
  */
 export async function getAmuletsForTransfer(params: GetAmuletsForTransferParams): Promise<AmuletForTransfer[]> {
   const { jsonApiClient, readAs, includeAllTransferInputs } = params;

--- a/src/utils/external-signing/execute-external-transaction.ts
+++ b/src/utils/external-signing/execute-external-transaction.ts
@@ -16,7 +16,12 @@ export interface ExecuteExternalTransactionOptions {
   readonly deduplicationPeriod?: InteractiveSubmissionExecuteRequest['deduplicationPeriod'];
 }
 
-/** Submit a previously prepared and externally signed interactive submission to the ledger. */
+/**
+ * Executes an interactive submission after offline signing (`interactiveSubmissionExecute`).
+ *
+ * @param options - Prepared blob from {@link prepareExternalTransaction}, submission id, per-party signatures
+ * @returns Validator response payload from interactive submission execute
+ */
 export async function executeExternalTransaction(
   options: ExecuteExternalTransactionOptions
 ): Promise<InteractiveSubmissionExecuteResponse> {

--- a/src/utils/external-signing/prepare-external-transaction.ts
+++ b/src/utils/external-signing/prepare-external-transaction.ts
@@ -22,7 +22,23 @@ export interface PrepareExternalTransactionResult extends InteractiveSubmissionP
   readonly commandId: string;
 }
 
-/** Convenience helper for preparing an interactive submission that will be signed off-ledger. */
+/**
+ * Runs interactive submission **prepare** so payloads can be signed offline (`interactiveSubmissionPrepare`).
+ *
+ * @param options - Ledger client, commands, identity (`userId`, `actAs`), synchronizer scope, optional disclosures
+ * @returns Prepared transaction blob plus echoed `commandId`
+ *
+ * @example
+ * ```ts
+ * const prepared = await prepareExternalTransaction({
+ *   ledgerClient,
+ *   commands: [{ ExerciseCommand: { … } }],
+ *   userId,
+ *   actAs: [partyId],
+ *   synchronizerId,
+ * });
+ * ```
+ */
 export async function prepareExternalTransaction(
   options: PrepareExternalTransactionOptions
 ): Promise<PrepareExternalTransactionResult> {

--- a/src/utils/mining/mining-rounds.ts
+++ b/src/utils/mining/mining-rounds.ts
@@ -6,7 +6,7 @@ import {
 } from '../../clients/validator-api/schemas/api';
 import { OperationError, OperationErrorCode } from '../../core/errors';
 
-/** Client interface required for mining round operations */
+/** Minimal Validator/client operations dependency surface required by mining helper utilities. */
 export interface MiningRoundClient {
   getOpenAndIssuingMiningRounds: () => Promise<GetOpenAndIssuingMiningRoundsResponse>;
 }

--- a/src/utils/parsers/fee-parser.ts
+++ b/src/utils/parsers/fee-parser.ts
@@ -1,4 +1,8 @@
-/** Types for fee-related data structures */
+/**
+ * Helpers for decoding Amulet fee breakdown from exercised transaction trees (`AmuletRules_Transfer`).
+ *
+ * Typical flow: submit a transfer, read `transactionTreeById`, pass `eventTree` into {@link parseFeesFromEventTree}.
+ */
 
 import { type TreeEvent } from '../../clients/ledger-json-api/schemas/api/events';
 import { ValidationError } from '../../core/errors';
@@ -130,10 +134,17 @@ function findAmuletRulesTransferEvent(eventTree: Record<string, TreeEvent>): Tre
 }
 
 /**
- * Parses fee information from an event tree (Record<string, TreeEvent>)
+ * Parses fee information from an event tree (`Record<string, TreeEvent>`), usually from a transaction tree response.
  *
- * @param eventTree - The event tree object
- * @returns FeeAnalysis object with extracted fee information and validation
+ * @param eventTree - Event tree containing an `AmuletRules_Transfer` exercise
+ * @returns Structured totals, per-party balance deltas, and simple arithmetic validation flags
+ * @throws ValidationError when no transferable fee-bearing exercise exists in the tree
+ *
+ * @example
+ * ```ts
+ * const analysis = parseFeesFromEventTree(transaction.transactionTreeById.eventTree);
+ * console.log(analysis.totalFees, analysis.feeBreakdown.holdingFees);
+ * ```
  */
 export function parseFeesFromEventTree(eventTree: Record<string, TreeEvent>): FeeAnalysis {
   const amuletRulesEvent = findAmuletRulesTransferEvent(eventTree);

--- a/src/utils/party/createParty.ts
+++ b/src/utils/party/createParty.ts
@@ -28,8 +28,24 @@ export interface PartyCreationResult {
 /**
  * Creates a party, optionally funds the wallet and if funded it then creates a preapproval contract for the party.
  *
- * @param options - Configuration options for party creation
- * @returns Promise resolving to the party creation result
+ * @param options - Ledger + validator clients, human-readable party prefix, optional funded wallet (`amount` > 0)
+ * @returns `partyId` plus optional `preapprovalContractId` when transfers succeed past onboarding funding.
+ * @throws ValidationError when `amount` is not a valid non-negative number string.
+ *
+ * @example Fund onboarding wallet + pre-approve transfers for downstream transfers:
+ * ```ts
+ * const { partyId, preapprovalContractId } = await createParty({
+ *   ledgerClient: canton.ledger,
+ *   validatorClient: canton.validator,
+ *   partyName: 'alice',
+ *   amount: '100',
+ * });
+ * ```
+ *
+ * @example Bare identity without sponsoring transfers (`amount` `'0'`):
+ * ```ts
+ * await createParty({ ledgerClient, validatorClient, partyName: 'bob', amount: '0' });
+ * ```
  */
 export async function createParty(options: CreatePartyOptions): Promise<PartyCreationResult> {
   // Use provided clients directly

--- a/src/utils/transactions/TransactionBatch.ts
+++ b/src/utils/transactions/TransactionBatch.ts
@@ -9,9 +9,7 @@ interface SubmitParams {
 }
 
 /**
- * Builder for batching multiple commands into a single ledger submission.
- *
- * Uses a fluent API so you can chain calls:
+ * Builder for batching multiple commands into a single ledger submission using fluent chaining.
  *
  * @example
  *   const result = await new TransactionBatch(client, [partyId])
@@ -26,6 +24,11 @@ export class TransactionBatch {
   private disclosedContracts: DisclosedContract[] = [];
   private commands: Command[] = [];
 
+  /**
+   * @param client - Ledger client performing submits (`submitAndWait`, etc.).
+   * @param actAs - Parties authorized as controllers/signer contexts on submissions (typically `readAs[0]` sender chain).
+   * @param readAs - Extra disclosure/read scopes forwarded verbatim when omitted elsewhere on submissions.
+   */
   constructor(client: LedgerJsonApiClient, actAs: readonly string[], readAs?: readonly string[]) {
     this.client = client;
     this.actAs = [...actAs];


### PR DESCRIPTION
Documentation on the public web SDK site (`fairmint/web`) uses hand-written Markdown. This PR only adds richer **TSDoc/JSDoc** on selected public surfaces so IDEs surface better inline hints—not a runtime/SDK behavior change.

**Files touched:**
- `src/Canton.ts`
- `src/clients/ledger-json-api/completion-stream.ts`
- `src/clients/ledger-json-api/operations/v2/commands/async/submit.ts`
- `src/clients/ledger-json-api/operations/v2/commands/completions.ts`
- `src/clients/ledger-json-api/operations/v2/commands/submit-and-wait.ts`
- `src/clients/ledger-json-api/operations/v2/commands/subscribe-to-completions.ts`
- `src/utils/amulet/get-amulets-for-transfer.ts`
- `src/utils/external-signing/execute-external-transaction.ts`
- `src/utils/external-signing/prepare-external-transaction.ts`
- `src/utils/mining/mining-rounds.ts`
- `src/utils/parsers/fee-parser.ts`
- `src/utils/party/createParty.ts`
- `src/utils/transactions/TransactionBatch.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation-only in the provided diff and should not affect runtime behavior; risk is limited to potential developer confusion if docs are inaccurate.
> 
> **Overview**
> Primarily improves **API documentation/JSDoc** across the SDK: clarifies `CantonConfig.apis`, expands `Canton` constructor examples, and adds usage/behavior docs for ledger command submission/completions (`submit-and-wait`, `async-submit`, HTTP `completions`, WebSocket `subscribeToCompletions`, and `waitForCompletion*`).
> 
> Also tightens utility docs and examples for transfer input selection (`getAmuletsForTransfer`), external signing helpers (`prepareExternalTransaction`, `executeExternalTransaction`), fee parsing (`parseFeesFromEventTree`), mining helpers, and `TransactionBatch` constructor parameters; no runtime logic changes are introduced in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc76bedf9d8a655dfc237f3a2a7d231d88ce857a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded JSDoc comments across multiple modules with improved parameter descriptions, return type documentation, and usage examples.
  * Clarified behavior and error handling in key API operations and utility functions for better developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->