### PR TITLE
[codex] Add command trace context submission support

### DIFF
--- a/src/clients/ledger-json-api/index.ts
+++ b/src/clients/ledger-json-api/index.ts
@@ -1,2 +1,3 @@
 export * from './completion-stream';
 export { LedgerJsonApiClient } from './LedgerJsonApiClient.generated';
+export type { TraceContext } from './schemas';

--- a/src/clients/ledger-json-api/schemas/operations/commands.ts
+++ b/src/clients/ledger-json-api/schemas/operations/commands.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { CompositeCommandSchema, DeduplicationPeriodSchema, DisclosedContractSchema } from '../api/commands';
 import { ReassignmentCommandSchema } from '../api/reassignment';
-import { MinLedgerTimeRelSchema, PrefetchContractKeySchema } from '../common';
+import { MinLedgerTimeRelSchema, PrefetchContractKeySchema, TraceContextSchema } from '../common';
 import { NonEmptyStringSchema } from './base';
 import { OperationEventFormatSchema, TransactionFormatSchema } from './updates';
 
@@ -30,6 +30,8 @@ const BaseCommandParamsSchema = z.object({
   minLedgerTimeRel: MinLedgerTimeRelSchema.optional(),
   /** Submission ID. */
   submissionId: NonEmptyStringSchema.optional(),
+  /** Trace context propagated to Canton command submissions. */
+  traceContext: TraceContextSchema.optional(),
   /** Disclosed contracts to include. */
   disclosedContracts: z.array(DisclosedContractSchema).optional(),
   /** Target synchronizer ID. */

--- a/test/unit/operations/submit-and-wait-for-transaction-tree.test.ts
+++ b/test/unit/operations/submit-and-wait-for-transaction-tree.test.ts
@@ -1,0 +1,57 @@
+import { SubmitAndWaitForTransactionTree } from '../../../src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree';
+import type { BaseClient } from '../../../src/core';
+
+const createCommand = (): { CreateCommand: { templateId: string; createArguments: Record<string, never> } } => ({
+  CreateCommand: {
+    templateId: '#pkg:Module:Template',
+    createArguments: {},
+  },
+});
+
+describe('SubmitAndWaitForTransactionTree', () => {
+  it('forwards traceContext in the submit request body', async () => {
+    const makePostRequest = jest.fn().mockResolvedValue({
+      transactionTree: {
+        updateId: 'update-123',
+      },
+    });
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      getPartyId: () => 'alice::123',
+      makePostRequest,
+    } as unknown as BaseClient;
+
+    await new SubmitAndWaitForTransactionTree(client).execute({
+      commands: [createCommand()],
+      commandId: 'cmd-123',
+      traceContext: {
+        traceId: 'trace-123',
+        spanId: 'span-123',
+        parentSpanId: 'parent-123',
+        metadata: {
+          requestId: 'request-123',
+        },
+      },
+    });
+
+    expect(makePostRequest).toHaveBeenCalledWith(
+      'https://ledger.example/v2/commands/submit-and-wait-for-transaction-tree',
+      expect.objectContaining({
+        actAs: ['alice::123'],
+        commandId: 'cmd-123',
+        traceContext: {
+          traceId: 'trace-123',
+          spanId: 'span-123',
+          parentSpanId: 'parent-123',
+          metadata: {
+            requestId: 'request-123',
+          },
+        },
+      }),
+      expect.objectContaining({
+        contentType: 'application/json',
+        includeBearerToken: true,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds trace-context support to the Ledger JSON API command submission params used by the TypeScript SDK.

- adds `traceContext` to the shared command params schema used by `submitAndWait`, `submitAndWaitForTransaction`, `submitAndWaitForTransactionTree`, and async submit
- exports the existing `TraceContext` type from the public ledger client surface
- adds focused coverage proving `submitAndWaitForTransactionTree` forwards `traceContext` into the POST body

This unblocks downstream SDKs from passing distributed tracing metadata through Canton command submissions instead of keeping it log-only.

## Validation

- `npm run build:core`
- `npm test -- test/unit/operations/submit-and-wait-for-transaction-tree.test.ts --runInBand`
- `npx eslint src/clients/ledger-json-api/schemas/operations/commands.ts src/clients/ledger-json-api/index.ts test/unit/operations/submit-and-wait-for-transaction-tree.test.ts`
- `npx prettier --check src/clients/ledger-json-api/schemas/operations/commands.ts src/clients/ledger-json-api/index.ts test/unit/operations/submit-and-wait-for-transaction-tree.test.ts`

## Known existing validation gap

`npm run build:lint` still fails on existing unrelated strictness errors in `test/integration/localnet/ledger-api/paid-traffic-cost.test.ts` and `test/integration/localnet/ledger-api/updates.test.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional schema field and public type export with a focused unit test; no changes to auth or core submission logic beyond forwarding metadata.
> 
> **Overview**
> Adds optional **`traceContext`** to the shared **`BaseCommandParamsSchema`**, so callers can pass distributed tracing metadata on Canton command submissions for **`submitAndWait`**, **`submitAndWaitForTransaction`**, **`submitAndWaitForTransactionTree`**, and async submit paths that reuse those params.
> 
> Re-exports the existing **`TraceContext`** type from the public ledger JSON API client entrypoint. A unit test asserts **`SubmitAndWaitForTransactionTree`** includes **`traceContext`** in the POST body when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9bc79f6d01dd9bca9552b1b86a304a2c172b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->