### PR TITLE
[codex] Add external-party CC transfer helpers

### DIFF
--- a/src/clients/validator-api/operations/v0/admin/index.ts
+++ b/src/clients/validator-api/operations/v0/admin/index.ts
@@ -4,4 +4,6 @@ export * from './generate-external-party-topology';
 export * from './get-external-party-balance';
 export * from './list-external-party-setup-proposals';
 export * from './list-users';
+export * from './prepare-transfer-preapproval-send';
 export * from './submit-external-party-topology';
+export * from './submit-transfer-preapproval-send';

--- a/src/clients/validator-api/operations/v0/admin/prepare-transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/admin/prepare-transfer-preapproval-send.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../core';
+import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+/**
+ * Prepare an externally signed CC transfer
+ *
+ * Prepares a TransferCommand transaction that must be signed by the external sender and then submitted with
+ * submitTransferPreapprovalSend.
+ */
+export const PrepareTransferPreapprovalSend = createApiOperation<
+  operations['prepareTransferPreapprovalSend']['requestBody']['content']['application/json'],
+  operations['prepareTransferPreapprovalSend']['responses']['200']['content']['application/json']
+>({
+  paramsSchema: z.object({
+    sender_party_id: z.string().min(1),
+    receiver_party_id: z.string().min(1),
+    amount: z.number().positive(),
+    expires_at: z.string().min(1),
+    nonce: z.number().int().nonnegative(),
+    verbose_hashing: z.boolean().default(false),
+    description: z.string().optional(),
+  }) as z.ZodType<operations['prepareTransferPreapprovalSend']['requestBody']['content']['application/json']>,
+  method: 'POST',
+  buildUrl: (_params, apiUrl: string) =>
+    `${apiUrl}/api/validator/v0/admin/external-party/transfer-preapproval/prepare-send`,
+  buildRequestData: (params) => params,
+});

--- a/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../core';
+import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+/**
+ * Submit an externally signed CC transfer
+ *
+ * Submits the signed transaction returned by prepareTransferPreapprovalSend.
+ */
+export const SubmitTransferPreapprovalSend = createApiOperation<
+  operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json'],
+  operations['submitTransferPreapprovalSend']['responses']['200']['content']['application/json']
+>({
+  paramsSchema: z.object({
+    submission: z.object({
+      party_id: z.string().min(1),
+      transaction: z.string().min(1),
+      signed_tx_hash: z.string().regex(/^[0-9a-fA-F]+$/),
+      public_key: z.string().regex(/^[0-9a-fA-F]+$/),
+    }),
+  }) as z.ZodType<operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json']>,
+  method: 'POST',
+  buildUrl: (_params, apiUrl: string) =>
+    `${apiUrl}/api/validator/v0/admin/external-party/transfer-preapproval/submit-send`,
+  buildRequestData: (params) => params,
+});

