### PR TITLE
ENG-521: Add typed Canton event parsers

### DIFF
--- a/src/utils/amulet/offers.ts
+++ b/src/utils/amulet/offers.ts
@@ -2,6 +2,7 @@ import { type LedgerJsonApiClient } from '../../clients/ledger-json-api';
 import { type SubmitAndWaitForTransactionTreeResponse } from '../../clients/ledger-json-api/operations';
 import { EnvLoader } from '../../core/config/EnvLoader';
 import { OperationError, OperationErrorCode } from '../../core/errors';
+import { parseCreatedEvent } from '../parsers';
 
 export interface CreateTransferOfferParams {
   /** Ledger client for submitting commands. */
@@ -64,7 +65,8 @@ export async function createTransferOffer(params: CreateTransferOfferParams): Pr
   });
 
   const transferOfferEvent = transferOfferCid.transactionTree.eventsById['1'];
-  if (!transferOfferEvent || !('CreatedTreeEvent' in transferOfferEvent)) {
+  const createdEvent = parseCreatedEvent(transferOfferEvent);
+  if (!createdEvent) {
     const firstKey = transferOfferEvent ? Object.keys(transferOfferEvent)[0] : 'undefined';
     throw new OperationError(`Expected CreatedTreeEvent but got ${firstKey}`, OperationErrorCode.TRANSACTION_FAILED, {
       eventType: firstKey,
@@ -73,7 +75,7 @@ export async function createTransferOffer(params: CreateTransferOfferParams): Pr
     });
   }
 
-  return transferOfferEvent.CreatedTreeEvent.value.contractId;
+  return createdEvent.contractId;
 }
 
 /**

--- a/src/utils/amulet/offers.ts
+++ b/src/utils/amulet/offers.ts
@@ -2,7 +2,7 @@ import { type LedgerJsonApiClient } from '../../clients/ledger-json-api';
 import { type SubmitAndWaitForTransactionTreeResponse } from '../../clients/ledger-json-api/operations';
 import { EnvLoader } from '../../core/config/EnvLoader';
 import { OperationError, OperationErrorCode } from '../../core/errors';
-import { parseCreatedEvent } from '../parsers';
+import { extractEventsFromTransaction, hasTemplateName } from '../parsers';
 
 export interface CreateTransferOfferParams {
   /** Ledger client for submitting commands. */
@@ -64,12 +64,11 @@ export async function createTransferOffer(params: CreateTransferOfferParams): Pr
     actAs: [validatorParty],
   });
 
