### PR TITLE
Update Splice submodule to 0.6.8

### DIFF
--- a/src/clients/ledger-json-api/completion-stream.ts
+++ b/src/clients/ledger-json-api/completion-stream.ts
@@ -1,6 +1,8 @@
 import { type LedgerJsonApiClient } from './index';
 import { type CompletionsWsMessage } from './operations/v2/commands/subscribe-to-completions';
 
+const COMPLETION_STREAM_RETRY_DELAY_MS = 250;
+
 /**
  * Arguments for {@link waitForCompletion} / {@link waitForCompletionWithMetadata}.
  *
@@ -75,11 +77,16 @@ async function waitForCompletionCore<T>(
   const { submissionId, partyId, userId, beginExclusive, timeoutMs = 10 * 60 * 1000 } = params;
 
   return new Promise((resolve, reject) => {
-    let closed = false;
+    let settled = false;
     let subscription: { close: () => void } | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
     const cleanup = (): void => {
-      closed = true;
+      settled = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
       if (subscription) {
         subscription.close();
         subscription = null;
@@ -92,7 +99,7 @@ async function waitForCompletionCore<T>(
     }, timeoutMs);
 
     const handleError = (error: unknown): void => {
-      if (closed) {
+      if (settled) {
         return;
       }
       clearTimeout(timer);
@@ -101,51 +108,70 @@ async function waitForCompletionCore<T>(
       reject(err);
     };
 
-    void ledgerClient
-      .subscribeToCompletions(
-        {
-          userId,
-          parties: [partyId],
-          beginExclusive,
-        },
-        {
-          onMessage: (message: CompletionsWsMessage) => {
-            const completion = extractCompletion(message);
-            if (!completion) {
-              return;
-            }
-            if (completion.submissionId !== submissionId) {
-              return;
-            }
-            clearTimeout(timer);
-            cleanup();
+    const scheduleResubscribe = (): void => {
+      if (settled) {
+        return;
+      }
+      subscription = null;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        subscribe();
+      }, COMPLETION_STREAM_RETRY_DELAY_MS);
+    };
 
-            if (completion.statusCode && completion.statusCode !== 0) {
-              reject(new Error(completion.statusMessage ?? 'Transaction failed'));
-              return;
-            }
+    const handleMessage = (message: CompletionsWsMessage): void => {
+      const completion = extractCompletion(message);
+      if (!completion) {
+        return;
+      }
+      if (completion.submissionId !== submissionId) {
+        return;
+      }
 
-            const { updateId } = completion;
-            if (!updateId) {
-              reject(new Error('Completion did not include updateId'));
-              return;
-            }
+      if (completion.statusCode && completion.statusCode !== 0) {
+        handleError(new Error(completion.statusMessage ?? 'Transaction failed'));
+        return;
+      }
 
-            resolve(mapSuccess(completion, updateId));
+      const { updateId } = completion;
+      if (!updateId) {
+        handleError(new Error('Completion did not include updateId'));
+        return;
+      }
+
+      clearTimeout(timer);
+      cleanup();
+      resolve(mapSuccess(completion, updateId));
+    };
+
+    const subscribe = (): void => {
+      if (settled) {
+        return;
+      }
+
+      void ledgerClient
+        .subscribeToCompletions(
+          {
+            userId,
+            parties: [partyId],
+            beginExclusive,
           },
-          onError: handleError,
-          onClose: () => {
-            handleError(new Error('Completion subscription closed before receiving response'));
+          {
+            onMessage: handleMessage,
+            onError: handleError,
+            onClose: scheduleResubscribe,
           },
-        }
-      )
-      .then((sub) => {
-        subscription = sub;
-        if (closed) {
-          subscription.close();
-        }
-      })
-      .catch(handleError);
+        )
+        .then((sub) => {
+          subscription = sub;
+          if (settled) {
+            subscription.close();
+          }
+        })
+        .catch(handleError);
+    };
+
+    subscribe();
   });
 }
 
@@ -158,7 +184,7 @@ async function waitForCompletionCore<T>(
  * @param ledgerClient - Client used to open `subscribeToCompletions`
  * @param params - Submission identity, party/user, offset cursor, optional timeout
  * @returns The canonical update id string for the completed submission
- * @throws Error if the completion reports non-zero status, omits `updateId`, the stream errors/closes early, or time runs out
+ * @throws Error if the completion reports non-zero status, omits `updateId`, the stream errors, or time runs out
  *
  * @example
  * ```ts

--- a/src/clients/ledger-json-api/completion-stream.ts
+++ b/src/clients/ledger-json-api/completion-stream.ts
@@ -113,6 +113,9 @@ async function waitForCompletionCore<T>(
         return;
       }
       subscription = null;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
       retryTimer = setTimeout(() => {
         retryTimer = null;
         subscribe();

--- a/src/clients/ledger-json-api/completion-stream.ts
+++ b/src/clients/ledger-json-api/completion-stream.ts
@@ -80,6 +80,7 @@ async function waitForCompletionCore<T>(
     let settled = false;
     let subscription: { close: () => void } | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let subscribeAttempt = 0;
 
     const cleanup = (): void => {
       settled = true;
@@ -108,8 +109,8 @@ async function waitForCompletionCore<T>(
       reject(err);
     };
 
-    const scheduleResubscribe = (): void => {
-      if (settled) {
+    const scheduleResubscribe = (attempt: number): void => {
+      if (settled || attempt !== subscribeAttempt) {
         return;
       }
       subscription = null;
@@ -122,7 +123,11 @@ async function waitForCompletionCore<T>(
       }, COMPLETION_STREAM_RETRY_DELAY_MS);
     };
 
-    const handleMessage = (message: CompletionsWsMessage): void => {
+    const handleMessage = (attempt: number, message: CompletionsWsMessage): void => {
+      if (attempt !== subscribeAttempt) {
+        return;
+      }
+
       const completion = extractCompletion(message);
       if (!completion) {
         return;
@@ -152,6 +157,9 @@ async function waitForCompletionCore<T>(
         return;
       }
 
+      const attempt = subscribeAttempt + 1;
+      subscribeAttempt = attempt;
+
       void ledgerClient
         .subscribeToCompletions(
           {
@@ -160,12 +168,20 @@ async function waitForCompletionCore<T>(
             beginExclusive,
           },
           {
-            onMessage: handleMessage,
-            onError: handleError,
-            onClose: scheduleResubscribe,
+            onMessage: (message) => handleMessage(attempt, message),
+            onError: (error) => {
+              if (attempt === subscribeAttempt) {
+                handleError(error);
+              }
+            },
+            onClose: () => scheduleResubscribe(attempt),
           },
         )
         .then((sub) => {
+          if (attempt !== subscribeAttempt) {
+            sub.close();
+            return;
+          }
           subscription = sub;
           if (settled) {
             subscription.close();

--- a/src/clients/ledger-json-api/completion-stream.ts
+++ b/src/clients/ledger-json-api/completion-stream.ts
@@ -113,7 +113,9 @@ async function waitForCompletionCore<T>(
       if (settled || attempt !== subscribeAttempt) {
         return;
       }
+      const activeSubscription = subscription;
       subscription = null;
+      activeSubscription?.close();
       if (retryTimer) {
         clearTimeout(retryTimer);
       }

--- a/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree.ts
@@ -1,5 +1,6 @@
 import { type z } from 'zod';
 import { createApiOperation } from '../../../../../core';
+import { ApiError } from '../../../../../core/errors';
 import type { paths } from '../../../../../generated/canton/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi';
 import { SubmitAndWaitForTransactionTreeParamsSchema } from '../../../schemas/operations';
 
@@ -7,8 +8,11 @@ const endpoint = '/v2/commands/submit-and-wait-for-transaction-tree' as const;
 
 export type SubmitAndWaitForTransactionTreeParams = z.infer<typeof SubmitAndWaitForTransactionTreeParamsSchema>;
 
-export type SubmitAndWaitForTransactionTreeResponse =
-  paths[typeof endpoint]['post']['responses']['200']['content']['application/json'];
+type GeneratedResponse = paths[typeof endpoint]['post']['responses']['200']['content']['application/json'];
+
+export type SubmitAndWaitForTransactionTreeResponse = GeneratedResponse & {
+  readonly transactionTree: NonNullable<GeneratedResponse['transactionTree']>;
+};
 
 export const SubmitAndWaitForTransactionTree = createApiOperation<
   SubmitAndWaitForTransactionTreeParams,
@@ -24,4 +28,11 @@ export const SubmitAndWaitForTransactionTree = createApiOperation<
       `submit-and-wait-for-transaction-tree-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
     actAs: params.actAs ?? [client.getPartyId()],
   }),
+  transformResponse: (response) => {
+    const generatedResponse = response as GeneratedResponse;
+    if (!generatedResponse.transactionTree) {
+      throw new ApiError('Submit-and-wait-for-transaction-tree response did not include a transaction tree');
+    }
+    return response;
+  },
 });

--- a/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree.ts
@@ -28,9 +28,9 @@ export const SubmitAndWaitForTransactionTree = createApiOperation<
       `submit-and-wait-for-transaction-tree-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
     actAs: params.actAs ?? [client.getPartyId()],
   }),
-  transformResponse: (response) => {
-    const generatedResponse = response as GeneratedResponse;
-    if (!generatedResponse.transactionTree) {
+  transformResponse: (response): SubmitAndWaitForTransactionTreeResponse => {
+    const generatedResponse = response as unknown as { readonly transactionTree?: unknown };
+    if (generatedResponse.transactionTree === undefined || generatedResponse.transactionTree === null) {
       throw new ApiError('Submit-and-wait-for-transaction-tree response did not include a transaction tree');
     }
     return response;

--- a/src/clients/ledger-json-api/operations/v2/parties/aggregate-parties.ts
+++ b/src/clients/ledger-json-api/operations/v2/parties/aggregate-parties.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { ApiOperation } from '../../../../../core';
+import { ApiError } from '../../../../../core/errors';
 import type { paths } from '../../../../../generated/canton/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi';
 
 const endpoint = '/v2/parties';
@@ -36,8 +37,13 @@ export async function fetchAllParties(
       includeBearerToken: true,
     });
 
-    if (response.partyDetails.length > 0) {
-      aggregatedPartyDetails.push(...response.partyDetails);
+    const rawPartyDetails: unknown = response.partyDetails;
+    if (!Array.isArray(rawPartyDetails)) {
+      throw new ApiError('ListParties response did not include partyDetails');
+    }
+    const partyDetails = rawPartyDetails as PartyDetail[];
+    if (partyDetails.length > 0) {
+      aggregatedPartyDetails.push(...partyDetails);
     }
 
     const nextTokenRaw = response.nextPageToken;

--- a/src/clients/ledger-json-api/operations/v2/parties/aggregate-parties.ts
+++ b/src/clients/ledger-json-api/operations/v2/parties/aggregate-parties.ts
@@ -36,7 +36,7 @@ export async function fetchAllParties(
       includeBearerToken: true,
     });
 
-    if (response.partyDetails?.length) {
+    if (response.partyDetails.length > 0) {
       aggregatedPartyDetails.push(...response.partyDetails);
     }
 

--- a/src/clients/ledger-json-api/operations/v2/parties/external/allocate-external-party.ts
+++ b/src/clients/ledger-json-api/operations/v2/parties/external/allocate-external-party.ts
@@ -31,8 +31,8 @@ export const AllocateExternalPartyParamsSchema = z.object({
   /** Synchronizer ID on which to onboard the party */
   synchronizer: z.string(),
   /** Topology transactions to onboard the external party (from generate-topology endpoint) */
