### PR TITLE
ENG-481: Add validator onboarding to localnet tests

### DIFF
--- a/test/integration/localnet/validator-api/ans.test.ts
+++ b/test/integration/localnet/validator-api/ans.test.ts
@@ -1,16 +1,11 @@
-/**
- * ValidatorApiClient integration tests: ANS Operations
- *
- * NOTE: These tests require the user to be onboarded to the validator. In basic cn-quickstart setup, ANS entry endpoint
- * returns 404 until onboarding completes. These tests are skipped until we add onboarding to the test setup. See:
- * tasks/2026/01/hd/2026.01.02-sdk-refactoring-and-testing.md (Backlog section)
- */
+/** ValidatorApiClient integration tests: ANS Operations. */
 
-import { getClient } from './setup';
+import { ensureValidatorUserOnboarded, getClient } from './setup';
 
 describe('ValidatorApiClient / ANS', () => {
-  // Skip: Requires user onboarding - entry endpoint returns 404 without it
-  test.skip('listAnsEntries returns ANS entries', async () => {
+  beforeAll(ensureValidatorUserOnboarded);
+
+  test('listAnsEntries returns ANS entries', async () => {
     const client = getClient();
     const response = await client.listAnsEntries();
 

--- a/test/integration/localnet/validator-api/ans.test.ts
+++ b/test/integration/localnet/validator-api/ans.test.ts
@@ -1,9 +1,9 @@
 /** ValidatorApiClient integration tests: ANS Operations. */
 
-import { ensureValidatorUserOnboarded, getClient } from './setup';
+import { ensureValidatorUserOnboarded, getClient, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS } from './setup';
 
 describe('ValidatorApiClient / ANS', () => {
-  beforeAll(ensureValidatorUserOnboarded);
+  beforeAll(ensureValidatorUserOnboarded, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS);
 
   test('listAnsEntries returns ANS entries', async () => {
     const client = getClient();

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -4,6 +4,8 @@ import { ApiError, CantonRuntime, ValidatorApiClient } from '../../../../src';
 import { buildIntegrationTestClientConfig, retry } from '../../../utils/testConfig';
 
 const DEFAULT_VALIDATOR_USER_NAME = 'app-provider-validator';
+const VALIDATOR_ONBOARDING_TIMEOUT_MS = 150_000;
+export const VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS = VALIDATOR_ONBOARDING_TIMEOUT_MS + 30_000;
 
 let client: ValidatorApiClient | null = null;
 let onboardingPromise: Promise<void> | null = null;
@@ -22,7 +24,11 @@ export function getClient(): ValidatorApiClient {
 
 /** Ensure the cn-quickstart OAuth client has an onboarded wallet user before wallet-scoped endpoint tests run. */
 export async function ensureValidatorUserOnboarded(): Promise<void> {
-  onboardingPromise ??= onboardValidatorUser();
+  onboardingPromise ??= withTimeout(
+    onboardValidatorUser(),
+    VALIDATOR_ONBOARDING_TIMEOUT_MS,
+    `validator wallet user ${DEFAULT_VALIDATOR_USER_NAME} onboarding`
+  );
   return onboardingPromise;
 }
 
@@ -47,7 +53,7 @@ async function onboardValidatorUser(): Promise<void> {
       return true;
     },
     {
-      timeoutMs: 60_000,
+      timeoutMs: VALIDATOR_ONBOARDING_TIMEOUT_MS,
       pollIntervalMs: 2_000,
       description: `validator wallet user ${DEFAULT_VALIDATOR_USER_NAME} onboarding`,
     }
@@ -95,4 +101,20 @@ function isAlreadyOnboardedError(error: unknown): boolean {
 
 function isApiErrorStatus(error: unknown, status: number): boolean {
   return error instanceof ApiError && error.status === status;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, description: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${description}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -56,8 +56,7 @@ async function onboardValidatorUser(): Promise<void> {
 
 async function isValidatorWalletReady(validatorClient: ValidatorApiClient): Promise<boolean> {
   try {
-    await assertValidatorWalletReady(validatorClient);
-    return true;
+    return await checkValidatorWalletReady(validatorClient);
   } catch (error) {
     if (isApiErrorStatus(error, 404)) {
       return false;
@@ -67,11 +66,19 @@ async function isValidatorWalletReady(validatorClient: ValidatorApiClient): Prom
 }
 
 async function assertValidatorWalletReady(validatorClient: ValidatorApiClient): Promise<void> {
-  const status = await validatorClient.getUserStatus();
-  if (!status.user_onboarded || !status.user_wallet_installed || !status.party_id) {
+  if (!(await checkValidatorWalletReady(validatorClient))) {
+    const status = await validatorClient.getUserStatus();
     throw new Error(`Validator user ${DEFAULT_VALIDATOR_USER_NAME} is not fully onboarded: ${JSON.stringify(status)}`);
   }
+}
+
+async function checkValidatorWalletReady(validatorClient: ValidatorApiClient): Promise<boolean> {
+  const status = await validatorClient.getUserStatus();
+  if (!status.user_onboarded || !status.user_wallet_installed || !status.party_id) {
+    return false;
+  }
   await validatorClient.getWalletBalance();
+  return true;
 }
 
 function isAlreadyOnboardedError(error: unknown): boolean {

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -1,6 +1,6 @@
 /** Shared setup for ValidatorApiClient integration tests. */
 
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,8 +9,9 @@ import { buildIntegrationTestClientConfig, retry } from '../../../utils/testConf
 
 const DEFAULT_VALIDATOR_USER_NAME = 'app-provider-validator';
 const VALIDATOR_ONBOARDING_TIMEOUT_MS = 150_000;
-export const VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS = VALIDATOR_ONBOARDING_TIMEOUT_MS + 30_000;
+export const VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS = VALIDATOR_ONBOARDING_TIMEOUT_MS + 120_000;
 const VALIDATOR_ONBOARDING_LOCK_DIR = join(tmpdir(), 'canton-node-sdk-validator-onboarding.lock');
+const VALIDATOR_ONBOARDING_LOCK_OWNER_FILE = join(VALIDATOR_ONBOARDING_LOCK_DIR, 'owner');
 
 let client: ValidatorApiClient | null = null;
 let onboardingPromise: Promise<void> | null = null;
@@ -113,12 +114,21 @@ function isApiErrorStatus(error: unknown, status: number): boolean {
 async function tryAcquireOnboardingLock(): Promise<boolean> {
   try {
     await mkdir(VALIDATOR_ONBOARDING_LOCK_DIR);
-    await writeFile(join(VALIDATOR_ONBOARDING_LOCK_DIR, 'owner'), `${process.pid}\n`);
-    return true;
   } catch (error) {
     if (hasErrorCode(error, 'EEXIST')) {
+      if (await releaseStaleOnboardingLock()) {
+        return tryAcquireOnboardingLock();
+      }
       return false;
     }
+    throw error;
+  }
+
+  try {
+    await writeFile(VALIDATOR_ONBOARDING_LOCK_OWNER_FILE, `${process.pid}\n`);
+    return true;
+  } catch (error) {
+    await releaseOnboardingLock();
     throw error;
   }
 }
@@ -127,8 +137,39 @@ async function releaseOnboardingLock(): Promise<void> {
   await rm(VALIDATOR_ONBOARDING_LOCK_DIR, { recursive: true, force: true });
 }
 
+async function releaseStaleOnboardingLock(): Promise<boolean> {
+  try {
+    const ownerPid = Number((await readFile(VALIDATOR_ONBOARDING_LOCK_OWNER_FILE, 'utf8')).trim());
+    if (Number.isInteger(ownerPid) && ownerPid > 0 && isProcessAlive(ownerPid)) {
+      return false;
+    }
+  } catch (error) {
+    if (!hasErrorCode(error, 'ENOENT')) {
+      throw error;
+    }
+  }
+
+  await releaseOnboardingLock();
+  return true;
+}
+
 function hasErrorCode(error: unknown, code: string): boolean {
   return error instanceof Error && 'code' in error && (error as { code?: unknown }).code === code;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (hasErrorCode(error, 'ESRCH')) {
+      return false;
+    }
+    if (hasErrorCode(error, 'EPERM')) {
+      return true;
+    }
+    throw error;
+  }
 }
 
 async function registerValidatorUser(validatorClient: ValidatorApiClient): Promise<void> {

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -29,7 +29,7 @@ export async function ensureValidatorUserOnboarded(): Promise<void> {
 async function onboardValidatorUser(): Promise<void> {
   const validatorClient = getClient();
 
-  if (await isValidatorUserOnboarded(validatorClient)) {
+  if (await isValidatorWalletReady(validatorClient)) {
     return;
   }
 
@@ -43,7 +43,7 @@ async function onboardValidatorUser(): Promise<void> {
 
   await retry(
     async (): Promise<boolean> => {
-      await validatorClient.getUserStatus();
+      await assertValidatorWalletReady(validatorClient);
       return true;
     },
     {
@@ -54,9 +54,9 @@ async function onboardValidatorUser(): Promise<void> {
   );
 }
 
-async function isValidatorUserOnboarded(validatorClient: ValidatorApiClient): Promise<boolean> {
+async function isValidatorWalletReady(validatorClient: ValidatorApiClient): Promise<boolean> {
   try {
-    await validatorClient.getUserStatus();
+    await assertValidatorWalletReady(validatorClient);
     return true;
   } catch (error) {
     if (isApiErrorStatus(error, 404)) {
@@ -64,6 +64,14 @@ async function isValidatorUserOnboarded(validatorClient: ValidatorApiClient): Pr
     }
     throw error;
   }
+}
+
+async function assertValidatorWalletReady(validatorClient: ValidatorApiClient): Promise<void> {
+  const status = await validatorClient.getUserStatus();
+  if (!status.user_onboarded || !status.user_wallet_installed || !status.party_id) {
+    throw new Error(`Validator user ${DEFAULT_VALIDATOR_USER_NAME} is not fully onboarded: ${JSON.stringify(status)}`);
+  }
+  await validatorClient.getWalletBalance();
 }
 
 function isAlreadyOnboardedError(error: unknown): boolean {

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -1,9 +1,12 @@
 /** Shared setup for ValidatorApiClient integration tests. */
 
-import { CantonRuntime, ValidatorApiClient } from '../../../../src';
-import { buildIntegrationTestClientConfig } from '../../../utils/testConfig';
+import { ApiError, CantonRuntime, ValidatorApiClient } from '../../../../src';
+import { buildIntegrationTestClientConfig, retry } from '../../../utils/testConfig';
+
+const DEFAULT_VALIDATOR_USER_NAME = 'app-provider-validator';
 
 let client: ValidatorApiClient | null = null;
+let onboardingPromise: Promise<void> | null = null;
 
 /**
  * Get the shared ValidatorApiClient instance for tests. Creates the client on first call, reuses it for subsequent
@@ -15,4 +18,66 @@ export function getClient(): ValidatorApiClient {
     client = new ValidatorApiClient(new CantonRuntime(config));
   }
   return client;
+}
+
+/** Ensure the cn-quickstart OAuth client has an onboarded wallet user before wallet-scoped endpoint tests run. */
+export async function ensureValidatorUserOnboarded(): Promise<void> {
+  onboardingPromise ??= onboardValidatorUser();
+  return onboardingPromise;
+}
+
+async function onboardValidatorUser(): Promise<void> {
+  const validatorClient = getClient();
+
+  if (await isValidatorUserOnboarded(validatorClient)) {
+    return;
+  }
+
+  try {
+    await validatorClient.createUser({ name: DEFAULT_VALIDATOR_USER_NAME });
+  } catch (error) {
+    if (!isAlreadyOnboardedError(error)) {
+      throw error;
+    }
+  }
+
+  await retry(
+    async (): Promise<boolean> => {
+      await validatorClient.getUserStatus();
+      return true;
+    },
+    {
+      timeoutMs: 60_000,
+      pollIntervalMs: 2_000,
+      description: `validator wallet user ${DEFAULT_VALIDATOR_USER_NAME} onboarding`,
+    }
+  );
+}
+
+async function isValidatorUserOnboarded(validatorClient: ValidatorApiClient): Promise<boolean> {
+  try {
+    await validatorClient.getUserStatus();
+    return true;
+  } catch (error) {
+    if (isApiErrorStatus(error, 404)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isAlreadyOnboardedError(error: unknown): boolean {
+  if (!(error instanceof ApiError)) {
+    return false;
+  }
+
+  if (error.status === 409) {
+    return true;
+  }
+
+  return error.status === 400 && /\b(already|exists|duplicate)\b/i.test(error.message);
+}
+
+function isApiErrorStatus(error: unknown, status: number): boolean {
+  return error instanceof ApiError && error.status === status;
 }

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -1,11 +1,16 @@
 /** Shared setup for ValidatorApiClient integration tests. */
 
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { ApiError, CantonRuntime, ValidatorApiClient } from '../../../../src';
 import { buildIntegrationTestClientConfig, retry } from '../../../utils/testConfig';
 
 const DEFAULT_VALIDATOR_USER_NAME = 'app-provider-validator';
 const VALIDATOR_ONBOARDING_TIMEOUT_MS = 150_000;
 export const VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS = VALIDATOR_ONBOARDING_TIMEOUT_MS + 30_000;
+const VALIDATOR_ONBOARDING_LOCK_DIR = join(tmpdir(), 'canton-node-sdk-validator-onboarding.lock');
 
 let client: ValidatorApiClient | null = null;
 let onboardingPromise: Promise<void> | null = null;
@@ -24,33 +29,35 @@ export function getClient(): ValidatorApiClient {
 
 /** Ensure the cn-quickstart OAuth client has an onboarded wallet user before wallet-scoped endpoint tests run. */
 export async function ensureValidatorUserOnboarded(): Promise<void> {
-  onboardingPromise ??= withTimeout(
-    onboardValidatorUser(),
-    VALIDATOR_ONBOARDING_TIMEOUT_MS,
-    `validator wallet user ${DEFAULT_VALIDATOR_USER_NAME} onboarding`
-  );
+  onboardingPromise ??= onboardValidatorUser();
   return onboardingPromise;
 }
 
 async function onboardValidatorUser(): Promise<void> {
   const validatorClient = getClient();
 
-  if (await isValidatorWalletReady(validatorClient)) {
-    return;
-  }
-
-  try {
-    await validatorClient.createUser({ name: DEFAULT_VALIDATOR_USER_NAME });
-  } catch (error) {
-    if (!isAlreadyOnboardedError(error)) {
-      throw error;
-    }
-  }
-
   await retry(
     async (): Promise<boolean> => {
-      await assertValidatorWalletReady(validatorClient);
-      return true;
+      if (await isValidatorWalletReady(validatorClient)) {
+        return true;
+      }
+
+      if (!(await tryAcquireOnboardingLock())) {
+        throw new Error(`Validator user ${DEFAULT_VALIDATOR_USER_NAME} onboarding is in progress`);
+      }
+
+      try {
+        if (await isValidatorWalletReady(validatorClient)) {
+          return true;
+        }
+
+        await registerValidatorUser(validatorClient);
+
+        await assertValidatorWalletReady(validatorClient);
+        return true;
+      } finally {
+        await releaseOnboardingLock();
+      }
     },
     {
       timeoutMs: VALIDATOR_ONBOARDING_TIMEOUT_MS,
@@ -103,18 +110,33 @@ function isApiErrorStatus(error: unknown, status: number): boolean {
   return error instanceof ApiError && error.status === status;
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, description: string): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
+async function tryAcquireOnboardingLock(): Promise<boolean> {
   try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${description}`)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
+    await mkdir(VALIDATOR_ONBOARDING_LOCK_DIR);
+    await writeFile(join(VALIDATOR_ONBOARDING_LOCK_DIR, 'owner'), `${process.pid}\n`);
+    return true;
+  } catch (error) {
+    if (hasErrorCode(error, 'EEXIST')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function releaseOnboardingLock(): Promise<void> {
+  await rm(VALIDATOR_ONBOARDING_LOCK_DIR, { recursive: true, force: true });
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && (error as { code?: unknown }).code === code;
+}
+
+async function registerValidatorUser(validatorClient: ValidatorApiClient): Promise<void> {
+  try {
+    await validatorClient.registerNewUser();
+  } catch (error) {
+    if (!isAlreadyOnboardedError(error)) {
+      throw error;
     }
   }
 }

--- a/test/integration/localnet/validator-api/setup.ts
+++ b/test/integration/localnet/validator-api/setup.ts
@@ -1,6 +1,6 @@
 /** Shared setup for ValidatorApiClient integration tests. */
 
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,10 +8,11 @@ import { ApiError, CantonRuntime, ValidatorApiClient } from '../../../../src';
 import { buildIntegrationTestClientConfig, retry } from '../../../utils/testConfig';
 
 const DEFAULT_VALIDATOR_USER_NAME = 'app-provider-validator';
-const VALIDATOR_ONBOARDING_TIMEOUT_MS = 150_000;
-export const VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS = VALIDATOR_ONBOARDING_TIMEOUT_MS + 120_000;
+const VALIDATOR_ONBOARDING_TIMEOUT_MS = 240_000;
+export const VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS = 300_000;
 const VALIDATOR_ONBOARDING_LOCK_DIR = join(tmpdir(), 'canton-node-sdk-validator-onboarding.lock');
 const VALIDATOR_ONBOARDING_LOCK_OWNER_FILE = join(VALIDATOR_ONBOARDING_LOCK_DIR, 'owner');
+const VALIDATOR_ONBOARDING_LOCK_STALE_MS = 30_000;
 
 let client: ValidatorApiClient | null = null;
 let onboardingPromise: Promise<void> | null = null;
@@ -147,10 +148,18 @@ async function releaseStaleOnboardingLock(): Promise<boolean> {
     if (!hasErrorCode(error, 'ENOENT')) {
       throw error;
     }
+    if (!(await isOnboardingLockOldEnoughToSteal())) {
+      return false;
+    }
   }
 
   await releaseOnboardingLock();
   return true;
+}
+
+async function isOnboardingLockOldEnoughToSteal(): Promise<boolean> {
+  const lockStats = await stat(VALIDATOR_ONBOARDING_LOCK_DIR);
+  return Date.now() - lockStats.mtimeMs >= VALIDATOR_ONBOARDING_LOCK_STALE_MS;
 }
 
 function hasErrorCode(error: unknown, code: string): boolean {

--- a/test/integration/localnet/validator-api/transfers.test.ts
+++ b/test/integration/localnet/validator-api/transfers.test.ts
@@ -1,16 +1,11 @@
-/**
- * ValidatorApiClient integration tests: Transfer Operations
- *
- * NOTE: These tests require the user to be onboarded to the validator. In basic cn-quickstart setup, wallet endpoints
- * return 404 until onboarding completes. These tests are skipped until we add onboarding to the test setup. See:
- * tasks/2026/01/hd/2026.01.02-sdk-refactoring-and-testing.md (Backlog section)
- */
+/** ValidatorApiClient integration tests: Transfer Operations. */
 
-import { getClient } from './setup';
+import { ensureValidatorUserOnboarded, getClient } from './setup';
 
 describe('ValidatorApiClient / Transfers', () => {
-  // Skip: Requires user onboarding - wallet endpoints return 404 without it
-  test.skip('listTransferOffers returns transfer offers list', async () => {
+  beforeAll(ensureValidatorUserOnboarded);
+
+  test('listTransferOffers returns transfer offers list', async () => {
     const client = getClient();
     const response = await client.listTransferOffers();
 

--- a/test/integration/localnet/validator-api/transfers.test.ts
+++ b/test/integration/localnet/validator-api/transfers.test.ts
@@ -1,9 +1,9 @@
 /** ValidatorApiClient integration tests: Transfer Operations. */
 
-import { ensureValidatorUserOnboarded, getClient } from './setup';
+import { ensureValidatorUserOnboarded, getClient, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS } from './setup';
 
 describe('ValidatorApiClient / Transfers', () => {
-  beforeAll(ensureValidatorUserOnboarded);
+  beforeAll(ensureValidatorUserOnboarded, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS);
 
   test('listTransferOffers returns transfer offers list', async () => {
     const client = getClient();

--- a/test/integration/localnet/validator-api/wallet.test.ts
+++ b/test/integration/localnet/validator-api/wallet.test.ts
@@ -1,9 +1,9 @@
 /** ValidatorApiClient integration tests: Wallet Operations. */
 
-import { ensureValidatorUserOnboarded, getClient } from './setup';
+import { ensureValidatorUserOnboarded, getClient, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS } from './setup';
 
 describe('ValidatorApiClient / Wallet', () => {
-  beforeAll(ensureValidatorUserOnboarded);
+  beforeAll(ensureValidatorUserOnboarded, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS);
 
   test('getWalletBalance returns balance information', async () => {
     const client = getClient();

--- a/test/integration/localnet/validator-api/wallet.test.ts
+++ b/test/integration/localnet/validator-api/wallet.test.ts
@@ -1,16 +1,11 @@
-/**
- * ValidatorApiClient integration tests: Wallet Operations
- *
- * NOTE: These tests require the user to be onboarded to the validator. In basic cn-quickstart setup, wallet endpoints
- * return 404 until onboarding completes. These tests are skipped until we add onboarding to the test setup. See:
- * tasks/2026/01/hd/2026.01.02-sdk-refactoring-and-testing.md (Backlog section)
- */
+/** ValidatorApiClient integration tests: Wallet Operations. */
 
-import { getClient } from './setup';
+import { ensureValidatorUserOnboarded, getClient } from './setup';
 
 describe('ValidatorApiClient / Wallet', () => {
-  // Skip: Requires user onboarding - wallet endpoints return 404 without it
-  test.skip('getWalletBalance returns balance information', async () => {
+  beforeAll(ensureValidatorUserOnboarded);
+
+  test('getWalletBalance returns balance information', async () => {
     const client = getClient();
     const response = await client.getWalletBalance();
 
@@ -19,8 +14,7 @@ describe('ValidatorApiClient / Wallet', () => {
     expect(response.effective_unlocked_qty).toBeDefined();
   });
 
-  // Skip: Requires user onboarding - wallet endpoints return 404 without it
-  test.skip('getUserStatus returns user status', async () => {
+  test('getUserStatus returns user status', async () => {
     const client = getClient();
     const response = await client.getUserStatus();
 


### PR DESCRIPTION
## Summary
- Add shared LocalNet validator test setup that registers/onboards the authenticated `app-provider-validator` user when wallet status is missing or reports not onboarded.
- Wait for `user_onboarded`, `user_wallet_installed`, `party_id`, and a successful wallet balance call before running wallet-scoped validator tests.
- Unskip wallet, transfer-offer, and ANS validator integration tests that depend on the onboarded wallet user.

## Linear
- [ENG-481](https://linear.app/fairmint/issue/ENG-481/add-user-onboarding-to-test-setup-6-tests)

## Duplicate-effort check
- No open PR existed for `ENG-481` or `nick/eng-481-add-user-onboarding-to-test-setup` before this PR was found/created during the run.
- Prior related PRs were not active duplicates: [#187](https://github.com/Fairmint/canton-node-sdk/pull/187) is closed unmerged; [#226](https://github.com/Fairmint/canton-node-sdk/pull/226) is merged and explicitly left these tests skipped pending onboarding.
- Reused the `nick/eng-481-add-user-onboarding-to-test-setup` local/remote branch for this work instead of creating a parallel branch.

## Validation
- `npm run build:core` passed.
- `npm run build:lint` passed.
- `npx prettier --check test/integration/localnet/validator-api/setup.ts test/integration/localnet/validator-api/wallet.test.ts test/integration/localnet/validator-api/transfers.test.ts test/integration/localnet/validator-api/ans.test.ts` passed.
- `npx eslint test/integration/localnet/validator-api/setup.ts test/integration/localnet/validator-api/wallet.test.ts test/integration/localnet/validator-api/transfers.test.ts test/integration/localnet/validator-api/ans.test.ts` passed.
- Targeted LocalNet suites were attempted locally with `npm test -- --runTestsByPath test/integration/localnet/validator-api/wallet.test.ts test/integration/localnet/validator-api/transfers.test.ts test/integration/localnet/validator-api/ans.test.ts --runInBand`, but local auth setup is incomplete: Keycloak is not reachable/authenticating at `localhost:8082`.
- CI caught readiness bugs and the branch was updated for them: `aa1d865` waits for wallet status/balance readiness; `0b870fd` treats false `user_onboarded`/`user_wallet_installed` status as a signal to onboard instead of failing; `d013732` gives the onboarding hook a bounded timeout; `7d9ae1d` serializes onboarding across parallel Jest workers and uses the authenticated-user `registerNewUser()` flow; `bd7fcf6` hardens stale lock cleanup; `abe8a9a` aligns retry and hook timeouts.
- Fresh CI passed for `abe8a9a`, including `test-cn-quickstart`.

## Notes
ENG-481 still describes six tests, but current `main` already replaced the two scan API cases with active scan coverage. This PR handles the remaining validator API skipped tests that still point at ENG-481.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to integration test setup and enabling skipped tests; no production SDK or runtime behavior is modified.
> 
> **Overview**
> Adds shared **validator onboarding** in `test/integration/localnet/validator-api/setup.ts` so wallet-scoped LocalNet tests can run against cn-quickstart without manual setup.
> 
> `ensureValidatorUserOnboarded()` dedupes work via a shared promise, polls until `getUserStatus` reports onboarded wallet + `party_id` and `getWalletBalance` succeeds (treating 404 as not ready), and otherwise calls `registerNewUser()` while tolerating already-onboarded API errors. Parallel Jest workers coordinate through a **tmp-dir file lock** with stale-lock recovery.
> 
> **Wallet**, **transfers**, and **ANS** integration suites now use `beforeAll(ensureValidatorUserOnboarded)` with a 5-minute hook timeout and **remove `test.skip`** on the tests that previously failed without an onboarded user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe8a9abe982fc926c69dd917269afab1dbdc8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