--- a/src/utils/amulet/external-party-cc-transfer.ts
+++ b/src/utils/amulet/external-party-cc-transfer.ts
@@ -1,0 +1,181 @@
+import { type ValidatorApiClient } from '../../clients/validator-api';
+import { ApiError, ValidationError } from '../../core/errors';
+
+const DEFAULT_TRANSFER_EXPIRY_MS = 60 * 60 * 1000;
+
+export interface PrepareExternalPartyCcTransferParams {
+  /** Externally hosted party that sends the CC. */
+  readonly senderPartyId: string;
+  /** Receiver party ID. */
+  readonly receiverPartyId: string;
+  /** CC amount to send. */
+  readonly amount: number | string;
+  /** Optional transfer description visible in Canton transfer command state. */
+  readonly description?: string;
+  /** Transaction expiry. Defaults to one hour from now. */
+  readonly expiresAt?: Date | string;
+  /** TransferCommand nonce. Defaults to the current sender counter, or 0 when no counter exists yet. */
+  readonly nonce?: number;
+  /** Request verbose hashing details from the validator for troubleshooting. */
+  readonly verboseHashing?: boolean;
+}
+
+export interface PreparedExternalPartyCcTransfer {
+  /** Base64-encoded prepared transaction that the external party signs. */
+  readonly transaction: string;
+  /** Hex-encoded hash that must be signed by the external party key. */
+  readonly transactionHashHex: string;
+  /** Prefix for the TransferCommand contract ID created by the prepared transaction. */
+  readonly transferCommandContractIdPrefix: string;
+  /** Nonce used to prepare the transfer command. */
+  readonly nonce: number;
+  /** Expiry timestamp used to prepare the transfer command. */
+  readonly expiresAt: string;
+  /** Raw validator response. */
+  readonly raw: Awaited<ReturnType<ValidatorApiClient['prepareTransferPreapprovalSend']>>;
+}
+
+export interface SubmitExternalPartyCcTransferParams {
+  /** Externally hosted party that signed the CC transfer. */
+  readonly senderPartyId: string;
+  /** Base64-encoded prepared transaction returned by prepareExternalPartyCcTransfer. */
+  readonly transaction: string;
+  /** Hex-encoded signature over transactionHashHex. */
+  readonly transactionHashSignatureHex: string;
+  /** Hex-encoded raw Ed25519 public key for the external party. */
+  readonly publicKeyHex: string;
+}
+
+export interface SubmittedExternalPartyCcTransfer {
+  /** Canton update ID for the submitted transfer command. */
+  readonly updateId: string;
+  /** Raw validator response. */
+  readonly raw: Awaited<ReturnType<ValidatorApiClient['submitTransferPreapprovalSend']>>;
+}
+
+/**
+ * Prepares a CC transfer from an externally hosted Canton party.
+ *
+ * The returned transactionHashHex is the only value the browser wallet needs to sign; the SDK does not receive private
+ * keys.
+ */
+export async function prepareExternalPartyCcTransfer(
+  validatorClient: ValidatorApiClient,
+  params: PrepareExternalPartyCcTransferParams
+): Promise<PreparedExternalPartyCcTransfer> {
+  const amount = normalizePositiveAmount(params.amount);
+  const expiresAt = normalizeExpiresAt(params.expiresAt);
+  const nonce = params.nonce ?? (await lookupNextNonce(validatorClient, params.senderPartyId));
+
+  validatePartyId('senderPartyId', params.senderPartyId);
+  validatePartyId('receiverPartyId', params.receiverPartyId);
+  validateNonce(nonce);
+
+  const raw = await validatorClient.prepareTransferPreapprovalSend({
+    sender_party_id: params.senderPartyId,
+    receiver_party_id: params.receiverPartyId,
+    amount,
+    expires_at: expiresAt,
+    nonce,
+    verbose_hashing: params.verboseHashing ?? false,
+    ...(params.description ? { description: params.description } : {}),
+  });
+
+  return {
+    transaction: raw.transaction,
+    transactionHashHex: raw.tx_hash,
+    transferCommandContractIdPrefix: raw.transfer_command_contract_id_prefix,
+    nonce,
+    expiresAt,
+    raw,
+  };
+}
+
+/** Submits an externally signed CC transfer prepared by prepareExternalPartyCcTransfer. */
+export async function submitExternalPartyCcTransfer(
+  validatorClient: ValidatorApiClient,
+  params: SubmitExternalPartyCcTransferParams
+): Promise<SubmittedExternalPartyCcTransfer> {
+  validatePartyId('senderPartyId', params.senderPartyId);
+  validateHex('transactionHashSignatureHex', params.transactionHashSignatureHex);
+  validateHex('publicKeyHex', params.publicKeyHex);
+
+  const raw = await validatorClient.submitTransferPreapprovalSend({
+    submission: {
+      party_id: params.senderPartyId,
+      transaction: params.transaction,
+      signed_tx_hash: params.transactionHashSignatureHex,
+      public_key: params.publicKeyHex,
+    },
+  });
+
+  return {
+    updateId: raw.update_id,
+    raw,
+  };
+}
+
+async function lookupNextNonce(validatorClient: ValidatorApiClient, party: string): Promise<number> {
+  try {
+    const response = await validatorClient.lookupTransferCommandCounterByParty({ party });
+    validateNonce(response.counter);
+    return response.counter;
+  } catch (error) {
+    if (isNotFound(error)) {
+      return 0;
+    }
+    throw error;
+  }
+}
+
+function normalizePositiveAmount(amount: number | string): number {
+  const value = typeof amount === 'string' ? Number(amount) : amount;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new ValidationError('CC transfer amount must be a positive number', { amount });
+  }
+  return value;
+}
+
+function normalizeExpiresAt(expiresAt?: Date | string): string {
+  if (expiresAt instanceof Date) {
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new ValidationError('expiresAt must be a valid date');
+    }
+    return expiresAt.toISOString();
+  }
+
+  if (typeof expiresAt === 'string') {
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new ValidationError('expiresAt must be a valid date-time string', { expiresAt });
+    }
+    return parsed.toISOString();
+  }
+
+  return new Date(Date.now() + DEFAULT_TRANSFER_EXPIRY_MS).toISOString();
+}
+
+function validateNonce(nonce: number): void {
+  if (!Number.isInteger(nonce) || nonce < 0) {
+    throw new ValidationError('Transfer nonce must be a non-negative integer', { nonce });
+  }
+}
+
+function validatePartyId(name: string, value: string): void {
+  if (!value.trim()) {
+    throw new ValidationError(`${name} is required`);
+  }
+}
+
+function validateHex(name: string, value: string): void {
+  if (!/^[0-9a-fA-F]+$/.test(value)) {
+    throw new ValidationError(`${name} must be hex-encoded`, { [name]: value });
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 404;
+  }
+  return typeof error === 'object' && error !== null && 'status' in error && error.status === 404;
+}

