### PR TITLE
[ENG-461] Add Canton health check utilities

### DIFF
--- a/src/Canton.ts
+++ b/src/Canton.ts
@@ -167,12 +167,18 @@ export class Canton {
 
     await Promise.all(
       servicesToCheck.map(async (service) => {
-        if (service === 'ledger') {
-          services.ledger = await this.checkLedgerHealth();
-        } else if (service === 'validator') {
-          services.validator = await this.checkValidatorHealth();
-        } else {
-          services.scan = await this.checkScanHealth();
+        switch (service) {
+          case 'ledger':
+            services.ledger = await this.checkLedgerHealth();
+            return;
+          case 'validator':
+            services.validator = await this.checkValidatorHealth();
+            return;
+          case 'scan':
+            services.scan = await this.checkScanHealth();
+            return;
+          default:
+            throw new Error(`Unknown Canton health service: ${String(service)}`);
         }
       })
     );

--- a/src/Canton.ts
+++ b/src/Canton.ts
@@ -4,6 +4,42 @@ import { type Logger } from './core/logging';
 import { CantonRuntime } from './core/runtime';
 import { type ClientConfig, type NetworkType, type ProviderType } from './core/types';
 
+export type CantonHealthService = 'ledger' | 'validator' | 'scan';
+
+/** Options for one-shot Canton service health checks. */
+export interface CantonHealthCheckOptions {
+  /** Services to check. Defaults to ledger, validator, and scan. */
+  readonly services?: readonly CantonHealthService[];
+}
+
+/** Health check result for one Canton service. */
+export interface CantonServiceHealthStatus {
+  /** True when every probe for this service succeeded. */
+  readonly ok: boolean;
+  /** Readiness probe result, when the service exposes a readiness endpoint. */
+  readonly ready?: boolean;
+  /** Liveness probe result, when the service exposes a liveness endpoint. */
+  readonly live?: boolean;
+  /** Version response, when the service exposes a version endpoint. */
+  readonly version?: unknown;
+  /** Status response, when the service exposes a status endpoint. */
+  readonly status?: unknown;
+  /** Combined probe error messages when one or more probes failed. */
+  readonly error?: string;
+}
+
+/** Combined health check result for selected Canton services. */
+export interface ServiceHealthStatus {
+  /** True when every selected service is healthy. */
+  readonly ok: boolean;
+  /** ISO timestamp for when the check completed. */
+  readonly checkedAt: string;
+  /** Per-service health results. */
+  readonly services: Partial<Record<CantonHealthService, CantonServiceHealthStatus>>;
+}
+
+type ProbeResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
 /**
  * Configuration for the Canton unified client. Initializes all clients with shared settings.
  *
@@ -71,8 +107,6 @@ export class Canton {
   /**
    * Creates a new Canton unified client.
    *
-   * @param config - Connection targets (`network`, optional `provider`) plus identity/logging/API overrides.
-   *
    * @example
    *   const canton = new Canton({ network: 'localnet' });
    *
@@ -82,6 +116,8 @@ export class Canton {
    *     provider: '5n',
    *     debug: true,
    *   });
+   *
+   * @param config - Connection targets (`network`, optional `provider`) plus identity/logging/API overrides.
    */
   constructor(config: CantonConfig) {
     this.config = config;
@@ -118,6 +154,75 @@ export class Canton {
     this.ledger.setPartyId(partyId);
     this.validator.setPartyId(partyId);
   }
+
+  /**
+   * Checks configured Canton services without waiting or throwing on partial failures.
+   *
+   * Ledger health is represented by the JSON API version endpoint because this checkout does not expose a JSON API
+   * readiness/liveness operation. Validator and Scan use their readiness/liveness endpoints.
+   */
+  public async checkHealth(options: CantonHealthCheckOptions = {}): Promise<ServiceHealthStatus> {
+    const servicesToCheck = options.services ?? (['ledger', 'validator', 'scan'] as const);
+    const services: Partial<Record<CantonHealthService, CantonServiceHealthStatus>> = {};
+
+    await Promise.all(
+      servicesToCheck.map(async (service) => {
+        if (service === 'ledger') {
+          services.ledger = await this.checkLedgerHealth();
+        } else if (service === 'validator') {
+          services.validator = await this.checkValidatorHealth();
+        } else {
+          services.scan = await this.checkScanHealth();
+        }
+      })
+    );
+
+    return {
+      ok: Object.values(services).every((service) => service.ok),
+      checkedAt: new Date().toISOString(),
+      services,
+    };
+  }
+
+  private async checkLedgerHealth(): Promise<CantonServiceHealthStatus> {
+    const version = await probe(async () => this.ledger.getVersion());
+    return {
+      ok: version.ok,
+      ...(version.ok ? { version: version.value } : { error: version.error }),
+    };
+  }
+
+  private async checkValidatorHealth(): Promise<CantonServiceHealthStatus> {
+    const [ready, live] = await Promise.all([
+      probe(async () => this.validator.isReady()),
+      probe(async () => this.validator.isLive()),
+    ]);
+    const errors = collectErrors(ready, live);
+
+    return {
+      ok: ready.ok && live.ok,
+      ready: ready.ok,
+      live: live.ok,
+      ...(errors.length > 0 ? { error: errors.join('; ') } : {}),
+    };
+  }
+
+  private async checkScanHealth(): Promise<CantonServiceHealthStatus> {
+    const [ready, live, status] = await Promise.all([
+      probe(async () => this.scan.isReady()),
+      probe(async () => this.scan.isLive()),
+      probe(async () => this.scan.getHealthStatus()),
+    ]);
+    const errors = collectErrors(ready, live, status);
+
+    return {
+      ok: ready.ok && live.ok && status.ok,
+      ready: ready.ok,
+      live: live.ok,
+      ...(status.ok ? { status: status.value } : {}),
+      ...(errors.length > 0 ? { error: errors.join('; ') } : {}),
+    };
+  }
 }
 
 /** Builds a ClientConfig from CantonConfig, omitting undefined values to preserve exactOptionalPropertyTypes. */
@@ -134,4 +239,23 @@ function buildClientConfig(config: CantonConfig): ClientConfig {
   if (config.apis !== undefined) clientConfig.apis = { ...config.apis };
 
   return clientConfig;
+}
+
+async function probe<T>(operation: () => Promise<T>): Promise<ProbeResult<T>> {
+  try {
+    return { ok: true, value: await operation() };
+  } catch (error) {
+    return { ok: false, error: formatHealthError(error) };
+  }
+}
+
+function collectErrors(...results: ReadonlyArray<ProbeResult<unknown>>): string[] {
+  return results.flatMap((result) => (result.ok ? [] : [result.error]));
+}
+
+function formatHealthError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }

--- a/src/Canton.ts
+++ b/src/Canton.ts
@@ -162,7 +162,7 @@ export class Canton {
    * readiness/liveness operation. Validator and Scan use their readiness/liveness endpoints.
    */
   public async checkHealth(options: CantonHealthCheckOptions = {}): Promise<ServiceHealthStatus> {
-    const servicesToCheck = options.services ?? (['ledger', 'validator', 'scan'] as const);
+    const servicesToCheck = [...new Set(options.services ?? (['ledger', 'validator', 'scan'] as const))];
     const services: Partial<Record<CantonHealthService, CantonServiceHealthStatus>> = {};
 
     await Promise.all(
@@ -219,10 +219,14 @@ export class Canton {
       probe(async () => this.scan.isLive()),
       probe(async () => this.scan.getHealthStatus()),
     ]);
+    const scanStatusOk = status.ok && isSuccessfulScanStatus(status.value);
     const errors = collectErrors(ready, live, status);
+    if (status.ok && !scanStatusOk) {
+      errors.push(formatScanStatusError(status.value));
+    }
 
     return {
-      ok: ready.ok && live.ok && status.ok,
+      ok: ready.ok && live.ok && scanStatusOk,
       ready: ready.ok,
       live: live.ok,
       ...(status.ok ? { status: status.value } : {}),
@@ -257,6 +261,34 @@ async function probe<T>(operation: () => Promise<T>): Promise<ProbeResult<T>> {
 
 function collectErrors(...results: ReadonlyArray<ProbeResult<unknown>>): string[] {
   return results.flatMap((result) => (result.ok ? [] : [result.error]));
+}
+
+function isSuccessfulScanStatus(status: unknown): boolean {
+  return isRecord(status) && 'success' in status;
+}
+
+function formatScanStatusError(status: unknown): string {
+  if (!isRecord(status)) {
+    return 'scan status response was not an object';
+  }
+  if ('not_initialized' in status) {
+    return 'scan status not initialized';
+  }
+  if ('failed' in status) {
+    const { failed } = status;
+    if (isRecord(failed)) {
+      const { error } = failed;
+      if (typeof error === 'string') {
+        return `scan status failed: ${error}`;
+      }
+    }
+    return 'scan status failed';
+  }
+  return 'scan status did not report success';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function formatHealthError(error: unknown): string {

--- a/src/clients/validator-api/operations/v0/health.ts
+++ b/src/clients/validator-api/operations/v0/health.ts
@@ -15,7 +15,7 @@ const publicRequestConfig = { contentType: 'application/json', includeBearerToke
 export const IsReady = createApiOperation<void, void>({
   paramsSchema: z.void(),
   method: 'GET',
-  buildUrl: (_params: void, apiUrl: string) => `${apiUrl}/api/validator/readyz`,
+  buildUrl: (_params: void, apiUrl: string): string => `${apiUrl}/api/validator/readyz`,
   requestConfig: publicRequestConfig,
 });
 
@@ -31,6 +31,6 @@ export const IsReady = createApiOperation<void, void>({
 export const IsLive = createApiOperation<void, void>({
   paramsSchema: z.void(),
   method: 'GET',
-  buildUrl: (_params: void, apiUrl: string) => `${apiUrl}/api/validator/livez`,
+  buildUrl: (_params: void, apiUrl: string): string => `${apiUrl}/api/validator/livez`,
   requestConfig: publicRequestConfig,
 });

--- a/src/clients/validator-api/operations/v0/health.ts
+++ b/src/clients/validator-api/operations/v0/health.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../core';
+
+const publicRequestConfig = { contentType: 'application/json', includeBearerToken: false } as const;
+
+/**
+ * Checks whether the validator API is ready to serve traffic
+ *
+ * @example
+ *   ```typescript
+ *   await client.isReady();
+ *
+ *   ```;
+ */
+export const IsReady = createApiOperation<void, void>({
+  paramsSchema: z.void(),
+  method: 'GET',
+  buildUrl: (_params: void, apiUrl: string) => `${apiUrl}/api/validator/readyz`,
+  requestConfig: publicRequestConfig,
+});
+
+/**
+ * Checks whether the validator API process is live
+ *
+ * @example
+ *   ```typescript
+ *   await client.isLive();
+ *
+ *   ```;
+ */
+export const IsLive = createApiOperation<void, void>({
+  paramsSchema: z.void(),
+  method: 'GET',
+  buildUrl: (_params: void, apiUrl: string) => `${apiUrl}/api/validator/livez`,
+  requestConfig: publicRequestConfig,
+});

--- a/src/clients/validator-api/operations/v0/index.ts
+++ b/src/clients/validator-api/operations/v0/index.ts
@@ -1,6 +1,7 @@
 export * from './admin';
 export * from './ans';
 export * from './get-validator-user-info';
+export * from './health';
 export * from './register';
 export * from './scan-proxy';
 export * from './wallet';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-export { Canton, type CantonConfig } from './Canton';
+export {
+  Canton,
+  type CantonConfig,
+  type CantonHealthCheckOptions,
+  type CantonHealthService,
+  type CantonServiceHealthStatus,
+  type ServiceHealthStatus,
+} from './Canton';
 export * from './clients';
 export * from './core';
 export * from './utils';

--- a/src/utils/health/index.ts
+++ b/src/utils/health/index.ts
@@ -1,0 +1,1 @@
+export * from './wait-for-ready';

--- a/src/utils/health/wait-for-ready.ts
+++ b/src/utils/health/wait-for-ready.ts
@@ -1,0 +1,29 @@
+import { type Canton, type CantonHealthCheckOptions, type ServiceHealthStatus } from '../../Canton';
+import { waitForCondition, type WaitForConditionOptions } from '../../core/utils/polling';
+
+export interface WaitForReadyOptions extends WaitForConditionOptions {
+  /** Health check service selection passed to Canton.checkHealth(). */
+  readonly healthCheck?: CantonHealthCheckOptions;
+}
+
+/**
+ * Waits until the selected Canton services report healthy.
+ *
+ * Defaults to five minutes because LocalNet can take several minutes to become ready.
+ */
+export async function waitForReady(
+  canton: Pick<Canton, 'checkHealth'>,
+  options: WaitForReadyOptions = {}
+): Promise<ServiceHealthStatus> {
+  return waitForCondition(
+    async () => {
+      const health = await canton.checkHealth(options.healthCheck);
+      return health.ok ? health : null;
+    },
+    {
+      timeout: options.timeout ?? 300_000,
+      interval: options.interval ?? 5_000,
+      timeoutMessage: options.timeoutMessage ?? 'Timed out waiting for Canton services to become ready',
+    }
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './amulet';
 export * from './contracts';
 export * from './external-signing';
+export * from './health';
 export * from './mining';
 export * from './parsers';
 export * from './party';

--- a/test/integration/localnet/validator-api/health.test.ts
+++ b/test/integration/localnet/validator-api/health.test.ts
@@ -1,0 +1,15 @@
+/** ValidatorApiClient integration tests: Health and Status */
+
+import { getClient } from './setup';
+
+describe('ValidatorApiClient / Health', () => {
+  test('isReady completes without error', async () => {
+    const client = getClient();
+    await client.isReady();
+  });
+
+  test('isLive completes without error', async () => {
+    const client = getClient();
+    await client.isLive();
+  });
+});

--- a/test/unit/canton-health.test.ts
+++ b/test/unit/canton-health.test.ts
@@ -39,4 +39,30 @@ describe('Canton.checkHealth', () => {
     } satisfies Partial<CantonServiceHealthStatus>);
     expect(health.services.scan).toBeUndefined();
   });
+
+  it('rejects unknown service values supplied by runtime JavaScript callers', async () => {
+    const canton = new Canton({
+      network: 'localnet',
+      apis: {
+        LEDGER_JSON_API: {
+          apiUrl: 'https://ledger.example',
+          auth: { grantType: 'client_credentials', clientId: 'ledger', clientSecret: 'secret' },
+        },
+        VALIDATOR_API: {
+          apiUrl: 'https://validator.example',
+          auth: { grantType: 'client_credentials', clientId: 'validator', clientSecret: 'secret' },
+        },
+        SCAN_API: {
+          apiUrl: 'https://scan.example/api/scan',
+          auth: { grantType: 'client_credentials', clientId: '' },
+        },
+      },
+    });
+
+    await expect(
+      canton.checkHealth({
+        services: ['validatorr'] as unknown as readonly ['validator'],
+      })
+    ).rejects.toThrow('Unknown Canton health service: validatorr');
+  });
 });

--- a/test/unit/canton-health.test.ts
+++ b/test/unit/canton-health.test.ts
@@ -1,0 +1,42 @@
+import { Canton, type CantonServiceHealthStatus } from '../../src';
+
+describe('Canton.checkHealth', () => {
+  it('aggregates selected service health without throwing on partial failure', async () => {
+    const canton = new Canton({
+      network: 'localnet',
+      apis: {
+        LEDGER_JSON_API: {
+          apiUrl: 'https://ledger.example',
+          auth: { grantType: 'client_credentials', clientId: 'ledger', clientSecret: 'secret' },
+        },
+        VALIDATOR_API: {
+          apiUrl: 'https://validator.example',
+          auth: { grantType: 'client_credentials', clientId: 'validator', clientSecret: 'secret' },
+        },
+        SCAN_API: {
+          apiUrl: 'https://scan.example/api/scan',
+          auth: { grantType: 'client_credentials', clientId: '' },
+        },
+      },
+    });
+
+    jest.spyOn(canton.ledger, 'getVersion').mockResolvedValue({ version: '3.4.0' });
+    jest.spyOn(canton.validator, 'isReady').mockResolvedValue(undefined);
+    jest.spyOn(canton.validator, 'isLive').mockRejectedValue(new Error('validator unavailable'));
+
+    const health = await canton.checkHealth({ services: ['ledger', 'validator'] });
+
+    expect(health.ok).toBe(false);
+    expect(health.services.ledger).toMatchObject({
+      ok: true,
+      version: { version: '3.4.0' },
+    } satisfies Partial<CantonServiceHealthStatus>);
+    expect(health.services.validator).toMatchObject({
+      ok: false,
+      ready: true,
+      live: false,
+      error: 'validator unavailable',
+    } satisfies Partial<CantonServiceHealthStatus>);
+    expect(health.services.scan).toBeUndefined();
+  });
+});

--- a/test/unit/canton-health.test.ts
+++ b/test/unit/canton-health.test.ts
@@ -1,24 +1,28 @@
-import { Canton, type CantonServiceHealthStatus } from '../../src';
+import { Canton, type CantonHealthCheckOptions, type CantonServiceHealthStatus } from '../../src';
+
+function createCanton(): Canton {
+  return new Canton({
+    network: 'localnet',
+    apis: {
+      LEDGER_JSON_API: {
+        apiUrl: 'https://ledger.example',
+        auth: { grantType: 'client_credentials', clientId: 'ledger', clientSecret: 'secret' },
+      },
+      VALIDATOR_API: {
+        apiUrl: 'https://validator.example',
+        auth: { grantType: 'client_credentials', clientId: 'validator', clientSecret: 'secret' },
+      },
+      SCAN_API: {
+        apiUrl: 'https://scan.example/api/scan',
+        auth: { grantType: 'client_credentials', clientId: '' },
+      },
+    },
+  });
+}
 
 describe('Canton.checkHealth', () => {
-  it('aggregates selected service health without throwing on partial failure', async () => {
-    const canton = new Canton({
-      network: 'localnet',
-      apis: {
-        LEDGER_JSON_API: {
-          apiUrl: 'https://ledger.example',
-          auth: { grantType: 'client_credentials', clientId: 'ledger', clientSecret: 'secret' },
-        },
-        VALIDATOR_API: {
-          apiUrl: 'https://validator.example',
-          auth: { grantType: 'client_credentials', clientId: 'validator', clientSecret: 'secret' },
-        },
-        SCAN_API: {
-          apiUrl: 'https://scan.example/api/scan',
-          auth: { grantType: 'client_credentials', clientId: '' },
-        },
-      },
-    });
+  it('aggregates selected service health without throwing on partial failure', async (): Promise<void> => {
+    const canton = createCanton();
 
     jest.spyOn(canton.ledger, 'getVersion').mockResolvedValue({ version: '3.4.0' });
     jest.spyOn(canton.validator, 'isReady').mockResolvedValue(undefined);
@@ -40,29 +44,32 @@ describe('Canton.checkHealth', () => {
     expect(health.services.scan).toBeUndefined();
   });
 
-  it('rejects unknown service values supplied by runtime JavaScript callers', async () => {
-    const canton = new Canton({
-      network: 'localnet',
-      apis: {
-        LEDGER_JSON_API: {
-          apiUrl: 'https://ledger.example',
-          auth: { grantType: 'client_credentials', clientId: 'ledger', clientSecret: 'secret' },
-        },
-        VALIDATOR_API: {
-          apiUrl: 'https://validator.example',
-          auth: { grantType: 'client_credentials', clientId: 'validator', clientSecret: 'secret' },
-        },
-        SCAN_API: {
-          apiUrl: 'https://scan.example/api/scan',
-          auth: { grantType: 'client_credentials', clientId: '' },
-        },
-      },
-    });
+  it('marks scan unhealthy when status body does not report success', async (): Promise<void> => {
+    const canton = createCanton();
 
-    await expect(
-      canton.checkHealth({
-        services: ['validatorr'] as unknown as readonly ['validator'],
-      })
-    ).rejects.toThrow('Unknown Canton health service: validatorr');
+    jest.spyOn(canton.scan, 'isReady').mockResolvedValue(undefined);
+    jest.spyOn(canton.scan, 'isLive').mockResolvedValue(undefined);
+    jest.spyOn(canton.scan, 'getHealthStatus').mockResolvedValue({ not_initialized: { active: true } });
+
+    const health = await canton.checkHealth({ services: ['scan', 'scan'] });
+
+    expect(canton.scan.isReady).toHaveBeenCalledTimes(1);
+    expect(canton.scan.isLive).toHaveBeenCalledTimes(1);
+    expect(canton.scan.getHealthStatus).toHaveBeenCalledTimes(1);
+    expect(health.ok).toBe(false);
+    expect(health.services.scan).toMatchObject({
+      ok: false,
+      ready: true,
+      live: true,
+      status: { not_initialized: { active: true } },
+      error: 'scan status not initialized',
+    } satisfies Partial<CantonServiceHealthStatus>);
+  });
+
+  it('rejects unknown service values supplied by runtime JavaScript callers', async (): Promise<void> => {
+    const canton = createCanton();
+    const options = { services: ['validatorr'] } as unknown as CantonHealthCheckOptions;
+
+    await expect(canton.checkHealth(options)).rejects.toThrow('Unknown Canton health service: validatorr');
   });
 });

--- a/test/unit/clients/validator-api-health.test.ts
+++ b/test/unit/clients/validator-api-health.test.ts
@@ -19,7 +19,7 @@ import { ValidatorApiClient } from '../../../src';
 import { CantonRuntime, type ClientConfig } from '../../../src/core';
 
 interface MockAxiosInstance {
-  get: jest.Mock;
+  get: jest.Mock<Promise<{ data: undefined }>, [string, Record<string, unknown>]>;
 }
 
 function createClient(): { client: ValidatorApiClient; mockAxiosInstance: MockAxiosInstance } {
@@ -77,5 +77,19 @@ describe('ValidatorApiClient health checks', () => {
     expect(mockAxiosInstance.get).toHaveBeenCalledWith('http://localhost:3903/api/validator/livez', {
       headers: { 'Content-Type': 'application/json' },
     });
+  });
+
+  it('rejects when validator readyz request fails', async () => {
+    const { client, mockAxiosInstance } = createClient();
+    mockAxiosInstance.get.mockRejectedValueOnce(new Error('readyz unavailable'));
+
+    await expect(client.isReady()).rejects.toThrow('readyz unavailable');
+  });
+
+  it('rejects when validator livez request fails', async () => {
+    const { client, mockAxiosInstance } = createClient();
+    mockAxiosInstance.get.mockRejectedValueOnce(new Error('livez unavailable'));
+
+    await expect(client.isLive()).rejects.toThrow('livez unavailable');
   });
 });

--- a/test/unit/clients/validator-api-health.test.ts
+++ b/test/unit/clients/validator-api-health.test.ts
@@ -1,0 +1,81 @@
+import axios from 'axios';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual('axios');
+  return {
+    ...actual,
+    create: jest.fn(() => ({
+      get: jest.fn(),
+      post: jest.fn(),
+      delete: jest.fn(),
+      patch: jest.fn(),
+      defaults: { headers: { common: {} } },
+    })),
+    isAxiosError: actual.isAxiosError,
+  };
+});
+
+import { ValidatorApiClient } from '../../../src';
+import { CantonRuntime, type ClientConfig } from '../../../src/core';
+
+interface MockAxiosInstance {
+  get: jest.Mock;
+}
+
+function createClient(): { client: ValidatorApiClient; mockAxiosInstance: MockAxiosInstance } {
+  const config: ClientConfig = {
+    network: 'localnet',
+    authUrl: 'https://auth.example',
+    apis: {
+      VALIDATOR_API: {
+        apiUrl: 'http://localhost:3903',
+        auth: {
+          grantType: 'client_credentials',
+          clientId: 'validator-client',
+          clientSecret: 'secret',
+        },
+      },
+    },
+  };
+
+  const client = new ValidatorApiClient(new CantonRuntime(config));
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- axios.create is a mocked function in this test module
+  const mockResults = jest.mocked(axios.create).mock.results;
+  const latestResult = mockResults[mockResults.length - 1];
+  if (!latestResult) {
+    throw new Error('Expected axios.create to be called');
+  }
+
+  return {
+    client,
+    mockAxiosInstance: latestResult.value as MockAxiosInstance,
+  };
+}
+
+describe('ValidatorApiClient health checks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls validator readyz without bearer auth', async () => {
+    const { client, mockAxiosInstance } = createClient();
+    mockAxiosInstance.get.mockResolvedValueOnce({ data: undefined });
+
+    await expect(client.isReady()).resolves.toBeUndefined();
+
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('http://localhost:3903/api/validator/readyz', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  it('calls validator livez without bearer auth', async () => {
+    const { client, mockAxiosInstance } = createClient();
+    mockAxiosInstance.get.mockResolvedValueOnce({ data: undefined });
+
+    await expect(client.isLive()).resolves.toBeUndefined();
+
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('http://localhost:3903/api/validator/livez', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});

--- a/test/unit/health/wait-for-ready.test.ts
+++ b/test/unit/health/wait-for-ready.test.ts
@@ -1,0 +1,65 @@
+import { waitForReady, type ServiceHealthStatus } from '../../../src';
+
+function healthyStatus(): ServiceHealthStatus {
+  return {
+    ok: true,
+    checkedAt: '2026-06-17T00:00:00.000Z',
+    services: {
+      validator: {
+        ok: true,
+        ready: true,
+        live: true,
+      },
+    },
+  };
+}
+
+describe('waitForReady', () => {
+  it('returns once health checks are healthy', async () => {
+    const ready = healthyStatus();
+    const canton = {
+      checkHealth: jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          checkedAt: '2026-06-17T00:00:00.000Z',
+          services: {
+            validator: {
+              ok: false,
+              ready: false,
+              live: true,
+              error: 'starting',
+            },
+          },
+        } satisfies ServiceHealthStatus)
+        .mockResolvedValueOnce(ready),
+    };
+
+    await expect(waitForReady(canton, { timeout: 1_000, interval: 1 })).resolves.toBe(ready);
+    expect(canton.checkHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a configurable timeout', async () => {
+    const canton = {
+      checkHealth: jest.fn().mockResolvedValue({
+        ok: false,
+        checkedAt: '2026-06-17T00:00:00.000Z',
+        services: {
+          validator: {
+            ok: false,
+            ready: false,
+            live: false,
+          },
+        },
+      } satisfies ServiceHealthStatus),
+    };
+
+    await expect(
+      waitForReady(canton, {
+        timeout: 20,
+        interval: 5,
+        timeoutMessage: 'Validator did not become ready',
+      })
+    ).rejects.toThrow('Validator did not become ready');
+  });
+});


### PR DESCRIPTION
## Summary
- add unauthenticated Validator API `isReady()` / `isLive()` operations for `/api/validator/readyz` and `/api/validator/livez`
- add `Canton.checkHealth()` for one-shot ledger/validator/scan health summaries without throwing on partial failures
- add `waitForReady()` utility with LocalNet-friendly defaults and focused unit/integration coverage
- document usage in the GitHub wiki: https://github.com/Fairmint/canton-node-sdk/wiki/Health-checks

## Duplicate-effort check
- no open Fairmint/canton-node-sdk PR matched ENG-461 or health-check work
- open node-sdk PRs were unrelated (#343 package trimming, #337 dependabot)
- no local or remote ENG-461/health branch existed
- recent Codex session matches were broad assigned-issue list output, not an active ENG-461 implementation

## Validation
- `npm run build`
- `npx eslint src/Canton.ts src/index.ts src/clients/validator-api/operations/v0/health.ts src/clients/validator-api/operations/v0/index.ts src/utils/index.ts src/utils/health/index.ts src/utils/health/wait-for-ready.ts test/integration/localnet/validator-api/health.test.ts test/unit/canton-health.test.ts test/unit/clients/validator-api-health.test.ts test/unit/health/wait-for-ready.test.ts`
- `npx jest test/unit/clients/validator-api-health.test.ts test/unit/canton-health.test.ts test/unit/health/wait-for-ready.test.ts --runInBand`
- `git diff --check`

Linear: ENG-461

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API surface and read-only health probes; no auth or data-mutation paths changed beyond new public GET endpoints.
> 
> **Overview**
> Adds **one-shot** and **polling** health utilities for ledger, validator, and scan, aimed at LocalNet startup and ops checks.
> 
> **`Canton.checkHealth()`** runs selected services in parallel and returns a structured `ServiceHealthStatus` without throwing when individual probes fail. Ledger uses `getVersion()`; validator uses new unauthenticated **`readyz` / `livez`** calls; scan combines readiness/liveness with **`getHealthStatus()`** and treats non-`success` bodies as unhealthy with explicit error text.
> 
> **`waitForReady()`** polls `checkHealth()` via existing `waitForCondition`, with a **5-minute default timeout** and configurable service subset.
> 
> Public exports include the new health types; unit and LocalNet integration tests cover aggregation, scan status parsing, validator HTTP behavior, and polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddbd8a8df7165e341238a3b6d4324c35a7a44dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-shot service health checks via `Canton.checkHealth()`, including per-service results and an overall status.
  * Added `waitForReady` polling support that waits for `checkHealth()` to report healthy.
  * Exposed validator readiness/liveness endpoints for health monitoring.
  * Expanded public exports with health-check types and status interfaces.
* **Tests**
  * Added unit and integration test coverage for Canton health checks, validator API health endpoints, and `waitForReady`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->