-  onboardingTransactions: z.array(SignedTransactionSchema).optional(),
-  /** Signatures for the multi-hash (alternative to signing each individual transaction) */
+  onboardingTransactions: z.array(SignedTransactionSchema),
+  /** Signatures for the multi-hash (alternative to signatures on each individual transaction) */
   multiHashSignatures: z.array(SignatureSchema).optional(),
   /** Identity provider ID. If not set, assume the party is managed by the default identity provider. */
   identityProviderId: z.string(),
@@ -45,8 +45,8 @@ export type AllocateExternalPartyResponse = GeneratedResponse;
 /**
  * Allocate a new external party
  *
- * This endpoint completes the onboarding of an external party by submitting the signed topology transactions or
- * multi-hash signatures. The topology transactions and multi-hash should be obtained from the generate-topology
+ * This endpoint completes the onboarding of an external party by submitting the topology transactions and signatures.
+ * The topology transactions and multi-hash should be obtained from the generate-topology
  * endpoint and signed with the external party's private key.
  *
  * @example
@@ -55,6 +55,9 @@ export type AllocateExternalPartyResponse = GeneratedResponse;
  *   const result = await client.allocateExternalParty({
  *     synchronizer: 'global-synchronizer',
  *     identityProviderId: 'default',
+ *     onboardingTransactions: [{
+ *       transaction: 'serialized-transaction'
+ *     }],
  *     multiHashSignatures: [{
  *       format: 'SIGNATURE_FORMAT_RAW',
  *       signature: 'base64-encoded-signature',
@@ -81,9 +84,7 @@ export const AllocateExternalParty = createApiOperation<AllocateExternalPartyPar
   buildRequestData: (params: AllocateExternalPartyParams, _client: BaseClient): GeneratedRequest => ({
     synchronizer: params.synchronizer,
     identityProviderId: params.identityProviderId,
-    ...(params.onboardingTransactions && {
-      onboardingTransactions: params.onboardingTransactions,
-    }),
+    onboardingTransactions: params.onboardingTransactions,
     ...(params.multiHashSignatures && {
       multiHashSignatures: params.multiHashSignatures,
     }),

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -43,7 +43,10 @@ export class GetActiveContracts {
       ({ activeAtOffset } = validated);
     } else {
       const ledgerEnd = await this.client.getLedgerEnd({});
-      ({ offset: activeAtOffset } = ledgerEnd);
+      if (ledgerEnd.offset === undefined) {
+        throw new ApiError('Ledger end response did not include an offset');
+      }
+      activeAtOffset = ledgerEnd.offset;
     }
 
     // Build party list - default to client's party list if not provided

--- a/src/clients/scan-api/ScanApiClient.ts
+++ b/src/clients/scan-api/ScanApiClient.ts
@@ -40,6 +40,14 @@ function resolveConfiguredScanApiUrl(runtime: CantonRuntime): string | undefined
   }
 }
 
+function getScanHostRoot(scanApiUrl: string): string {
+  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
+}
+
+interface RotatableScanUrl {
+  readonly buildUrl: (baseUrl: string) => string;
+}
+
 /**
  * Public Scan API client.
  *
@@ -95,17 +103,33 @@ export class ScanApiClient extends ScanApiClientGenerated {
     }
   }
 
-  private getRelativeUrlWithinApiRoot(fullUrl: string): string | null {
+  private getRotatableUrl(fullUrl: string): RotatableScanUrl | null {
     for (const base of this.scanApiUrls) {
       if (fullUrl.startsWith(base)) {
-        return fullUrl.slice(base.length);
+        const relativePath = fullUrl.slice(base.length);
+        return {
+          buildUrl: (baseUrl): string => `${baseUrl}${relativePath}`,
+        };
+      }
+
+      const hostRoot = getScanHostRoot(base);
+      if (fullUrl.startsWith(hostRoot)) {
+        const relativePath = fullUrl.slice(hostRoot.length);
+        if (relativePath.startsWith('/')) {
+          return {
+            buildUrl: (baseUrl): string => `${getScanHostRoot(baseUrl)}${relativePath}`,
+          };
+        }
       }
     }
 
     const marker = '/api/scan';
     const idx = fullUrl.indexOf(marker);
     if (idx >= 0) {
-      return fullUrl.slice(idx + marker.length);
+      const relativePath = fullUrl.slice(idx + marker.length);
+      return {
+        buildUrl: (baseUrl): string => `${baseUrl}${relativePath}`,
+      };
     }
 
     return null;
@@ -116,8 +140,8 @@ export class ScanApiClient extends ScanApiClientGenerated {
       return doRequest(fullUrl);
     }
 
-    const relative = this.getRelativeUrlWithinApiRoot(fullUrl);
-    if (relative === null) {
+    const rotatableUrl = this.getRotatableUrl(fullUrl);
+    if (rotatableUrl === null) {
       return doRequest(fullUrl);
     }
 
@@ -130,7 +154,7 @@ export class ScanApiClient extends ScanApiClientGenerated {
       if (!base) {
         continue;
       }
-      const url = `${base}${relative}`;
+      const url = rotatableUrl.buildUrl(base);
 
       try {
         const result = await doRequest(url);

--- a/src/clients/scan-api/operations/v0/index.ts
+++ b/src/clients/scan-api/operations/v0/index.ts
@@ -1,1 +1,2 @@
 export * from './scan';
+export * from './registry';

--- a/src/clients/scan-api/operations/v0/registry/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/index.ts
@@ -1,0 +1,1 @@
+export * from './metadata';

--- a/src/clients/scan-api/operations/v0/registry/metadata/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/index.ts
@@ -1,0 +1,1 @@
+export * from './v1';

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
@@ -7,6 +7,10 @@ type ApiPath = '/registry/metadata/v1/instruments/{instrumentId}';
 const endpoint = '/registry/metadata/v1/instruments';
 const publicRequestConfig = { contentType: 'application/json', includeBearerToken: false } as const;
 
+function getRegistryApiUrl(scanApiUrl: string): string {
+  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
+}
+
 export const GetInstrumentParamsSchema = z.object({
   instrumentId: z.string(),
 });
@@ -18,6 +22,6 @@ export type GetInstrumentResponse = paths[ApiPath]['get']['responses']['200']['c
 export const GetInstrument = createApiOperation<GetInstrumentParams, GetInstrumentResponse>({
   paramsSchema: GetInstrumentParamsSchema,
   method: 'GET',
-  buildUrl: (params, apiUrl) => `${apiUrl}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
+  buildUrl: (params, apiUrl) => `${getRegistryApiUrl(apiUrl)}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
   requestConfig: publicRequestConfig,
 });

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
@@ -18,10 +18,30 @@ export const GetInstrumentParamsSchema = z.object({
 export type GetInstrumentParams = z.infer<typeof GetInstrumentParamsSchema>;
 export type GetInstrumentResponse = paths[ApiPath]['get']['responses']['200']['content']['application/json'];
 
+type RawGetInstrumentResponse = Omit<GetInstrumentResponse, 'totalSupply' | 'totalSupplyAsOf'> & {
+  totalSupply?: string | null;
+  totalSupplyAsOf?: string | null;
+};
+
+function normalizeInstrumentResponse(response: GetInstrumentResponse): GetInstrumentResponse {
+  const raw = response as RawGetInstrumentResponse;
+  const { totalSupply, totalSupplyAsOf, ...instrument } = raw;
+  const normalized: GetInstrumentResponse = { ...instrument };
+  if (totalSupply != null) {
+    normalized.totalSupply = totalSupply;
+  }
+  if (totalSupplyAsOf != null) {
+    normalized.totalSupplyAsOf = totalSupplyAsOf;
+  }
+  return normalized;
+}
+
 /** Retrieve an instrument's token metadata from the public Scan API. */
 export const GetInstrument = createApiOperation<GetInstrumentParams, GetInstrumentResponse>({
   paramsSchema: GetInstrumentParamsSchema,
   method: 'GET',
-  buildUrl: (params, apiUrl) => `${getRegistryApiUrl(apiUrl)}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
+  buildUrl: (params, apiUrl): string =>
+    `${getRegistryApiUrl(apiUrl)}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
   requestConfig: publicRequestConfig,
+  transformResponse: normalizeInstrumentResponse,
 });

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../../../core';
+import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
+
+type ApiPath = '/registry/metadata/v1/instruments/{instrumentId}';
+
+const endpoint = '/registry/metadata/v1/instruments';
+const publicRequestConfig = { contentType: 'application/json', includeBearerToken: false } as const;
+
+export const GetInstrumentParamsSchema = z.object({
+  instrumentId: z.string(),
+});
+
+export type GetInstrumentParams = z.infer<typeof GetInstrumentParamsSchema>;
+export type GetInstrumentResponse = paths[ApiPath]['get']['responses']['200']['content']['application/json'];
+
+/** Retrieve an instrument's token metadata from the public Scan API. */
+export const GetInstrument = createApiOperation<GetInstrumentParams, GetInstrumentResponse>({
+  paramsSchema: GetInstrumentParamsSchema,
+  method: 'GET',
+  buildUrl: (params, apiUrl) => `${apiUrl}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
+  requestConfig: publicRequestConfig,
+});

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/index.ts
@@ -1,0 +1,1 @@
+export * from './get-instrument';

--- a/src/clients/scan-api/operations/v0/scan.ts
+++ b/src/clients/scan-api/operations/v0/scan.ts
@@ -443,16 +443,6 @@ export const LookupFeaturedAppRight = createApiOperation<
   requestConfig: publicRequestConfig,
 });
 
-export const GetTopValidatorsByValidatorFaucets = createApiOperation<
-  void,
-  operations['getTopValidatorsByValidatorFaucets']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/top-validators-by-validator-faucets`,
-  requestConfig: publicRequestConfig,
-});
-
 const LookupTransferPreapprovalByPartyParamsSchema = z.object({ party: z.string() });
 export type LookupTransferPreapprovalByPartyParams = z.infer<typeof LookupTransferPreapprovalByPartyParamsSchema>;
 export const LookupTransferPreapprovalByParty = createApiOperation<
