### PR TITLE
[codex] Tighten external-party CC transfer validation

### DIFF
--- a/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import { createApiOperation } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
 
+const HEX_BYTES_PATTERN = /^(?:[0-9a-fA-F]{2})+$/;
+
 /**
  * Submit an externally signed CC transfer
  *
@@ -15,8 +17,8 @@ export const SubmitTransferPreapprovalSend = createApiOperation<
     submission: z.object({
       party_id: z.string().min(1),
       transaction: z.string().min(1),
-      signed_tx_hash: z.string().regex(/^[0-9a-fA-F]+$/),
-      public_key: z.string().regex(/^[0-9a-fA-F]+$/),
+      signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
+      public_key: z.string().regex(HEX_BYTES_PATTERN),
     }),
   }) as z.ZodType<operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json']>,
   method: 'POST',

--- a/src/utils/amulet/external-party-cc-transfer.ts
+++ b/src/utils/amulet/external-party-cc-transfer.ts
@@ -63,12 +63,12 @@ export async function prepareExternalPartyCcTransfer(
   validatorClient: ValidatorApiClient,
   params: PrepareExternalPartyCcTransferParams
 ): Promise<PreparedExternalPartyCcTransfer> {
+  validatePartyId('senderPartyId', params.senderPartyId);
+  validatePartyId('receiverPartyId', params.receiverPartyId);
   const amount = normalizePositiveAmount(params.amount);
   const expiresAt = normalizeExpiresAt(params.expiresAt);
   const nonce = params.nonce ?? (await lookupNextNonce(validatorClient, params.senderPartyId));
 
-  validatePartyId('senderPartyId', params.senderPartyId);
-  validatePartyId('receiverPartyId', params.receiverPartyId);
   validateNonce(nonce);
 
   const raw = await validatorClient.prepareTransferPreapprovalSend({
@@ -165,10 +165,15 @@ function validatePartyId(name: string, value: string): void {
   if (!value.trim()) {
     throw new ValidationError(`${name} is required`);
   }
+  if (value !== value.trim()) {
+    throw new ValidationError(`${name} must not include leading or trailing whitespace`, {
+      [name]: value,
+    });
+  }
 }
 
 function validateHex(name: string, value: string): void {
-  if (!/^[0-9a-fA-F]+$/.test(value)) {
+  if (!/^(?:[0-9a-fA-F]{2})+$/.test(value)) {
     throw new ValidationError(`${name} must be hex-encoded`, { [name]: value });
   }
 }

--- a/test/unit/amulet/external-party-cc-transfer.test.ts
+++ b/test/unit/amulet/external-party-cc-transfer.test.ts
@@ -26,7 +26,7 @@ describe('external party CC transfer helpers', () => {
     validatorClient = createMockValidatorClient();
   });
 
-  it('prepares a CC transfer using the sender transfer-command counter as nonce', async () => {
+  it('prepares a CC transfer using the sender transfer-command counter as nonce', async (): Promise<void> => {
     const result = await prepareExternalPartyCcTransfer(validatorClient, {
       senderPartyId: 'sender::fingerprint',
       receiverPartyId: 'receiver::fingerprint',
@@ -56,7 +56,7 @@ describe('external party CC transfer helpers', () => {
     });
   });
 
-  it('uses nonce 0 when the sender has no transfer-command counter yet', async () => {
+  it('uses nonce 0 when the sender has no transfer-command counter yet', async (): Promise<void> => {
     validatorClient.lookupTransferCommandCounterByParty.mockRejectedValueOnce(new ApiError('not found', 404));
 
     await prepareExternalPartyCcTransfer(validatorClient, {
@@ -69,7 +69,7 @@ describe('external party CC transfer helpers', () => {
     expect(validatorClient.prepareTransferPreapprovalSend).toHaveBeenCalledWith(expect.objectContaining({ nonce: 0 }));
   });
 
-  it('submits a signed CC transfer through the validator endpoint', async () => {
+  it('submits a signed CC transfer through the validator endpoint', async (): Promise<void> => {
     const result = await submitExternalPartyCcTransfer(validatorClient, {
       senderPartyId: 'sender::fingerprint',
       transaction: 'prepared-transaction-base64',
@@ -88,7 +88,7 @@ describe('external party CC transfer helpers', () => {
     expect(result.updateId).toBe('update-123');
   });
 
-  it('rejects invalid amounts before calling the validator', async () => {
+  it('rejects invalid amounts before calling the validator', async (): Promise<void> => {
     await expect(
       prepareExternalPartyCcTransfer(validatorClient, {
         senderPartyId: 'sender::fingerprint',
@@ -98,5 +98,53 @@ describe('external party CC transfer helpers', () => {
     ).rejects.toThrow('CC transfer amount must be a positive number');
 
     expect(validatorClient.prepareTransferPreapprovalSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid sender party IDs before looking up the nonce', async (): Promise<void> => {
+    await expect(
+      prepareExternalPartyCcTransfer(validatorClient, {
+        senderPartyId: '   ',
+        receiverPartyId: 'receiver::fingerprint',
+        amount: 1,
+      })
+    ).rejects.toThrow('senderPartyId is required');
+
+    expect(validatorClient.lookupTransferCommandCounterByParty).not.toHaveBeenCalled();
+    expect(validatorClient.prepareTransferPreapprovalSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects party IDs with leading or trailing whitespace', async (): Promise<void> => {
+    await expect(
+      submitExternalPartyCcTransfer(validatorClient, {
+        senderPartyId: ' sender::fingerprint ',
+        transaction: 'prepared-transaction-base64',
+        transactionHashSignatureHex: 'deadbeef',
+        publicKeyHex: 'abcdef',
+      })
+    ).rejects.toThrow('senderPartyId must not include leading or trailing whitespace');
+
+    expect(validatorClient.submitTransferPreapprovalSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects odd-length hex strings before calling the validator', async (): Promise<void> => {
+    await expect(
+      submitExternalPartyCcTransfer(validatorClient, {
+        senderPartyId: 'sender::fingerprint',
+        transaction: 'prepared-transaction-base64',
+        transactionHashSignatureHex: 'abc',
+        publicKeyHex: 'abcdef',
+      })
+    ).rejects.toThrow('transactionHashSignatureHex must be hex-encoded');
+
+    await expect(
+      submitExternalPartyCcTransfer(validatorClient, {
+        senderPartyId: 'sender::fingerprint',
+        transaction: 'prepared-transaction-base64',
+        transactionHashSignatureHex: 'deadbeef',
+        publicKeyHex: 'abc',
+      })
+    ).rejects.toThrow('publicKeyHex must be hex-encoded');
+
+    expect(validatorClient.submitTransferPreapprovalSend).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #340 after it was merged while review feedback was still arriving.
- Fail fast on blank or whitespace-padded party IDs before nonce lookup / submit.
- Require byte-aligned hex strings for external-party CC transfer signatures and public keys.

## Validation
- npm test -- test/unit/amulet/external-party-cc-transfer.test.ts --runInBand
- npm run build:core

Linked: Fairmint/apiv2#478 / ENG-1298

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation only on external-party transfer prepare/submit paths; no change to signing or submission logic beyond rejecting malformed strings earlier.
> 
> **Overview**
> Tightens **external-party CC transfer** validation so bad inputs fail before validator calls.
> 
> **Party IDs** are validated at the start of prepare (before nonce lookup) and on submit. Blank IDs still fail; **leading or trailing whitespace** is now rejected explicitly.
> 
> **Hex fields** (`signed_tx_hash`, `public_key`, signature, and public key in the SDK) must be **byte-aligned** hex—pairs of hex digits only—matching a shared `HEX_BYTES_PATTERN` on the submit API schema and `validateHex` in the transfer helper.
> 
> Unit tests cover early rejection for blank/whitespace party IDs and odd-length hex without hitting the validator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd157c9b5af1b913866b2cf0e19e8781cf5669f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for external party transfer operations to enforce proper hex string formatting (even-length byte pairs).
  * Improved party ID validation to reject inputs with leading or trailing whitespace.
  * Validation checks now occur earlier in the process to catch errors sooner.

* **Tests**
  * Added unit tests for transfer operation input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->