-  const transferOfferEvent = transferOfferCid.transactionTree.eventsById['1'];
-  const createdEvent = parseCreatedEvent(transferOfferEvent);
+  const createdEvents = extractEventsFromTransaction(transferOfferCid).created;
+  const createdEvent = createdEvents.find((event) => hasTemplateName(event.templateId, 'TransferOffer'));
   if (!createdEvent) {
-    const firstKey = transferOfferEvent ? Object.keys(transferOfferEvent)[0] : 'undefined';
-    throw new OperationError(`Expected CreatedTreeEvent but got ${firstKey}`, OperationErrorCode.TRANSACTION_FAILED, {
-      eventType: firstKey,
+    throw new OperationError(`Failed to create TransferOffer contract`, OperationErrorCode.TRANSACTION_FAILED, {
+      createdTemplateIds: createdEvents.map((event) => event.templateId),
       receiverPartyId,
       amount,
     });

--- a/src/utils/amulet/offers.ts
+++ b/src/utils/amulet/offers.ts
@@ -65,7 +65,7 @@ export async function createTransferOffer(params: CreateTransferOfferParams): Pr
   });
 
   const createdEvents = extractEventsFromTransaction(transferOfferCid).created;
-  const createdEvent = createdEvents.find((event) => hasTemplateName(event.templateId, 'TransferOffer'));
+  const createdEvent = createdEvents.find((event): boolean => hasTemplateName(event.templateId, 'TransferOffer'));
   if (!createdEvent) {
     throw new OperationError(`Failed to create TransferOffer contract`, OperationErrorCode.TRANSACTION_FAILED, {
       createdTemplateIds: createdEvents.map((event) => event.templateId),

--- a/src/utils/amulet/pre-approve-transfers.ts
+++ b/src/utils/amulet/pre-approve-transfers.ts
@@ -163,7 +163,7 @@ export async function preApproveTransfers(
   }
 
   // Extract the created TransferPreapproval contract ID from the result
-  const contractId = extractEventsFromTransaction(result).created.find((event) =>
+  const contractId = extractEventsFromTransaction(result).created.find((event): boolean =>
     hasTemplateName(event.templateId, 'TransferPreapproval')
   )?.contractId;
 

--- a/src/utils/amulet/pre-approve-transfers.ts
+++ b/src/utils/amulet/pre-approve-transfers.ts
@@ -4,7 +4,7 @@ import { type DisclosedContract, type ExerciseCommand } from '../../clients/ledg
 import { type ValidatorApiClient } from '../../clients/validator-api';
 import { ApiError, OperationError, OperationErrorCode } from '../../core/errors';
 import { getCurrentMiningRoundContext } from '../mining/mining-rounds';
-import { extractEventsFromTransaction } from '../parsers';
+import { extractEventsFromTransaction, hasTemplateName } from '../parsers';
 import { getAmuletsForTransfer } from './get-amulets-for-transfer';
 
 export interface PreApproveTransfersParams {
@@ -164,7 +164,7 @@ export async function preApproveTransfers(
 
   // Extract the created TransferPreapproval contract ID from the result
   const contractId = extractEventsFromTransaction(result).created.find((event) =>
-    event.templateId.includes('TransferPreapproval')
+    hasTemplateName(event.templateId, 'TransferPreapproval')
   )?.contractId;
 
   if (!contractId) {

--- a/src/utils/amulet/pre-approve-transfers.ts
+++ b/src/utils/amulet/pre-approve-transfers.ts
@@ -4,6 +4,7 @@ import { type DisclosedContract, type ExerciseCommand } from '../../clients/ledg
 import { type ValidatorApiClient } from '../../clients/validator-api';
 import { ApiError, OperationError, OperationErrorCode } from '../../core/errors';
 import { getCurrentMiningRoundContext } from '../mining/mining-rounds';
+import { extractEventsFromTransaction } from '../parsers';
 import { getAmuletsForTransfer } from './get-amulets-for-transfer';
 
 export interface PreApproveTransfersParams {
@@ -162,20 +163,9 @@ export async function preApproveTransfers(
   }
 
   // Extract the created TransferPreapproval contract ID from the result
-  const events = result.transactionTree.eventsById;
-  let contractId: string | undefined;
-
-  for (const eventKey in events) {
-    const event = events[eventKey];
-    if (
-      event &&
-      'CreatedTreeEvent' in event &&
-      event.CreatedTreeEvent.value.templateId.includes('TransferPreapproval')
-    ) {
-      ({ contractId } = event.CreatedTreeEvent.value);
-      break;
-    }
-  }
+  const contractId = extractEventsFromTransaction(result).created.find((event) =>
+    event.templateId.includes('TransferPreapproval')
+  )?.contractId;
 
   if (!contractId) {
     throw new OperationError('Failed to create TransferPreapproval contract', OperationErrorCode.TRANSACTION_FAILED, {

--- a/src/utils/parsers/event-parser.ts
+++ b/src/utils/parsers/event-parser.ts
@@ -1,0 +1,285 @@
+import { isRecord, isString } from '../../core/utils';
+
+export interface ParsedTemplateId {
+  readonly packageId: string;
+  readonly module: string;
+  readonly templateName: string;
+}
+
+export interface ParsedCreatedEvent {
+  readonly contractId: string;
+  readonly templateId: string;
+  readonly packageName?: string;
+  readonly createArgument: Readonly<Record<string, unknown>>;
+  readonly contractKey?: unknown;
+  readonly witnessParties?: readonly string[];
+  readonly signatories?: readonly string[];
+  readonly observers?: readonly string[];
+  readonly offset?: number;
+  readonly nodeId?: number;
+  readonly createdEventBlob?: string;
+  readonly createdAt?: string;
+  readonly interfaceViews?: readonly string[];
+  readonly implementedInterfaces?: readonly string[];
+  readonly synchronizerId?: string;
+}
+
+export interface ParsedArchivedEvent {
+  readonly contractId: string;
+  readonly templateId: string;
+  readonly packageName?: string;
+  readonly witnessParties?: readonly string[];
+  readonly offset?: number;
+  readonly nodeId?: number;
+  readonly implementedInterfaces?: readonly string[];
+  readonly synchronizerId?: string;
+}
+
+export interface ParsedExercisedEvent {
+  readonly contractId: string;
+  readonly templateId: string;
+  readonly choice: string;
+  readonly packageName?: string;
+  readonly interfaceId?: string | null;
+  readonly exerciseArgument?: Readonly<Record<string, unknown>>;
+  readonly exerciseResult?: Readonly<Record<string, unknown>>;
+  readonly actingParties?: readonly string[];
+  readonly witnessParties?: readonly string[];
+  readonly consuming?: boolean;
+  readonly offset?: number;
+  readonly nodeId?: number;
+  readonly lastDescendantNodeId?: number;
+  readonly implementedInterfaces?: readonly string[];
+  readonly synchronizerId?: string;
+}
+
+export interface ParsedTransactionEvents {
+  readonly created: ParsedCreatedEvent[];
+  readonly archived: ParsedArchivedEvent[];
+  readonly exercised: ParsedExercisedEvent[];
+}
+
+type EventVariant = 'created' | 'archived' | 'exercised';
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+const VARIANT_KEYS: Record<EventVariant, readonly string[]> = {
+  created: ['CreatedTreeEvent', 'CreatedEvent', 'createdEvent'],
+  archived: ['ArchivedTreeEvent', 'ArchivedEvent', 'archivedEvent'],
+  exercised: ['ExercisedTreeEvent', 'ExercisedEvent', 'exercisedEvent'],
+};
+
+function readString(value: unknown): string | undefined {
+  return isString(value) ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function readStringArray(value: unknown): readonly string[] | undefined {
+  return Array.isArray(value) && value.every(isString) ? value : undefined;
+}
+
+function readRecord(value: unknown): Readonly<Record<string, unknown>> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function readNullableString(value: unknown): string | null | undefined {
+  return value === null || isString(value) ? value : undefined;
+}
+
+function unwrapVariant(event: unknown, variant: EventVariant): Readonly<Record<string, unknown>> | null {
+  if (!isRecord(event)) return null;
+
+  for (const key of VARIANT_KEYS[variant]) {
+    const wrapper = event[key];
+    if (!isRecord(wrapper)) continue;
+    const { value } = wrapper;
+    return readRecord(value) ?? wrapper;
+  }
+
+  return null;
+}
+
+function readSynchronizerId(event: unknown): string | undefined {
+  if (!isRecord(event)) return undefined;
+  return readString(event['synchronizerId']);
+}
+
+export function parseTemplateId(templateId: string): ParsedTemplateId {
+  const parts = templateId.split(':');
+  if (parts.length < 3 || parts.some((part) => part.length === 0)) {
+    throw new Error(`Invalid templateId: ${templateId}`);
+  }
+
+  return {
+    packageId: parts[0] as string,
+    module: parts.slice(1, -1).join(':'),
+    templateName: parts[parts.length - 1] as string,
+  };
+}
+
+export function parseCreatedEvent(event: unknown): ParsedCreatedEvent | null {
+  const value = unwrapVariant(event, 'created');
+  if (!value) return null;
+
+  const contractId = readString(value['contractId']);
+  const templateId = readString(value['templateId']);
+  if (!contractId || !templateId) return null;
+
+  const result: Mutable<ParsedCreatedEvent> = {
+    contractId,
+    templateId,
+    createArgument: readRecord(value['createArgument']) ?? readRecord(value['createArguments']) ?? {},
+  };
+  const packageName = readString(value['packageName']);
+  const witnessParties = readStringArray(value['witnessParties']);
+  const signatories = readStringArray(value['signatories']);
+  const observers = readStringArray(value['observers']);
+  const offset = readNumber(value['offset']);
+  const nodeId = readNumber(value['nodeId']);
+  const createdEventBlob = readString(value['createdEventBlob']);
+  const createdAt = readString(value['createdAt']);
+  const interfaceViews = readStringArray(value['interfaceViews']);
+  const implementedInterfaces = readStringArray(value['implementedInterfaces']);
+  const synchronizerId = readSynchronizerId(event);
+
+  if (packageName !== undefined) result.packageName = packageName;
+  if (value['contractKey'] !== undefined) result.contractKey = value['contractKey'];
+  if (witnessParties !== undefined) result.witnessParties = witnessParties;
+  if (signatories !== undefined) result.signatories = signatories;
+  if (observers !== undefined) result.observers = observers;
+  if (offset !== undefined) result.offset = offset;
+  if (nodeId !== undefined) result.nodeId = nodeId;
+  if (createdEventBlob !== undefined) result.createdEventBlob = createdEventBlob;
+  if (createdAt !== undefined) result.createdAt = createdAt;
+  if (interfaceViews !== undefined) result.interfaceViews = interfaceViews;
+  if (implementedInterfaces !== undefined) result.implementedInterfaces = implementedInterfaces;
+  if (synchronizerId !== undefined) result.synchronizerId = synchronizerId;
+
+  return result;
+}
+
+export function parseArchivedEvent(event: unknown): ParsedArchivedEvent | null {
+  const value = unwrapVariant(event, 'archived');
+  if (!value) return null;
+
+  const contractId = readString(value['contractId']);
+  const templateId = readString(value['templateId']);
+  if (!contractId || !templateId) return null;
+
+  const result: Mutable<ParsedArchivedEvent> = {
+    contractId,
+    templateId,
+  };
+  const packageName = readString(value['packageName']);
+  const witnessParties = readStringArray(value['witnessParties']);
+  const offset = readNumber(value['offset']);
+  const nodeId = readNumber(value['nodeId']);
+  const implementedInterfaces = readStringArray(value['implementedInterfaces']);
+  const synchronizerId = readSynchronizerId(event);
+
+  if (packageName !== undefined) result.packageName = packageName;
+  if (witnessParties !== undefined) result.witnessParties = witnessParties;
+  if (offset !== undefined) result.offset = offset;
+  if (nodeId !== undefined) result.nodeId = nodeId;
+  if (implementedInterfaces !== undefined) result.implementedInterfaces = implementedInterfaces;
+  if (synchronizerId !== undefined) result.synchronizerId = synchronizerId;
+
+  return result;
+}
+
+export function parseExercisedEvent(event: unknown): ParsedExercisedEvent | null {
+  const value = unwrapVariant(event, 'exercised');
+  if (!value) return null;
+
+  const contractId = readString(value['contractId']);
+  const templateId = readString(value['templateId']);
+  const choice = readString(value['choice']);
+  if (!contractId || !templateId || !choice) return null;
+
+  const result: Mutable<ParsedExercisedEvent> = {
+    contractId,
+    templateId,
+    choice,
+  };
+  const packageName = readString(value['packageName']);
+  const interfaceId = readNullableString(value['interfaceId']);
+  const exerciseArgument = readRecord(value['exerciseArgument']) ?? readRecord(value['choiceArgument']);
+  const exerciseResult = readRecord(value['exerciseResult']);
+  const actingParties = readStringArray(value['actingParties']);
+  const witnessParties = readStringArray(value['witnessParties']);
+  const consuming = readBoolean(value['consuming']);
+  const offset = readNumber(value['offset']);
+  const nodeId = readNumber(value['nodeId']);
+  const lastDescendantNodeId = readNumber(value['lastDescendantNodeId']);
+  const implementedInterfaces = readStringArray(value['implementedInterfaces']);
+  const synchronizerId = readSynchronizerId(event);
+
+  if (packageName !== undefined) result.packageName = packageName;
+  if (interfaceId !== undefined) result.interfaceId = interfaceId;
+  if (exerciseArgument !== undefined) result.exerciseArgument = exerciseArgument;
+  if (exerciseResult !== undefined) result.exerciseResult = exerciseResult;
+  if (actingParties !== undefined) result.actingParties = actingParties;
+  if (witnessParties !== undefined) result.witnessParties = witnessParties;
+  if (consuming !== undefined) result.consuming = consuming;
+  if (offset !== undefined) result.offset = offset;
+  if (nodeId !== undefined) result.nodeId = nodeId;
+  if (lastDescendantNodeId !== undefined) result.lastDescendantNodeId = lastDescendantNodeId;
+  if (implementedInterfaces !== undefined) result.implementedInterfaces = implementedInterfaces;
+  if (synchronizerId !== undefined) result.synchronizerId = synchronizerId;
+
+  return result;
+}
+
+function getNestedRecord(value: unknown, path: readonly string[]): Readonly<Record<string, unknown>> | null {
+  let current = value;
+  for (const segment of path) {
+    if (!isRecord(current)) return null;
+    current = current[segment];
+  }
+  return readRecord(current) ?? null;
+}
+
+function getEventsById(transaction: unknown): Readonly<Record<string, unknown>> | null {
+  const paths: ReadonlyArray<readonly string[]> = [
+    ['eventsById'],
+    ['eventTree'],
+    ['transactionTree', 'eventsById'],
+    ['transactionTree', 'eventTree'],
+    ['transaction', 'eventsById'],
+    ['transaction', 'eventTree'],
+  ];
+
+  for (const path of paths) {
+    const eventsById = getNestedRecord(transaction, path);
+    if (eventsById) return eventsById;
+  }
+
+  return null;
+}
+
+export function extractEventsFromTransaction(transaction: unknown): ParsedTransactionEvents {
+  const eventsById = getEventsById(transaction);
+  const events = eventsById ? Object.values(eventsById) : [];
+
+  return events.reduce<ParsedTransactionEvents>(
+    (acc, event) => {
+      const created = parseCreatedEvent(event);
+      if (created) acc.created.push(created);
+
+      const archived = parseArchivedEvent(event);
+      if (archived) acc.archived.push(archived);
+
+      const exercised = parseExercisedEvent(event);
+      if (exercised) acc.exercised.push(exercised);
+
+      return acc;
+    },
+    { created: [], archived: [], exercised: [] }
+  );
+}

--- a/src/utils/parsers/event-parser.ts
+++ b/src/utils/parsers/event-parser.ts
@@ -41,8 +41,8 @@ export interface ParsedExercisedEvent {
   readonly choice: string;
   readonly packageName?: string;
   readonly interfaceId?: string | null;
-  readonly exerciseArgument?: Readonly<Record<string, unknown>>;
-  readonly exerciseResult?: Readonly<Record<string, unknown>>;
+  readonly exerciseArgument?: unknown;
+  readonly exerciseResult?: unknown;
   readonly actingParties?: readonly string[];
   readonly witnessParties?: readonly string[];
   readonly consuming?: boolean;
@@ -124,8 +124,11 @@ export function parseTemplateId(templateId: string): ParsedTemplateId {
 }
 
 export function hasTemplateName(templateId: string, expectedTemplateName: string): boolean {
-  const lastColon = templateId.lastIndexOf(':');
-  return lastColon >= 0 && templateId.slice(lastColon + 1) === expectedTemplateName;
+  try {
+    return parseTemplateId(templateId).templateName === expectedTemplateName;
+  } catch {
+    return false;
+  }
 }
 
 export function parseCreatedEvent(event: unknown): ParsedCreatedEvent | null {
@@ -214,8 +217,9 @@ export function parseExercisedEvent(event: unknown): ParsedExercisedEvent | null
   };
   const packageName = readString(value['packageName']);
   const interfaceId = readNullableString(value['interfaceId']);
-  const exerciseArgument = readRecord(value['exerciseArgument']) ?? readRecord(value['choiceArgument']);
-  const exerciseResult = readRecord(value['exerciseResult']);
+  const exerciseArgument =
+    value['exerciseArgument'] !== undefined ? value['exerciseArgument'] : value['choiceArgument'];
+  const { exerciseResult } = value;
   const actingParties = readStringArray(value['actingParties']);
   const witnessParties = readStringArray(value['witnessParties']);
   const consuming = readBoolean(value['consuming']);
@@ -250,6 +254,15 @@ function getNestedRecord(value: unknown, path: readonly string[]): Readonly<Reco
   return readRecord(current) ?? null;
 }
 
+function getNestedArray(value: unknown, path: readonly string[]): readonly unknown[] | null {
+  let current = value;
+  for (const segment of path) {
+    if (!isRecord(current)) return null;
+    current = current[segment];
+  }
+  return Array.isArray(current) ? current : null;
+}
+
 function getEventsById(transaction: unknown): Readonly<Record<string, unknown>> | null {
   const paths: ReadonlyArray<readonly string[]> = [
     ['eventsById'],
@@ -268,9 +281,24 @@ function getEventsById(transaction: unknown): Readonly<Record<string, unknown>> 
   return null;
 }
 
+function getEventArray(transaction: unknown): readonly unknown[] | null {
+  const paths: ReadonlyArray<readonly string[]> = [
+    ['events'],
+    ['transactionTree', 'events'],
+    ['transaction', 'events'],
+  ];
+
+  for (const path of paths) {
+    const events = getNestedArray(transaction, path);
+    if (events) return events;
+  }
+
+  return null;
+}
+
 export function extractEventsFromTransaction(transaction: unknown): ParsedTransactionEvents {
   const eventsById = getEventsById(transaction);
-  const events = eventsById ? Object.values(eventsById) : [];
+  const events = eventsById ? Object.values(eventsById) : (getEventArray(transaction) ?? []);
 
   return events.reduce<ParsedTransactionEvents>(
     (acc, event) => {

--- a/src/utils/parsers/event-parser.ts
+++ b/src/utils/parsers/event-parser.ts
@@ -123,6 +123,11 @@ export function parseTemplateId(templateId: string): ParsedTemplateId {
   };
 }
 
+export function hasTemplateName(templateId: string, expectedTemplateName: string): boolean {
+  const lastColon = templateId.lastIndexOf(':');
+  return lastColon >= 0 && templateId.slice(lastColon + 1) === expectedTemplateName;
+}
+
 export function parseCreatedEvent(event: unknown): ParsedCreatedEvent | null {
   const value = unwrapVariant(event, 'created');
   if (!value) return null;

--- a/src/utils/parsers/index.ts
+++ b/src/utils/parsers/index.ts
@@ -1,1 +1,2 @@
+export * from './event-parser';
 export * from './fee-parser';

--- a/test/unit/amulet/offers.test.ts
+++ b/test/unit/amulet/offers.test.ts
@@ -26,7 +26,7 @@ interface MockTransactionTreeResponse {
     commandId: string;
     effectiveAt: string;
     offset: string;
-    eventsById: Record<string, { CreatedTreeEvent: { value: { contractId: string; templateId: string } } }>;
+    eventsById: Record<string, unknown>;
     rootEventIds: string[];
     synchronizerId: string;
     traceContext: undefined;
@@ -81,6 +81,39 @@ describe('createTransferOffer', () => {
 
     expect(result).toBe('transfer-offer-contract-123');
     expect(mockClient.submitAndWaitForTransactionTree).toHaveBeenCalledTimes(1);
+  });
+
+  it('finds transfer offer created events without relying on event id', async () => {
+    const mockResponse = createTransactionTreeResponse('transfer-offer-contract-123');
+    mockResponse.transactionTree.eventsById = {
+      '1': {
+        CreatedTreeEvent: {
+          value: {
+            contractId: 'other-contract-123',
+            templateId: 'pkg:Splice.Wallet.TransferOffer:NotTransferOffer',
+          },
+        },
+      },
+      '7': {
+        CreatedTreeEvent: {
+          value: {
+            contractId: 'transfer-offer-contract-123',
+            templateId: 'pkg:Splice.Wallet.TransferOffer:TransferOffer',
+          },
+        },
+      },
+    };
+    mockResponse.transactionTree.rootEventIds = ['7'];
+    const mockClient = createMockLedgerClient(mockResponse);
+
+    const result = await createTransferOffer({
+      ledgerClient: mockClient,
+      receiverPartyId: 'receiver::fingerprint',
+      amount: '100',
+      description: 'Test transfer',
+    });
+
+    expect(result).toBe('transfer-offer-contract-123');
   });
 
   it('uses validator party as actAs', async () => {
@@ -207,7 +240,7 @@ describe('createTransferOffer', () => {
         amount: '100',
         description: 'Test transfer',
       })
-    ).rejects.toThrow('Expected CreatedTreeEvent but got ExercisedTreeEvent');
+    ).rejects.toThrow('Failed to create TransferOffer contract');
   });
 
   it('throws when response has no events', async () => {
@@ -225,7 +258,7 @@ describe('createTransferOffer', () => {
         amount: '100',
         description: 'Test transfer',
       })
-    ).rejects.toThrow('Expected CreatedTreeEvent but got undefined');
+    ).rejects.toThrow('Failed to create TransferOffer contract');
   });
 });
 

--- a/test/unit/amulet/pre-approve-transfers.test.ts
+++ b/test/unit/amulet/pre-approve-transfers.test.ts
@@ -323,6 +323,46 @@ describe('preApproveTransfers', () => {
     ).rejects.toThrow('Failed to create TransferPreapproval contract');
   });
 
+  it('does not match similarly named preapproval templates', async () => {
+    mockLedgerClient.submitAndWaitForTransactionTree.mockResolvedValue({
+      transactionTree: {
+        updateId: 'update-123',
+        commandId: 'cmd-123',
+        workflowId: 'workflow-123',
+        effectiveAt: '2026-01-01T00:00:00Z',
+        offset: 100,
+        synchronizerId: 'sync-123',
+        recordTime: '2026-01-01T00:00:00Z',
+        eventsById: {
+          '1': {
+            CreatedTreeEvent: {
+              value: {
+                offset: 100,
+                nodeId: 1,
+                contractId: 'other-contract-123',
+                templateId: 'pkg:Splice.AmuletRules:NotTransferPreapproval',
+                createdEventBlob: 'blob-123',
+                createdAt: '2026-01-01T00:00:00Z',
+                witnessParties: ['party1'],
+                signatories: ['party1'],
+                observers: [],
+                packageName: 'test-package',
+                representativePackageId: 'pkg-123',
+                acsDelta: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await expect(
+      preApproveTransfers(mockLedgerClient, mockValidatorClient, {
+        receiverPartyId: 'receiver::fingerprint',
+      })
+    ).rejects.toThrow('Failed to create TransferPreapproval contract');
+  });
+
   it('includes amulet inputs from provider party', async () => {
     await preApproveTransfers(mockLedgerClient, mockValidatorClient, {
       receiverPartyId: 'receiver::fingerprint',

--- a/test/unit/amulet/pre-approve-transfers.test.ts
+++ b/test/unit/amulet/pre-approve-transfers.test.ts
@@ -341,6 +341,7 @@ describe('preApproveTransfers', () => {
                 nodeId: 1,
                 contractId: 'other-contract-123',
                 templateId: 'pkg:Splice.AmuletRules:NotTransferPreapproval',
+                createArgument: {},
                 createdEventBlob: 'blob-123',
                 createdAt: '2026-01-01T00:00:00Z',
                 witnessParties: ['party1'],

--- a/test/unit/amulet/pre-approve-transfers.test.ts
+++ b/test/unit/amulet/pre-approve-transfers.test.ts
@@ -1,5 +1,9 @@
 import type { LedgerJsonApiClient } from '../../../src/clients/ledger-json-api';
-import type { CompositeCommand, ExerciseCommand } from '../../../src/clients/ledger-json-api/schemas/api/commands';
+import type {
+  CompositeCommand,
+  DisclosedContract,
+  ExerciseCommand,
+} from '../../../src/clients/ledger-json-api/schemas/api/commands';
 import type { ValidatorApiClient } from '../../../src/clients/validator-api';
 import { preApproveTransfers } from '../../../src/utils/amulet/pre-approve-transfers';
 
@@ -218,11 +222,15 @@ describe('preApproveTransfers', () => {
     expect(callArgs?.disclosedContracts?.length).toBeGreaterThan(0);
 
     // Should include AmuletRules contract
-    const amuletRulesContract = callArgs?.disclosedContracts?.find((c) => c.contractId === 'amulet-rules-contract-123');
+    const amuletRulesContract = callArgs?.disclosedContracts?.find(
+      (c: DisclosedContract) => c.contractId === 'amulet-rules-contract-123'
+    );
     expect(amuletRulesContract).toBeDefined();
 
     // Should include mining round contract
-    const miningRoundContract = callArgs?.disclosedContracts?.find((c) => c.contractId === 'mining-round-contract-123');
+    const miningRoundContract = callArgs?.disclosedContracts?.find(
+      (c: DisclosedContract) => c.contractId === 'mining-round-contract-123'
+    );
     expect(miningRoundContract).toBeDefined();
   });
 
@@ -232,7 +240,9 @@ describe('preApproveTransfers', () => {
     });
 
     const callArgs = mockLedgerClient.submitAndWaitForTransactionTree.mock.calls[0]?.[0];
-    const featuredContract = callArgs?.disclosedContracts?.find((c) => c.contractId === 'featured-app-right-123');
+    const featuredContract = callArgs?.disclosedContracts?.find(
+      (c: DisclosedContract) => c.contractId === 'featured-app-right-123'
+    );
     expect(featuredContract).toBeDefined();
   });
 

--- a/test/unit/parsers/event-parser.test.ts
+++ b/test/unit/parsers/event-parser.test.ts
@@ -32,6 +32,7 @@ describe('event-parser', () => {
     it('matches exact template names', () => {
       expect(hasTemplateName('pkg:Module:TransferPreapproval', 'TransferPreapproval')).toBe(true);
       expect(hasTemplateName('pkg:Module:NotTransferPreapproval', 'TransferPreapproval')).toBe(false);
+      expect(hasTemplateName('pkg::TransferPreapproval', 'TransferPreapproval')).toBe(false);
       expect(hasTemplateName('TransferPreapproval', 'TransferPreapproval')).toBe(false);
     });
   });
@@ -210,6 +211,26 @@ describe('event-parser', () => {
       });
     });
 
+    it('preserves non-record exercise values', () => {
+      expect(
+        parseExercisedEvent({
+          ExercisedEvent: {
+            contractId: 'contract-1',
+            templateId: 'pkg:Module:Template',
+            choice: 'Archive',
+            choiceArgument: ['contract-1'],
+            exerciseResult: null,
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        choice: 'Archive',
+        exerciseArgument: ['contract-1'],
+        exerciseResult: null,
+      });
+    });
+
     it('returns null for malformed exercised events', () => {
       expect(
         parseExercisedEvent({
@@ -280,6 +301,23 @@ describe('event-parser', () => {
               },
             },
           },
+        },
+      });
+
+      expect(result.created[0]?.contractId).toBe('created-1');
+    });
+
+    it('extracts from transaction.events arrays', () => {
+      const result = extractEventsFromTransaction({
+        transaction: {
+          events: [
+            {
+              CreatedEvent: {
+                contractId: 'created-1',
+                templateId: 'pkg:Module:Created',
+              },
+            },
+          ],
         },
       });
 

--- a/test/unit/parsers/event-parser.test.ts
+++ b/test/unit/parsers/event-parser.test.ts
@@ -81,6 +81,37 @@ describe('event-parser', () => {
       });
     });
 
+    it('parses flattened CreatedEvent wrappers', () => {
+      expect(
+        parseCreatedEvent({
+          CreatedEvent: {
+            contractId: 'contract-1',
+            templateId: 'pkg:Module:Template',
+            createArguments: { owner: 'alice' },
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        createArgument: { owner: 'alice' },
+      });
+    });
+
+    it('parses lowercase createdEvent wrappers', () => {
+      expect(
+        parseCreatedEvent({
+          createdEvent: {
+            contractId: 'contract-1',
+            templateId: 'pkg:Module:Template',
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        createArgument: {},
+      });
+    });
+
     it('returns null for malformed created events', () => {
       expect(parseCreatedEvent({ CreatedTreeEvent: { value: { templateId: 'pkg:Module:Template' } } })).toBeNull();
       expect(parseCreatedEvent({ ExercisedTreeEvent: { value: { contractId: 'contract-1' } } })).toBeNull();
@@ -105,6 +136,20 @@ describe('event-parser', () => {
         templateId: 'pkg:Module:Template',
         witnessParties: ['alice'],
         offset: 99,
+      });
+    });
+
+    it('parses flattened ArchivedEvent wrappers', () => {
+      expect(
+        parseArchivedEvent({
+          ArchivedEvent: {
+            contractId: 'contract-1',
+            templateId: 'pkg:Module:Template',
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
       });
     });
 
@@ -139,6 +184,22 @@ describe('event-parser', () => {
         actingParties: ['alice'],
         consuming: true,
         offset: 10,
+      });
+    });
+
+    it('parses flattened ExercisedEvent wrappers', () => {
+      expect(
+        parseExercisedEvent({
+          ExercisedEvent: {
+            contractId: 'contract-1',
+            templateId: 'pkg:Module:Template',
+            choice: 'Archive',
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        choice: 'Archive',
       });
     });
 

--- a/test/unit/parsers/event-parser.test.ts
+++ b/test/unit/parsers/event-parser.test.ts
@@ -1,0 +1,229 @@
+import {
+  extractEventsFromTransaction,
+  parseArchivedEvent,
+  parseCreatedEvent,
+  parseExercisedEvent,
+  parseTemplateId,
+} from '../../../src/utils/parsers/event-parser';
+
+describe('event-parser', () => {
+  describe('parseTemplateId', () => {
+    it('parses package id, module, and template name', () => {
+      expect(parseTemplateId('#splice-amulet:Splice.Amulet:AppRewardCoupon')).toEqual({
+        packageId: '#splice-amulet',
+        module: 'Splice.Amulet',
+        templateName: 'AppRewardCoupon',
+      });
+    });
+
+    it('keeps extra module delimiters with the module component', () => {
+      expect(parseTemplateId('pkg:Module:Nested:Template')).toEqual({
+        packageId: 'pkg',
+        module: 'Module:Nested',
+        templateName: 'Template',
+      });
+    });
+
+    it('throws for invalid template ids', () => {
+      expect(() => parseTemplateId('pkg:OnlyModule')).toThrow('Invalid templateId');
+    });
+  });
+
+  describe('parseCreatedEvent', () => {
+    it('parses CreatedTreeEvent wrappers', () => {
+      const result = parseCreatedEvent({
+        CreatedTreeEvent: {
+          value: {
+            contractId: 'contract-1',
+            templateId: 'pkg:Module:Template',
+            packageName: 'package-name',
+            createArgument: { owner: 'alice' },
+            witnessParties: ['alice'],
+            signatories: ['alice'],
+            observers: ['bob'],
+            offset: 12,
+            nodeId: 1,
+            createdEventBlob: 'blob',
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        packageName: 'package-name',
+        createArgument: { owner: 'alice' },
+        witnessParties: ['alice'],
+        signatories: ['alice'],
+        observers: ['bob'],
+        offset: 12,
+        nodeId: 1,
+        createdEventBlob: 'blob',
+      });
+    });
+
+    it('parses CreatedEvent wrappers and defaults missing createArgument', () => {
+      expect(
+        parseCreatedEvent({
+          CreatedEvent: {
+            value: {
+              contractId: 'contract-1',
+              templateId: 'pkg:Module:Template',
+            },
+          },
+          synchronizerId: 'sync-1',
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        createArgument: {},
+        synchronizerId: 'sync-1',
+      });
+    });
+
+    it('returns null for malformed created events', () => {
+      expect(parseCreatedEvent({ CreatedTreeEvent: { value: { templateId: 'pkg:Module:Template' } } })).toBeNull();
+      expect(parseCreatedEvent({ ExercisedTreeEvent: { value: { contractId: 'contract-1' } } })).toBeNull();
+    });
+  });
+
+  describe('parseArchivedEvent', () => {
+    it('parses ArchivedTreeEvent wrappers', () => {
+      expect(
+        parseArchivedEvent({
+          ArchivedTreeEvent: {
+            value: {
+              contractId: 'contract-1',
+              templateId: 'pkg:Module:Template',
+              witnessParties: ['alice'],
+              offset: 99,
+            },
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        witnessParties: ['alice'],
+        offset: 99,
+      });
+    });
+
+    it('returns null for malformed archived events', () => {
+      expect(parseArchivedEvent({ ArchivedTreeEvent: { value: { contractId: 'contract-1' } } })).toBeNull();
+    });
+  });
+
+  describe('parseExercisedEvent', () => {
+    it('parses ExercisedTreeEvent wrappers', () => {
+      expect(
+        parseExercisedEvent({
+          ExercisedTreeEvent: {
+            value: {
+              contractId: 'contract-1',
+              templateId: 'pkg:Module:Template',
+              choice: 'Archive',
+              choiceArgument: { reason: 'done' },
+              exerciseResult: { archived: true },
+              actingParties: ['alice'],
+              consuming: true,
+              offset: 10,
+            },
+          },
+        })
+      ).toEqual({
+        contractId: 'contract-1',
+        templateId: 'pkg:Module:Template',
+        choice: 'Archive',
+        exerciseArgument: { reason: 'done' },
+        exerciseResult: { archived: true },
+        actingParties: ['alice'],
+        consuming: true,
+        offset: 10,
+      });
+    });
+
+    it('returns null for malformed exercised events', () => {
+      expect(
+        parseExercisedEvent({
+          ExercisedTreeEvent: {
+            value: {
+              contractId: 'contract-1',
+              templateId: 'pkg:Module:Template',
+            },
+          },
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe('extractEventsFromTransaction', () => {
+    it('extracts created, archived, and exercised events from a transaction tree response', () => {
+      const result = extractEventsFromTransaction({
+        transactionTree: {
+          eventsById: {
+            '1': {
+              CreatedTreeEvent: {
+                value: {
+                  contractId: 'created-1',
+                  templateId: 'pkg:Module:Created',
+                },
+              },
+            },
+            '2': {
+              ArchivedTreeEvent: {
+                value: {
+                  contractId: 'archived-1',
+                  templateId: 'pkg:Module:Archived',
+                },
+              },
+            },
+            '3': {
+              ExercisedTreeEvent: {
+                value: {
+                  contractId: 'exercised-1',
+                  templateId: 'pkg:Module:Exercised',
+                  choice: 'Choice',
+                },
+              },
+            },
+            '4': { unknown: true },
+          },
+        },
+      });
+
+      expect(result.created).toHaveLength(1);
+      expect(result.created[0]?.contractId).toBe('created-1');
+      expect(result.archived).toHaveLength(1);
+      expect(result.archived[0]?.contractId).toBe('archived-1');
+      expect(result.exercised).toHaveLength(1);
+      expect(result.exercised[0]?.contractId).toBe('exercised-1');
+    });
+
+    it('extracts from transaction.eventsById shapes', () => {
+      const result = extractEventsFromTransaction({
+        transaction: {
+          eventsById: {
+            '1': {
+              CreatedEvent: {
+                value: {
+                  contractId: 'created-1',
+                  templateId: 'pkg:Module:Created',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result.created[0]?.contractId).toBe('created-1');
+    });
+
+    it('returns empty arrays when no event map is present', () => {
+      expect(extractEventsFromTransaction({})).toEqual({
+        created: [],
+        archived: [],
+        exercised: [],
+      });
+    });
+  });
+});

--- a/test/unit/parsers/event-parser.test.ts
+++ b/test/unit/parsers/event-parser.test.ts
@@ -1,5 +1,6 @@
 import {
   extractEventsFromTransaction,
+  hasTemplateName,
   parseArchivedEvent,
   parseCreatedEvent,
   parseExercisedEvent,
@@ -26,6 +27,12 @@ describe('event-parser', () => {
 
     it('throws for invalid template ids', () => {
       expect(() => parseTemplateId('pkg:OnlyModule')).toThrow('Invalid templateId');
+    });
+
+    it('matches exact template names', () => {
+      expect(hasTemplateName('pkg:Module:TransferPreapproval', 'TransferPreapproval')).toBe(true);
+      expect(hasTemplateName('pkg:Module:NotTransferPreapproval', 'TransferPreapproval')).toBe(false);
+      expect(hasTemplateName('TransferPreapproval', 'TransferPreapproval')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add typed Canton event parser utilities for created, archived, and exercised ledger events.
- Add template-id parsing and transaction event extraction helpers.
- Migrate existing SDK transfer-offer and pre-approval event extraction to the shared parser.
- Add focused unit coverage for parser success/null paths and transaction extraction shapes.

## Validation

- `npx jest test/unit/parsers/event-parser.test.ts test/unit/amulet/offers.test.ts test/unit/amulet/pre-approve-transfers.test.ts --runInBand`
- `npx eslint src/utils/parsers/event-parser.ts src/utils/parsers/index.ts src/utils/amulet/offers.ts src/utils/amulet/pre-approve-transfers.ts test/unit/parsers/event-parser.test.ts test/unit/amulet/pre-approve-transfers.test.ts`
- `npx tsc --noEmit --target ES2020 --module commonjs --lib ES2020,DOM --strict --esModuleInterop --skipLibCheck --exactOptionalPropertyTypes --noUncheckedIndexedAccess src/utils/parsers/event-parser.ts`
- `npm run build:core`
- `npm run build:lint`

## Notes

This is the SDK-side implementation for [ENG-521](https://linear.app/fairmint/issue/ENG-521/canton-node-sdk-add-typed-canton-event-parsing-utilities).

The Linear acceptance item to migrate two `Fairmint/canton` app scripts still needs a coordinated follow-up after this SDK change is merged/released or otherwise consumable by that repo. The target script code lives in `Fairmint/canton/src/scripts/app`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how contract IDs are read from ledger transaction trees in transfer flows; behavior is more correct but could surface failures if real responses use unexpected shapes not covered by the parser.
> 
> **Overview**
> Adds shared **typed ledger event parsing** (`extractEventsFromTransaction`, `parseCreatedEvent` / archived / exercised, `parseTemplateId`, `hasTemplateName`) that normalizes multiple Canton response shapes (tree vs flat wrappers, `eventsById` vs `events`).
> 
> **Transfer offer** and **pre-approval** creation no longer assume a fixed event node or substring `templateId` checks; they scan created events and match the exact template name (`TransferOffer`, `TransferPreapproval`), with clearer failure errors when no matching contract is found.
> 
> Unit tests cover the parser and the updated extraction edge cases (wrong event id, similarly named templates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475e7b42d0c6bcb1e4f41f54ff5a185000cc105a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating the correct transfer offer and preapproval contracts from transaction event data, using safer template-name matching and consistent “failed to create” behavior when no valid created event is found.
* **Refactor**
  * Added a reusable runtime transaction-event parser to consistently interpret created, archived, and exercised events across different response shapes.
* **Tests**
  * Expanded unit coverage for template parsing, event extraction, and edge cases (including similarly named but non-matching preapproval templates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->