@@ -662,64 +652,6 @@ export const GetAcsSnapshot = createApiOperation<
   requestConfig: publicRequestConfig,
 });
 
-export const GetAggregatedRounds = createApiOperation<
-  void,
-  operations['getAggregatedRounds']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/aggregated-rounds`,
-  requestConfig: publicRequestConfig,
-});
-
-type ListRoundTotalsRequest = operations['listRoundTotals']['requestBody']['content']['application/json'];
-const ListRoundTotalsParamsSchema = z.object({ body: z.custom<ListRoundTotalsRequest>() });
-export type ListRoundTotalsParams = z.infer<typeof ListRoundTotalsParamsSchema>;
-export const ListRoundTotals = createApiOperation<
-  ListRoundTotalsParams,
-  operations['listRoundTotals']['responses']['200']['content']['application/json']
->({
-  paramsSchema: ListRoundTotalsParamsSchema,
-  method: 'POST',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/round-totals`,
-  buildRequestData: (params) => params.body,
-  requestConfig: publicRequestConfig,
-});
-
-type ListRoundPartyTotalsRequest = operations['listRoundPartyTotals']['requestBody']['content']['application/json'];
-const ListRoundPartyTotalsParamsSchema = z.object({ body: z.custom<ListRoundPartyTotalsRequest>() });
-export type ListRoundPartyTotalsParams = z.infer<typeof ListRoundPartyTotalsParamsSchema>;
-export const ListRoundPartyTotals = createApiOperation<
-  ListRoundPartyTotalsParams,
-  operations['listRoundPartyTotals']['responses']['200']['content']['application/json']
->({
-  paramsSchema: ListRoundPartyTotalsParamsSchema,
-  method: 'POST',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/round-party-totals`,
-  buildRequestData: (params) => params.body,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetTotalAmuletBalance = createApiOperation<
-  void,
-  operations['getTotalAmuletBalance']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/total-amulet-balance`,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetWalletBalance = createApiOperation<
-  void,
-  operations['getWalletBalance']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/wallet-balance`,
-  requestConfig: publicRequestConfig,
-});
-
 export const GetAmuletConfigForRound = createApiOperation<
   void,
   operations['getAmuletConfigForRound']['responses']['200']['content']['application/json']
@@ -727,70 +659,6 @@ export const GetAmuletConfigForRound = createApiOperation<
   paramsSchema: z.void(),
   method: 'GET',
   buildUrl: (_params, apiUrl) => `${apiUrl}/v0/amulet-config-for-round`,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetRoundOfLatestData = createApiOperation<
-  void,
-  operations['getRoundOfLatestData']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/round-of-latest-data`,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetRewardsCollected = createApiOperation<
-  void,
-  operations['getRewardsCollected']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/rewards-collected`,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetTopProvidersByAppRewards = createApiOperation<
-  void,
-  operations['getTopProvidersByAppRewards']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/top-providers-by-app-rewards`,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetTopValidatorsByValidatorRewards = createApiOperation<
-  void,
-  operations['getTopValidatorsByValidatorRewards']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/top-validators-by-validator-rewards`,
-  requestConfig: publicRequestConfig,
-});
-
-export const GetTopValidatorsByPurchasedTraffic = createApiOperation<
-  void,
-  operations['getTopValidatorsByPurchasedTraffic']['responses']['200']['content']['application/json']
->({
-  paramsSchema: z.void(),
-  method: 'GET',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/top-validators-by-purchased-traffic`,
-  requestConfig: publicRequestConfig,
-});
-
-type ListActivityRequest = operations['listActivity']['requestBody']['content']['application/json'];
-const ListActivityParamsSchema = z.object({ body: z.custom<ListActivityRequest>() });
-export type ListActivityParams = z.infer<typeof ListActivityParamsSchema>;
-export const ListActivity = createApiOperation<
-  ListActivityParams,
-  operations['listActivity']['responses']['200']['content']['application/json']
->({
-  paramsSchema: ListActivityParamsSchema,
-  method: 'POST',
-  buildUrl: (_params, apiUrl) => `${apiUrl}/v0/activities`,
-  buildRequestData: (params) => params.body,
   requestConfig: publicRequestConfig,
 });
 