--- a/src/utils/amulet/index.ts
+++ b/src/utils/amulet/index.ts
@@ -1,3 +1,4 @@
+export * from './external-party-cc-transfer';
 export * from './get-amulets-for-transfer';
 export * from './get-locked-amulets';
 export * from './offers';

--- a/test/unit/amulet/external-party-cc-transfer.test.ts
+++ b/test/unit/amulet/external-party-cc-transfer.test.ts
@@ -1,0 +1,102 @@
+import type { ValidatorApiClient } from '../../../src/clients/validator-api';
+import { ApiError } from '../../../src/core/errors';
+import {
+  prepareExternalPartyCcTransfer,
+  submitExternalPartyCcTransfer,
+} from '../../../src/utils/amulet/external-party-cc-transfer';
+
+const createMockValidatorClient = (): jest.Mocked<ValidatorApiClient> =>
+  ({
+    lookupTransferCommandCounterByParty: jest.fn().mockResolvedValue({ counter: 7 }),
+    prepareTransferPreapprovalSend: jest.fn().mockResolvedValue({
+      transaction: 'prepared-transaction-base64',
+      tx_hash: 'abc123',
+      transfer_command_contract_id_prefix: 'transfer-command-prefix',
+    }),
+    submitTransferPreapprovalSend: jest.fn().mockResolvedValue({
+      update_id: 'update-123',
+    }),
+  }) as unknown as jest.Mocked<ValidatorApiClient>;
+
+describe('external party CC transfer helpers', () => {
+  let validatorClient: jest.Mocked<ValidatorApiClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    validatorClient = createMockValidatorClient();
+  });
+
+  it('prepares a CC transfer using the sender transfer-command counter as nonce', async () => {
+    const result = await prepareExternalPartyCcTransfer(validatorClient, {
+      senderPartyId: 'sender::fingerprint',
+      receiverPartyId: 'receiver::fingerprint',
+      amount: '12.5',
+      description: 'invoice payment',
+      expiresAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(validatorClient.lookupTransferCommandCounterByParty).toHaveBeenCalledWith({
+      party: 'sender::fingerprint',
+    });
+    expect(validatorClient.prepareTransferPreapprovalSend).toHaveBeenCalledWith({
+      sender_party_id: 'sender::fingerprint',
+      receiver_party_id: 'receiver::fingerprint',
+      amount: 12.5,
+      expires_at: '2026-01-01T00:00:00.000Z',
+      nonce: 7,
+      verbose_hashing: false,
+      description: 'invoice payment',
+    });
+    expect(result).toMatchObject({
+      transaction: 'prepared-transaction-base64',
+      transactionHashHex: 'abc123',
+      transferCommandContractIdPrefix: 'transfer-command-prefix',
+      nonce: 7,
+      expiresAt: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('uses nonce 0 when the sender has no transfer-command counter yet', async () => {
+    validatorClient.lookupTransferCommandCounterByParty.mockRejectedValueOnce(new ApiError('not found', 404));
+
+    await prepareExternalPartyCcTransfer(validatorClient, {
+      senderPartyId: 'sender::fingerprint',
+      receiverPartyId: 'receiver::fingerprint',
+      amount: 1,
+      expiresAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(validatorClient.prepareTransferPreapprovalSend).toHaveBeenCalledWith(expect.objectContaining({ nonce: 0 }));
+  });
+
+  it('submits a signed CC transfer through the validator endpoint', async () => {
+    const result = await submitExternalPartyCcTransfer(validatorClient, {
+      senderPartyId: 'sender::fingerprint',
+      transaction: 'prepared-transaction-base64',
+      transactionHashSignatureHex: 'deadbeef',
+      publicKeyHex: 'abcdef',
+    });
+
+    expect(validatorClient.submitTransferPreapprovalSend).toHaveBeenCalledWith({
+      submission: {
+        party_id: 'sender::fingerprint',
+        transaction: 'prepared-transaction-base64',
+        signed_tx_hash: 'deadbeef',
+        public_key: 'abcdef',
+      },
+    });
+    expect(result.updateId).toBe('update-123');
+  });
+
+  it('rejects invalid amounts before calling the validator', async () => {
+    await expect(
+      prepareExternalPartyCcTransfer(validatorClient, {
+        senderPartyId: 'sender::fingerprint',
+        receiverPartyId: 'receiver::fingerprint',
+        amount: 0,
+      })
+    ).rejects.toThrow('CC transfer amount must be a positive number');
+
+    expect(validatorClient.prepareTransferPreapprovalSend).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add validator admin prepare/submit operations for external-party TransferPreapproval sends
- add SDK helpers for preparing and submitting Privy/external-party CC transfers without private-key custody
- normalize transfer-command nonce lookup, including nonce 0 when the counter is not found

## Validation
- npm test -- test/unit/amulet/external-party-cc-transfer.test.ts --runInBand
- npm run build:core

Related to Fairmint/apiv2#478 and ENG-1298.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fund-movement and validator admin APIs; risk is moderated by external signing, client-side validation, and tests, but incorrect nonce or submission handling could still affect transfers.
> 
> **Overview**
> Adds **externally signed CC (amulet) transfers** for parties hosted outside the SDK (e.g. browser/Privy wallets), using a prepare → sign hash → submit flow without private keys in the SDK.
> 
> New validator **admin** client operations call `prepare-send` and `submit-send` under `external-party/transfer-preapproval`. New amulet utilities **`prepareExternalPartyCcTransfer`** and **`submitExternalPartyCcTransfer`** wrap those calls with input validation, default **1h** expiry, and automatic **transfer-command nonce** from `lookupTransferCommandCounterByParty` (falling back to **0** on 404). Prepare returns the base64 transaction and hex hash for the wallet to sign; submit posts the signature and public key and returns the Canton **update ID**. Unit tests cover nonce behavior, submit wiring, and amount validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f46ee18c1fb58af7b4c3a0f702f0ba2cbf481f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preparing and submitting externally signed Canton Coin transfers
  * Includes comprehensive validation of transfer parameters including amounts, expiration times, nonces, party identifiers, and digital signatures
  * Provides utilities for normalizing and validating external party transfer data

* **Tests**
  * Added test suite covering external transfer preparation and submission scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->