### PR TITLE
Point npm package homepage at GitHub wiki

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "blockchain",
     "daml"
   ],
-  "homepage": "https://sdk.canton.fairmint.com/",
+  "homepage": "https://github.com/Fairmint/canton-node-sdk/wiki",
   "bugs": {
     "url": "https://github.com/Fairmint/canton-node-sdk/issues"
   },


### PR DESCRIPTION
## Summary

Documentation for this SDK now lives on the [GitHub wiki](https://github.com/Fairmint/canton-node-sdk/wiki). This updates `package.json` `homepage` so npm/registry links resolve to the wiki instead of the former hosted docs URL.

Related: web monorepo removes the Astro docs app; wiki hosts the migrated content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change in `package.json` with no runtime or build logic impact.
> 
> **Overview**
> Updates `package.json` `homepage` to link to the GitHub wiki instead of the previous hosted documentation URL, so npm/registry metadata routes users to the new docs location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e8dc1503d24104743033cf6d26fb82ecf93796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the package documentation reference URL to point to the project's wiki.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->