--- a/src/utils/external-signing/allocate-external-party.ts
+++ b/src/utils/external-signing/allocate-external-party.ts
@@ -8,7 +8,7 @@ export interface AllocateExternalPartyOptions {
   readonly ledgerClient: LedgerJsonApiClient;
   readonly synchronizerId: string;
   readonly identityProviderId: string;
-  readonly onboardingTransactions?: AllocateExternalPartyParams['onboardingTransactions'];
+  readonly onboardingTransactions: AllocateExternalPartyParams['onboardingTransactions'];
   readonly multiHashSignatures?: AllocateExternalPartyParams['multiHashSignatures'];
 }
 

--- a/src/utils/external-signing/create-external-party.ts
+++ b/src/utils/external-signing/create-external-party.ts
@@ -120,7 +120,7 @@ export async function createExternalParty(params: CreateExternalPartyParams): Pr
     );
   }
 
-  if (!topologyTransactions || topologyTransactions.length === 0) {
+  if (topologyTransactions.length === 0) {
     throw new OperationError(
       'No topology transactions returned from topology generation',
       OperationErrorCode.PARTY_CREATION_FAILED,

--- a/src/utils/external-signing/create-external-party.ts
+++ b/src/utils/external-signing/create-external-party.ts
@@ -120,7 +120,12 @@ export async function createExternalParty(params: CreateExternalPartyParams): Pr
     );
   }
 
-  if (topologyTransactions.length === 0) {
+  const rawTopologyTransactions: unknown = topologyTransactions;
+  if (
+    !Array.isArray(rawTopologyTransactions) ||
+    rawTopologyTransactions.length === 0 ||
+    !rawTopologyTransactions.every((transaction) => typeof transaction === 'string')
+  ) {
     throw new OperationError(
       'No topology transactions returned from topology generation',
       OperationErrorCode.PARTY_CREATION_FAILED,
@@ -144,7 +149,7 @@ export async function createExternalParty(params: CreateExternalPartyParams): Pr
   const multiHashSignature = Buffer.from(multiHashSignatureHex, 'hex').toString('base64');
 
   // Step 4: Allocate the party using Ledger JSON API
-  const onboardingTransactions = topologyTransactions.map((transaction: string) => ({ transaction }));
+  const onboardingTransactions = rawTopologyTransactions.map((transaction) => ({ transaction }));
 
   const allocateResult = await ledgerClient.allocateExternalParty({
     synchronizer: synchronizerId,

--- a/test/integration/localnet/ledger-api/paid-traffic-cost.test.ts
+++ b/test/integration/localnet/ledger-api/paid-traffic-cost.test.ts
@@ -109,7 +109,7 @@ describe('LedgerJsonApiClient / paidTrafficCost on completions', () => {
     const userId = await resolveLedgerUserId(client, validatorInfo.user_name);
 
     const partiesResponse = await client.listParties({});
-    const details = partiesResponse.partyDetails ?? [];
+    const details = partiesResponse.partyDetails;
     const receiverParty = details.map((entry: { party: string }) => entry.party).find((id: string) => id !== partyId);
     if (!receiverParty) {
       throw new Error(
@@ -120,6 +120,9 @@ describe('LedgerJsonApiClient / paidTrafficCost on completions', () => {
     const { contractId: walletInstallCid, synchronizerId } = await resolveWalletAppInstallContext(client, partyId);
 
     const ledgerEnd = await client.getLedgerEnd({});
+    if (ledgerEnd.offset === undefined) {
+      throw new Error('getLedgerEnd returned no offset');
+    }
     const beginExclusive = ledgerEnd.offset;
 
     const submissionId = `paid-traffic-it-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;

--- a/test/integration/localnet/ledger-api/updates.test.ts
+++ b/test/integration/localnet/ledger-api/updates.test.ts
@@ -12,9 +12,10 @@ describe('LedgerJsonApiClient / Updates', () => {
   beforeAll(async () => {
     const client = getClient();
     const parties = await client.listParties({});
-    const partyDetails = parties.partyDetails ?? [];
-    if (partyDetails.length > 0 && partyDetails[0]) {
-      partyId = partyDetails[0].party;
+    const { partyDetails } = parties;
+    const [firstPartyDetails] = partyDetails;
+    if (firstPartyDetails) {
+      partyId = firstPartyDetails.party;
     }
   });
 

--- a/test/integration/localnet/scan-api/balance.test.ts
+++ b/test/integration/localnet/scan-api/balance.test.ts
@@ -5,29 +5,28 @@
 import { getClient } from './setup';
 
 describe('ScanApiClient / Balance', () => {
-  test('getInstrument returns total Amulet supply metadata', async () => {
+  test('getInstrument returns Amulet metadata', async () => {
     const client = getClient();
 
-    const snapshot = await client.forceAcsSnapshotNow();
     const instrument = await client.getInstrument({ instrumentId: 'Amulet' });
 
-    expect(Number.isNaN(Date.parse(snapshot.record_time))).toBe(false);
-    expect(snapshot.migration_id).toBeGreaterThanOrEqual(0);
     expect(instrument.id).toBe('Amulet');
     expect(instrument.name).toBeDefined();
     expect(instrument.symbol).toBeDefined();
     expect(instrument.decimals).toBeGreaterThanOrEqual(0);
     expect(instrument.decimals).toBeLessThanOrEqual(10);
+    expect(instrument.supportedApis).toMatchObject({
+      'splice-api-token-metadata-v1': 1,
+      'splice-api-token-holding-v1': 1,
+      'splice-api-token-transfer-instruction-v1': 1,
+    });
 
     const { totalSupply, totalSupplyAsOf } = instrument;
-    if (typeof totalSupply !== 'string') {
-      throw new Error('Amulet instrument did not include totalSupply');
+    if (totalSupply !== undefined) {
+      expect(totalSupply).toMatch(/^\d+(?:\.\d+)?$/);
     }
-    if (typeof totalSupplyAsOf !== 'string') {
-      throw new Error('Amulet instrument did not include totalSupplyAsOf');
+    if (totalSupplyAsOf !== undefined) {
+      expect(Number.isNaN(Date.parse(totalSupplyAsOf))).toBe(false);
     }
-
-    expect(totalSupply).toMatch(/^\d+(?:\.\d+)?$/);
-    expect(Number.isNaN(Date.parse(totalSupplyAsOf))).toBe(false);
   });
 });

--- a/test/integration/localnet/scan-api/balance.test.ts
+++ b/test/integration/localnet/scan-api/balance.test.ts
@@ -1,19 +1,9 @@
 /**
  * ScanApiClient integration tests: Balance Information
  *
- * NOTE: Some balance endpoints may not be available in basic cn-quickstart setup. These tests are skipped until we
- * confirm endpoint availability. See: tasks/2026/01/hd/2026.01.02-sdk-refactoring-and-testing.md (Backlog section)
+ * NOTE: Legacy aggregate balance endpoints were removed from the Scan API in Splice 0.6.x.
  */
 
-import { getClient } from './setup';
-
 describe('ScanApiClient / Balance', () => {
-  // Skip: This endpoint may not be available in cn-quickstart
-  test.skip('getTotalAmuletBalance returns network balance', async () => {
-    const client = getClient();
-    const response = await client.getTotalAmuletBalance();
-
-    expect(response).toBeDefined();
-    expect(response.total_balance).toBeDefined();
-  });
+  test.todo('getTotalAmuletBalance was removed from the Scan API in Splice 0.6.x');
 });

--- a/test/integration/localnet/scan-api/balance.test.ts
+++ b/test/integration/localnet/scan-api/balance.test.ts
@@ -1,9 +1,33 @@
 /**
  * ScanApiClient integration tests: Balance Information
- *
- * NOTE: Legacy aggregate balance endpoints were removed from the Scan API in Splice 0.6.x.
  */
 
+import { getClient } from './setup';
+
 describe('ScanApiClient / Balance', () => {
-  test.todo('getTotalAmuletBalance was removed from the Scan API in Splice 0.6.x');
+  test('getInstrument returns total Amulet supply metadata', async () => {
+    const client = getClient();
+
+    const snapshot = await client.forceAcsSnapshotNow();
+    const instrument = await client.getInstrument({ instrumentId: 'Amulet' });
+
+    expect(Number.isNaN(Date.parse(snapshot.record_time))).toBe(false);
+    expect(snapshot.migration_id).toBeGreaterThanOrEqual(0);
+    expect(instrument.id).toBe('Amulet');
+    expect(instrument.name).toBeDefined();
+    expect(instrument.symbol).toBeDefined();
+    expect(instrument.decimals).toBeGreaterThanOrEqual(0);
+    expect(instrument.decimals).toBeLessThanOrEqual(10);
+
+    const { totalSupply, totalSupplyAsOf } = instrument;
+    if (typeof totalSupply !== 'string') {
+      throw new Error('Amulet instrument did not include totalSupply');
+    }
+    if (typeof totalSupplyAsOf !== 'string') {
+      throw new Error('Amulet instrument did not include totalSupplyAsOf');
+    }
+
+    expect(totalSupply).toMatch(/^\d+(?:\.\d+)?$/);
+    expect(Number.isNaN(Date.parse(totalSupplyAsOf))).toBe(false);
+  });
 });

--- a/test/integration/localnet/scan-api/balance.test.ts
+++ b/test/integration/localnet/scan-api/balance.test.ts
@@ -21,20 +21,12 @@ describe('ScanApiClient / Balance', () => {
       'splice-api-token-transfer-instruction-v1': 1,
     });
 
-    type LocalNetInstrument = Omit<typeof instrument, 'totalSupply' | 'totalSupplyAsOf'> & {
-      totalSupply?: string | null;
-      totalSupplyAsOf?: string | null;
-    };
-    const { totalSupply, totalSupplyAsOf } = instrument as LocalNetInstrument;
-    if (typeof totalSupply === 'string') {
+    const { totalSupply, totalSupplyAsOf } = instrument;
+    if (totalSupply !== undefined) {
       expect(totalSupply).toMatch(/^\d+(?:\.\d+)?$/);
-    } else {
-      expect(totalSupply == null).toBe(true);
     }
-    if (typeof totalSupplyAsOf === 'string') {
-      expect(Number.isNaN(Date.parse(totalSupplyAsOf))).toBe(false);
-    } else {
-      expect(totalSupplyAsOf == null).toBe(true);
+    if (totalSupplyAsOf !== undefined) {
+      expect(Date.parse(totalSupplyAsOf)).not.toBeNaN();
     }
   });
 });

--- a/test/integration/localnet/scan-api/balance.test.ts
+++ b/test/integration/localnet/scan-api/balance.test.ts
@@ -21,12 +21,20 @@ describe('ScanApiClient / Balance', () => {
       'splice-api-token-transfer-instruction-v1': 1,
     });
 
-    const { totalSupply, totalSupplyAsOf } = instrument;
-    if (totalSupply !== undefined) {
+    type LocalNetInstrument = Omit<typeof instrument, 'totalSupply' | 'totalSupplyAsOf'> & {
+      totalSupply?: string | null;
+      totalSupplyAsOf?: string | null;
+    };
+    const { totalSupply, totalSupplyAsOf } = instrument as LocalNetInstrument;
+    if (typeof totalSupply === 'string') {
       expect(totalSupply).toMatch(/^\d+(?:\.\d+)?$/);
+    } else {
+      expect(totalSupply == null).toBe(true);
     }
-    if (totalSupplyAsOf !== undefined) {
+    if (typeof totalSupplyAsOf === 'string') {
       expect(Number.isNaN(Date.parse(totalSupplyAsOf))).toBe(false);
+    } else {
+      expect(totalSupplyAsOf == null).toBe(true);
     }
   });
 });

--- a/test/integration/localnet/scan-api/mining.test.ts
+++ b/test/integration/localnet/scan-api/mining.test.ts
@@ -20,5 +20,24 @@ describe('ScanApiClient / Mining', () => {
     expect(response.open_mining_rounds).not.toBeNull();
   });
 
-  test.todo('getRoundOfLatestData was removed from the Scan API in Splice 0.6.x');
+  test('getDsoInfo returns the latest mining round contract', async () => {
+    const client = getClient();
+
+    const dsoInfo = await client.getDsoInfo();
+    const rounds = await client.getOpenAndIssuingMiningRounds({
+      body: {
+        cached_open_mining_round_contract_ids: [],
+        cached_issuing_round_contract_ids: [],
+      },
+    });
+
+    const latestMiningRound = dsoInfo.latest_mining_round;
+    const latestContract = latestMiningRound.contract;
+
+    expect(latestContract.contract_id).toBeDefined();
+    expect(latestContract.template_id).toContain('OpenMiningRound');
+    expect(rounds.open_mining_rounds[latestContract.contract_id]?.contract?.contract_id).toBe(
+      latestContract.contract_id
+    );
+  });
 });

--- a/test/integration/localnet/scan-api/mining.test.ts
+++ b/test/integration/localnet/scan-api/mining.test.ts
@@ -20,12 +20,5 @@ describe('ScanApiClient / Mining', () => {
     expect(response.open_mining_rounds).not.toBeNull();
   });
 
-  // Skip: This endpoint may not be available in cn-quickstart scan API
-  test.skip('getRoundOfLatestData returns latest round info', async () => {
-    const client = getClient();
-    const response = await client.getRoundOfLatestData();
-
-    expect(response).toBeDefined();
-    expect(response.round).toBeDefined();
-  });
+  test.todo('getRoundOfLatestData was removed from the Scan API in Splice 0.6.x');
 });

--- a/test/integration/localnet/scan-api/mining.test.ts
+++ b/test/integration/localnet/scan-api/mining.test.ts
@@ -36,8 +36,8 @@ describe('ScanApiClient / Mining', () => {
 
     expect(latestContract.contract_id).toBeDefined();
     expect(latestContract.template_id).toContain('OpenMiningRound');
-    expect(rounds.open_mining_rounds[latestContract.contract_id]?.contract?.contract_id).toBe(
-      latestContract.contract_id
-    );
+    const openRound = rounds.open_mining_rounds[latestContract.contract_id];
+    expect(openRound).toBeDefined();
+    expect(openRound?.contract?.contract_id).toBe(latestContract.contract_id);
   });
 });

--- a/test/unit/amulet/pre-approve-transfers.test.ts
+++ b/test/unit/amulet/pre-approve-transfers.test.ts
@@ -290,6 +290,7 @@ describe('preApproveTransfers', () => {
                 nodeId: 1,
                 contractId: 'other-contract-123',
                 templateId: 'pkg:Some.Other:Contract', // Not TransferPreapproval
+                createArgument: {},
                 createdEventBlob: 'blob-123',
                 createdAt: '2026-01-01T00:00:00Z',
                 witnessParties: ['party1'],

--- a/test/unit/clients/completion-stream.test.ts
+++ b/test/unit/clients/completion-stream.test.ts
@@ -86,4 +86,64 @@ describe('waitForCompletionWithMetadata', () => {
     }
     expect(secondSubscription.close).toHaveBeenCalledTimes(1);
   });
+
+  it('closes stale subscription handles that resolve after a retry connects', async () => {
+    jest.useFakeTimers();
+
+    const handlers: SubscribeHandlers[] = [];
+    const subscriptions = [createSubscription(), createSubscription()];
+    let resolveFirstSubscription: (subscription: CompletionSubscription) => void = () => undefined;
+    const firstSubscriptionPromise = new Promise<CompletionSubscription>((resolve) => {
+      resolveFirstSubscription = resolve;
+    });
+    const client = {
+      subscribeToCompletions: jest.fn(async (_params, nextHandlers: SubscribeHandlers) => {
+        handlers.push(nextHandlers);
+        if (handlers.length === 1) {
+          return firstSubscriptionPromise;
+        }
+        return subscriptions[1];
+      }),
+    } as unknown as jest.Mocked<LedgerJsonApiClient>;
+
+    const resultPromise = waitForCompletionWithMetadata(client, {
+      submissionId: 'submission-123',
+      partyId: 'party-123',
+      userId: 'user-123',
+      beginExclusive: 10,
+      timeoutMs: 30_000,
+    });
+
+    await Promise.resolve();
+    const firstHandlers = handlers[0];
+    if (!firstHandlers) {
+      throw new Error('Expected first completion subscription');
+    }
+
+    firstHandlers.onClose?.(1000, 'stream complete');
+    jest.advanceTimersByTime(250);
+    await Promise.resolve();
+
+    expect(client.subscribeToCompletions).toHaveBeenCalledTimes(2);
+
+    const firstSubscription = subscriptions[0];
+    if (!firstSubscription) {
+      throw new Error('Expected first completion subscription handle');
+    }
+    resolveFirstSubscription(firstSubscription);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(firstSubscription.close).toHaveBeenCalledTimes(1);
+
+    const secondHandlers = handlers[1];
+    if (!secondHandlers) {
+      throw new Error('Expected second completion subscription');
+    }
+    secondHandlers.onMessage(completionMessage('submission-123'));
+
+    await expect(resultPromise).resolves.toEqual({
+      updateId: 'update-123',
+      paidTrafficCost: 17n,
+    });
+  });
 });

--- a/test/unit/clients/completion-stream.test.ts
+++ b/test/unit/clients/completion-stream.test.ts
@@ -64,6 +64,7 @@ describe('waitForCompletionWithMetadata', () => {
       throw new Error('Expected first completion subscription');
     }
     firstHandlers.onClose?.(1000, 'stream complete');
+    firstHandlers.onClose?.(1000, 'duplicate close');
     jest.advanceTimersByTime(250);
     await Promise.resolve();
 

--- a/test/unit/clients/completion-stream.test.ts
+++ b/test/unit/clients/completion-stream.test.ts
@@ -1,0 +1,88 @@
+import { waitForCompletionWithMetadata } from '../../../src/clients/ledger-json-api';
+import type { LedgerJsonApiClient } from '../../../src/clients/ledger-json-api';
+import type { CompletionsWsMessage } from '../../../src/clients/ledger-json-api/operations/v2/commands/subscribe-to-completions';
+
+type SubscribeHandlers = Parameters<LedgerJsonApiClient['subscribeToCompletions']>[1];
+type CompletionSubscription = Awaited<ReturnType<LedgerJsonApiClient['subscribeToCompletions']>>;
+
+const completionMessage = (submissionId: string): CompletionsWsMessage =>
+  ({
+    completionResponse: {
+      Completion: {
+        value: {
+          submissionId,
+          updateId: 'update-123',
+          commandId: 'command-123',
+          offset: 42,
+          synchronizerTime: {
+            synchronizerId: 'sync-123',
+            recordTime: '2026-01-01T00:00:00Z',
+          },
+          status: { code: 0 },
+          paidTrafficCost: '17',
+        },
+      },
+    },
+  }) as CompletionsWsMessage;
+
+const createSubscription = (): CompletionSubscription => ({
+  close: jest.fn(),
+  isConnected: jest.fn().mockReturnValue(true),
+  getConnectionState: jest.fn().mockReturnValue(1),
+});
+
+describe('waitForCompletionWithMetadata', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resubscribes when the completions stream closes before the target completion arrives', async () => {
+    jest.useFakeTimers();
+
+    const handlers: SubscribeHandlers[] = [];
+    const subscriptions = [createSubscription(), createSubscription()];
+    const client = {
+      subscribeToCompletions: jest.fn(async (_params, nextHandlers: SubscribeHandlers) => {
+        handlers.push(nextHandlers);
+        return subscriptions[handlers.length - 1];
+      }),
+    } as unknown as jest.Mocked<LedgerJsonApiClient>;
+
+    const resultPromise = waitForCompletionWithMetadata(client, {
+      submissionId: 'submission-123',
+      partyId: 'party-123',
+      userId: 'user-123',
+      beginExclusive: 10,
+      timeoutMs: 30_000,
+    });
+
+    await Promise.resolve();
+    expect(client.subscribeToCompletions).toHaveBeenCalledTimes(1);
+
+    const firstHandlers = handlers[0];
+    if (!firstHandlers) {
+      throw new Error('Expected first completion subscription');
+    }
+    firstHandlers.onClose?.(1000, 'stream complete');
+    jest.advanceTimersByTime(250);
+    await Promise.resolve();
+
+    expect(client.subscribeToCompletions).toHaveBeenCalledTimes(2);
+
+    const secondHandlers = handlers[1];
+    if (!secondHandlers) {
+      throw new Error('Expected second completion subscription');
+    }
+    secondHandlers.onMessage(completionMessage('submission-123'));
+
+    await expect(resultPromise).resolves.toEqual({
+      updateId: 'update-123',
+      paidTrafficCost: 17n,
+    });
+    const secondSubscription = subscriptions[1];
+    if (!secondSubscription) {
+      throw new Error('Expected second completion subscription handle');
+    }
+    expect(secondSubscription.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/clients/completion-stream.test.ts
+++ b/test/unit/clients/completion-stream.test.ts
@@ -68,6 +68,11 @@ describe('waitForCompletionWithMetadata', () => {
     jest.advanceTimersByTime(250);
     await Promise.resolve();
 
+    const firstSubscription = subscriptions[0];
+    if (!firstSubscription) {
+      throw new Error('Expected first completion subscription handle');
+    }
+    expect(firstSubscription.close).toHaveBeenCalledTimes(1);
     expect(client.subscribeToCompletions).toHaveBeenCalledTimes(2);
 
     const secondHandlers = handlers[1];

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -127,7 +127,7 @@ describe('ScanApiClient', () => {
     });
 
     expect(mockAxiosInstance.get.mock.calls[0]?.[0]).toBe(
-      'https://scan.example/api/scan/registry/metadata/v1/instruments/Amulet%2FUSD'
+      'https://scan.example/registry/metadata/v1/instruments/Amulet%2FUSD'
     );
   });
 });

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -117,17 +117,54 @@ describe('ScanApiClient', () => {
         name: 'Amulet',
         symbol: 'AMT',
         decimals: 10,
+        totalSupply: null,
+        totalSupplyAsOf: null,
         supportedApis: {},
       },
     });
 
-    await expect(client.getInstrument({ instrumentId: 'Amulet/USD' })).resolves.toMatchObject({
+    const instrument = await client.getInstrument({ instrumentId: 'Amulet/USD' });
+
+    expect(instrument).toMatchObject({
       id: 'Amulet/USD',
       symbol: 'AMT',
     });
+    expect(instrument.totalSupply).toBeUndefined();
+    expect(instrument.totalSupplyAsOf).toBeUndefined();
 
     expect(mockAxiosInstance.get.mock.calls[0]?.[0]).toBe(
       'https://scan.example/registry/metadata/v1/instruments/Amulet%2FUSD'
     );
+  });
+
+  it('rotates token metadata registry requests across scan endpoints', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan-a.example/api/scan', 'https://scan-b.example/api/scan'],
+      }
+    );
+
+    mockAxiosInstance.get.mockRejectedValueOnce(new Error('first endpoint unavailable')).mockResolvedValueOnce({
+      data: {
+        id: 'Amulet',
+        name: 'Amulet',
+        symbol: 'AMT',
+        decimals: 10,
+        supportedApis: {},
+      },
+    });
+
+    await expect(client.getInstrument({ instrumentId: 'Amulet' })).resolves.toMatchObject({
+      id: 'Amulet',
+      symbol: 'AMT',
+    });
+
+    const requestedUrls = mockAxiosInstance.get.mock.calls.map((call) => call[0] as string);
+    expect(requestedUrls).toEqual([
+      'https://scan-a.example/registry/metadata/v1/instruments/Amulet',
+      'https://scan-b.example/registry/metadata/v1/instruments/Amulet',
+    ]);
+    expect(client.getApiUrl()).toBe('https://scan-b.example/api/scan');
   });
 });

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -102,4 +102,32 @@ describe('ScanApiClient', () => {
       'https://scan-b.example/api/scan/v0/scan/health',
     ]);
   });
+
+  it('gets token metadata instruments from the direct scan endpoint', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+
+    mockAxiosInstance.get.mockResolvedValueOnce({
+      data: {
+        id: 'Amulet/USD',
+        name: 'Amulet',
+        symbol: 'AMT',
+        decimals: 10,
+        supportedApis: {},
+      },
+    });
+
+    await expect(client.getInstrument({ instrumentId: 'Amulet/USD' })).resolves.toMatchObject({
+      id: 'Amulet/USD',
+      symbol: 'AMT',
+    });
+
+    expect(mockAxiosInstance.get.mock.calls[0]?.[0]).toBe(
+      'https://scan.example/api/scan/registry/metadata/v1/instruments/Amulet%2FUSD'
+    );
+  });
 });


### PR DESCRIPTION
## What
- Updates the vendored Splice submodule from `0.5.5` to upstream tag `0.6.8`.
- Aligns Ledger JSON API wrappers with the `0.6.8` generated OpenAPI types.
- Removes Scan v0 wrapper exports for endpoints that are no longer present upstream.
- Updates affected tests/fixtures for the new generated types.

## Why
Slack guidance requires moving validators past the `0.6.2` line. The latest tagged Splice release available upstream is `0.6.8`, so this moves the SDK to that supported line instead of stopping at the minimum.

## Impact
- `allocateExternalParty` now requires `onboardingTransactions`, matching the generated API contract.
- Removed Scan wrappers include legacy aggregate/balance/rewards endpoints that no longer exist in the `0.6.8` Scan OpenAPI spec.
- `submitAndWaitForTransactionTree` keeps the SDK-facing response type non-optional and throws if the deprecated endpoint ever returns no transaction tree.

## Checks
- `npm run build`
- `npm run lint`
- `npm test -- test/unit` (32 suites, 364 tests)
- `npm test` was also attempted, but localnet integration tests fail in this environment due unavailable/auth-failing local services at `localhost:8082` and `scan.localhost:4000`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API surface (required `onboardingTransactions`, removed Scan methods) affects callers; completion-stream auto-resubscribe changes failure modes for long waits; party/onboarding validation may surface errors that were previously ignored.
> 
> **Overview**
> Aligns Ledger JSON API and Scan clients with **Splice 0.6.8** generated types: tighter runtime checks, Scan surface trimmed to match upstream, and new registry metadata support.
> 
> **Completions waiting** now **resubscribes** (250ms delay) when the completions WebSocket closes before the target submission completes, instead of failing immediately; stale subscription handles from overlapping attempts are closed. Unit tests cover resubscribe and late-resolve races.
> 
> **Ledger JSON API (breaking / stricter):** `allocateExternalParty` and external-signing helpers require **`onboardingTransactions`**. Responses are validated with `ApiError` when **`transactionTree`**, **`partyDetails`**, or ledger-end **`offset`** are missing; party aggregation no longer treats absent `partyDetails` as empty.
> 
> **Scan API (breaking):** Removes v0 wrapper exports dropped from the 0.6.8 spec (legacy balance, rewards, aggregated rounds, activity, etc.). Adds **`getInstrument`** at `/registry/metadata/v1/instruments/{id}` (host root off scan base URL) with null `totalSupply` fields stripped. **`ScanApiClient`** endpoint rotation now rebuilds URLs for registry paths on the scan host, not only under `/api/scan`.
> 
> Tests and fixtures updated for required fields and replaced Scan integration cases (`getInstrument`, DSO/mining round checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c044cd1c0f9145ba7596e02808ee753c4c8e508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed multiple Scan API v0 operations.
  * Made `onboardingTransactions` required for external party allocation (including helper options).
* **New Features**
  * Added Scan API v0 `getInstrument` (metadata registry) and expanded registry exports.
  * Improved completions handling with resumable retry after WebSocket close.
* **Bug Fixes**
  * Added stricter runtime validation for API response shapes (e.g., `transactionTree`, `partyDetails`, ledger end `offset`, and topology transactions).
* **Tests**
  * Updated and extended integration/unit tests for the above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->