### PR TITLE
[codex] Add Canton response helpers

### DIFF
--- a/src/utils/canton-response-utils.ts
+++ b/src/utils/canton-response-utils.ts
@@ -1,6 +1,59 @@
 import { OperationError, OperationErrorCode } from '../core/errors';
 import { isRecord } from '../core/utils';
 
+export type CantonContractCreateArgument =
+  | readonly unknown[]
+  | Record<string, unknown>
+  | string
+  | number
+  | boolean
+  | null;
+
+export interface CantonNormalizedContract {
+  readonly contractId: string;
+  readonly templateId: string;
+  readonly createArgument: CantonContractCreateArgument;
+  readonly createdEventBlob: string | null;
+  readonly createdAt: string | null;
+}
+
+export interface CantonInstrumentId {
+  readonly admin: string;
+  readonly id: string;
+}
+
+export interface CantonUnlockedUtxo {
+  readonly contractId: string;
+  readonly amount: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface CantonLockedUtxo {
+  readonly contractId: string;
+  readonly amount: string;
+  readonly lock?: Record<string, unknown>;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface CantonTokenBalance {
+  readonly instrumentId: CantonInstrumentId;
+  readonly totalUnlockedBalance: string;
+  readonly totalLockedBalance: string;
+  readonly totalBalance: string;
+  readonly unlockedUtxos: readonly CantonUnlockedUtxo[];
+  readonly lockedUtxos: readonly CantonLockedUtxo[];
+}
+
+export interface CantonWalletBalances {
+  readonly partyId: string;
+  readonly fetchedAt: string;
+  readonly tokens: readonly CantonTokenBalance[];
+}
+
+export interface CantonCoinBalanceLookupOptions {
+  readonly expectedAdmin: string;
+}
+
 export function readRequiredString(source: unknown, key: string, operation: string): string {
   if (isRecord(source) && key in source) {
     const value = source[key];
@@ -14,4 +67,81 @@ export function readRequiredString(source: unknown, key: string, operation: stri
 
 export function objectOrEmpty(value: unknown): Record<string, unknown> {
   return isRecord(value) ? value : {};
+}
+
+export function normalizeCantonContractItem(item: unknown): CantonNormalizedContract {
+  if (!isRecord(item)) {
+    return emptyNormalizedContract();
+  }
+
+  return contractFromCreatedEvent(findCreatedEventPayload(item));
+}
+
+export function findCantonCoinBalance(
+  balances: CantonWalletBalances | null | undefined,
+  options: CantonCoinBalanceLookupOptions
+): CantonTokenBalance | null {
+  const expectedAdmin = options.expectedAdmin.trim();
+  if (!expectedAdmin) return null;
+
+  let partialMatch: CantonTokenBalance | null = null;
+  for (const token of balances?.tokens ?? []) {
+    if (token.instrumentId.admin !== expectedAdmin) continue;
+
+    const instrumentId = token.instrumentId.id;
+    if (instrumentId === 'Amulet') return token;
+    if (!partialMatch && instrumentId.toLowerCase() === 'amulet') {
+      partialMatch = token;
+    }
+  }
+  return partialMatch;
+}
+
+function findCreatedEventPayload(item: Record<string, unknown>): Record<string, unknown> {
+  const contractEntry = toRecord(item['contractEntry']);
+  const activeContract = toRecord(contractEntry?.['JsActiveContract']);
+  const createdEvent = toRecord(activeContract?.['createdEvent']);
+  return createdEvent ?? item;
+}
+
+function contractFromCreatedEvent(createdEvent: Record<string, unknown>): CantonNormalizedContract {
+  return {
+    contractId: toStringField(createdEvent['contractId']),
+    templateId: toStringField(createdEvent['templateId']),
+    createArgument: toCreateArgument(createdEvent['createArgument']),
+    createdEventBlob: toNullableStringField(createdEvent['createdEventBlob']),
+    createdAt: toNullableStringField(createdEvent['createdAt']),
+  };
+}
+
+function emptyNormalizedContract(): CantonNormalizedContract {
+  return {
+    contractId: '',
+    templateId: '',
+    createArgument: null,
+    createdEventBlob: null,
+    createdAt: null,
+  };
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function toCreateArgument(value: unknown): CantonContractCreateArgument {
+  if (value == null) return null;
+  if (Array.isArray(value)) return value;
+  if (isRecord(value)) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return null;
+}
+
+function toStringField(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function toNullableStringField(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './amulet';
+export * from './canton-response-utils';
 export * from './contracts';
 export * from './external-signing';
 export * from './health';

--- a/test/integration/localnet/canton-response-utils.test.ts
+++ b/test/integration/localnet/canton-response-utils.test.ts
@@ -1,0 +1,101 @@
+/** Canton response helper integration tests against cn-quickstart LocalNet. */
+
+import {
+  findCantonCoinBalance,
+  normalizeCantonContractItem,
+  type CantonWalletBalances,
+} from '../../../src/utils/canton-response-utils';
+import { getClient as getLedgerClient } from './ledger-api/setup';
+import {
+  ensureValidatorUserOnboarded,
+  getClient as getValidatorClient,
+  VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS,
+} from './validator-api/setup';
+
+const WALLET_APP_INSTALL_TEMPLATE_SUFFIX = 'Splice.Wallet.Install:WalletAppInstall';
+
+interface LiveWalletAmulet {
+  readonly contract: {
+    readonly contract: {
+      readonly contract_id: string;
+    };
+  };
+  readonly effective_amount: string | number;
+}
+
+describe('Canton response helpers / LocalNet', (): void => {
+  beforeAll(ensureValidatorUserOnboarded, VALIDATOR_ONBOARDING_HOOK_TIMEOUT_MS);
+
+  test('normalizes a live active-contract item from the ledger API', async (): Promise<void> => {
+    const ledgerClient = getLedgerClient();
+    const validatorClient = getValidatorClient();
+    const userStatus = await validatorClient.getUserStatus();
+    const partyId = userStatus.party_id;
+    if (!partyId) {
+      throw new Error('getUserStatus returned empty party_id');
+    }
+
+    const activeContracts = await ledgerClient.getActiveContracts({
+      parties: [partyId],
+      templateIds: [`#splice-wallet:${WALLET_APP_INSTALL_TEMPLATE_SUFFIX}`],
+      includeCreatedEventBlob: true,
+    });
+    const activeContract = activeContracts[0];
+    if (!activeContract) {
+      throw new Error(`Could not find ${WALLET_APP_INSTALL_TEMPLATE_SUFFIX} for ${partyId}`);
+    }
+
+    const normalized = normalizeCantonContractItem(activeContract);
+
+    expect(normalized.contractId).toMatch(/\S/);
+    expect(normalized.templateId).toContain(WALLET_APP_INSTALL_TEMPLATE_SUFFIX);
+    expect(normalized.createArgument).toEqual(expect.any(Object));
+    expect(normalized.createdEventBlob).toMatch(/\S/);
+  });
+
+  test('finds a Canton Coin balance built from live validator wallet data', async (): Promise<void> => {
+    const validatorClient = getValidatorClient();
+    const [{ dso_party_id: dsoPartyId }, userStatus, walletBalance, amulets] = await Promise.all([
+      validatorClient.getDsoPartyId(),
+      validatorClient.getUserStatus(),
+      validatorClient.getWalletBalance(),
+      validatorClient.getAmulets(),
+    ]);
+    const partyId = userStatus.party_id;
+    if (!partyId) {
+      throw new Error('getUserStatus returned empty party_id');
+    }
+    const toUtxo = (amulet: LiveWalletAmulet): { readonly contractId: string; readonly amount: string } => ({
+      contractId: amulet.contract.contract.contract_id,
+      amount: String(amulet.effective_amount),
+    });
+    const unlockedAmulets = amulets.amulets as readonly LiveWalletAmulet[];
+    const lockedAmulets = amulets.locked_amulets as readonly LiveWalletAmulet[];
+
+    const balances: CantonWalletBalances = {
+      partyId,
+      fetchedAt: new Date().toISOString(),
+      tokens: [
+        {
+          instrumentId: { admin: dsoPartyId, id: 'Amulet' },
+          totalUnlockedBalance: String(walletBalance.effective_unlocked_qty ?? '0'),
+          totalLockedBalance: '0',
+          totalBalance: String(walletBalance.effective_unlocked_qty ?? '0'),
+          unlockedUtxos: unlockedAmulets.map(toUtxo),
+          lockedUtxos: lockedAmulets.map(toUtxo),
+        },
+      ],
+    };
+    const [expectedToken] = balances.tokens;
+    if (!expectedToken) {
+      throw new Error('Integration test constructed no Canton Coin token balance');
+    }
+
+    const balance = findCantonCoinBalance(balances, { expectedAdmin: dsoPartyId });
+
+    expect(balance).toBe(expectedToken);
+    expect(balance?.instrumentId.id).toBe('Amulet');
+    expect(balance?.unlockedUtxos).toHaveLength(unlockedAmulets.length);
+    expect(balance?.lockedUtxos).toHaveLength(lockedAmulets.length);
+  });
+});

--- a/test/unit/canton-response-utils.test.ts
+++ b/test/unit/canton-response-utils.test.ts
@@ -1,0 +1,169 @@
+import {
+  findCantonCoinBalance,
+  normalizeCantonContractItem,
+  type CantonWalletBalances,
+} from '../../src/utils/canton-response-utils';
+
+describe('canton-response-utils', () => {
+  describe('normalizeCantonContractItem', () => {
+    it('normalizes flat active contract items', () => {
+      expect(
+        normalizeCantonContractItem({
+          contractId: 'cid',
+          templateId: 'pkg:Module:Template',
+          createArgument: { owner: 'party' },
+          createdEventBlob: 'blob',
+        })
+      ).toEqual({
+        contractId: 'cid',
+        templateId: 'pkg:Module:Template',
+        createArgument: { owner: 'party' },
+        createdEventBlob: 'blob',
+        createdAt: null,
+      });
+    });
+
+    it('normalizes wrapped ledger API active contract items', () => {
+      expect(
+        normalizeCantonContractItem({
+          workflowId: '',
+          contractEntry: {
+            JsActiveContract: {
+              createdEvent: {
+                contractId: 'wrapped-cid',
+                templateId: 'pkg:Wrapped:Template',
+                createArgument: { amount: '1' },
+                createdEventBlob: 'wrapped-blob',
+                createdAt: '2026-06-15T00:00:00.000Z',
+              },
+            },
+          },
+        })
+      ).toEqual({
+        contractId: 'wrapped-cid',
+        templateId: 'pkg:Wrapped:Template',
+        createArgument: { amount: '1' },
+        createdEventBlob: 'wrapped-blob',
+        createdAt: '2026-06-15T00:00:00.000Z',
+      });
+    });
+
+    it('handles malformed active contract items defensively', () => {
+      expect(normalizeCantonContractItem(null)).toEqual({
+        contractId: '',
+        templateId: '',
+        createArgument: null,
+        createdEventBlob: null,
+        createdAt: null,
+      });
+
+      expect(
+        normalizeCantonContractItem({
+          contractEntry: {
+            JsActiveContract: {
+              createdEvent: {
+                contractId: 123,
+                templateId: null,
+                createArgument: Symbol('bad'),
+                createdEventBlob: 456,
+                createdAt: false,
+              },
+            },
+          },
+        })
+      ).toEqual({
+        contractId: '',
+        templateId: '',
+        createArgument: null,
+        createdEventBlob: null,
+        createdAt: null,
+      });
+    });
+  });
+
+  describe('findCantonCoinBalance', () => {
+    it('finds Canton Coin balances by Amulet instrument id', () => {
+      const balances: CantonWalletBalances = {
+        partyId: 'party',
+        fetchedAt: '2026-06-15T00:00:00.000Z',
+        tokens: [
+          {
+            instrumentId: { admin: 'admin', id: 'USDC' },
+            totalUnlockedBalance: '2',
+            totalLockedBalance: '0',
+            totalBalance: '2',
+            unlockedUtxos: [],
+            lockedUtxos: [],
+          },
+          {
+            instrumentId: { admin: 'dso', id: 'Amulet' },
+            totalUnlockedBalance: '1',
+            totalLockedBalance: '3',
+            totalBalance: '4',
+            unlockedUtxos: [],
+            lockedUtxos: [],
+          },
+        ],
+      };
+
+      expect(findCantonCoinBalance(balances, { expectedAdmin: 'dso' })?.totalBalance).toBe('4');
+      expect(findCantonCoinBalance(balances, { expectedAdmin: 'unknown' })).toBeNull();
+    });
+
+    it('prefers exact Amulet balances before case-insensitive fallbacks', () => {
+      const balances: CantonWalletBalances = {
+        partyId: 'party',
+        fetchedAt: '2026-06-15T00:00:00.000Z',
+        tokens: [
+          {
+            instrumentId: { admin: 'dso', id: 'amulet' },
+            totalUnlockedBalance: '1',
+            totalLockedBalance: '0',
+            totalBalance: '1',
+            unlockedUtxos: [],
+            lockedUtxos: [],
+          },
+          {
+            instrumentId: { admin: 'dso', id: 'Amulet' },
+            totalUnlockedBalance: '4',
+            totalLockedBalance: '0',
+            totalBalance: '4',
+            unlockedUtxos: [],
+            lockedUtxos: [],
+          },
+        ],
+      };
+
+      expect(findCantonCoinBalance(balances, { expectedAdmin: 'dso' })?.totalBalance).toBe('4');
+    });
+
+    it('does not match arbitrary token ids or admins containing amulet', () => {
+      const balances: CantonWalletBalances = {
+        partyId: 'party',
+        fetchedAt: '2026-06-15T00:00:00.000Z',
+        tokens: [
+          {
+            instrumentId: { admin: 'admin', id: 'FakeAmuletCoin' },
+            totalUnlockedBalance: '999',
+            totalLockedBalance: '0',
+            totalBalance: '999',
+            unlockedUtxos: [],
+            lockedUtxos: [],
+          },
+          {
+            instrumentId: { admin: 'dso', id: 'amulet' },
+            totalUnlockedBalance: '1',
+            totalLockedBalance: '0',
+            totalBalance: '1',
+            unlockedUtxos: [],
+            lockedUtxos: [],
+          },
+        ],
+      };
+
+      expect(findCantonCoinBalance(balances, { expectedAdmin: 'dso' })?.totalBalance).toBe('1');
+      expect(findCantonCoinBalance(balances, { expectedAdmin: 'admin' })).toBeNull();
+      expect(findCantonCoinBalance(balances, { expectedAdmin: ' ' })).toBeNull();
+    });
+  });
+});

--- a/test/unit/canton-response-utils.test.ts
+++ b/test/unit/canton-response-utils.test.ts
@@ -4,9 +4,9 @@ import {
   type CantonWalletBalances,
 } from '../../src/utils/canton-response-utils';
 
-describe('canton-response-utils', () => {
-  describe('normalizeCantonContractItem', () => {
-    it('normalizes flat active contract items', () => {
+describe('canton-response-utils', (): void => {
+  describe('normalizeCantonContractItem', (): void => {
+    it('normalizes flat active contract items', (): void => {
       expect(
         normalizeCantonContractItem({
           contractId: 'cid',
@@ -23,7 +23,7 @@ describe('canton-response-utils', () => {
       });
     });
 
-    it('normalizes wrapped ledger API active contract items', () => {
+    it('normalizes wrapped ledger API active contract items', (): void => {
       expect(
         normalizeCantonContractItem({
           workflowId: '',
@@ -48,7 +48,7 @@ describe('canton-response-utils', () => {
       });
     });
 
-    it('handles malformed active contract items defensively', () => {
+    it('handles malformed active contract items defensively', (): void => {
       expect(normalizeCantonContractItem(null)).toEqual({
         contractId: '',
         templateId: '',
@@ -81,8 +81,8 @@ describe('canton-response-utils', () => {
     });
   });
 
-  describe('findCantonCoinBalance', () => {
-    it('finds Canton Coin balances by Amulet instrument id', () => {
+  describe('findCantonCoinBalance', (): void => {
+    it('finds Canton Coin balances by Amulet instrument id', (): void => {
       const balances: CantonWalletBalances = {
         partyId: 'party',
         fetchedAt: '2026-06-15T00:00:00.000Z',
@@ -110,7 +110,7 @@ describe('canton-response-utils', () => {
       expect(findCantonCoinBalance(balances, { expectedAdmin: 'unknown' })).toBeNull();
     });
 
-    it('prefers exact Amulet balances before case-insensitive fallbacks', () => {
+    it('prefers exact Amulet balances before case-insensitive fallbacks', (): void => {
       const balances: CantonWalletBalances = {
         partyId: 'party',
         fetchedAt: '2026-06-15T00:00:00.000Z',
@@ -137,7 +137,7 @@ describe('canton-response-utils', () => {
       expect(findCantonCoinBalance(balances, { expectedAdmin: 'dso' })?.totalBalance).toBe('4');
     });
 
-    it('does not match arbitrary token ids or admins containing amulet', () => {
+    it('does not match arbitrary token ids or admins containing amulet', (): void => {
       const balances: CantonWalletBalances = {
         partyId: 'party',
         fetchedAt: '2026-06-15T00:00:00.000Z',


### PR DESCRIPTION
## Summary
- Add `normalizeCantonContractItem` and `findCantonCoinBalance` to the shared `canton-response-utils` utility surface.
- Export the response utility module from `src/utils` so callers can import the helpers from `@fairmint/canton-node-sdk`.
- Add focused unit coverage for flat/wrapped active-contract normalization and Amulet balance selection.

## Rationale
These helpers normalize Canton ledger and Amulet response shapes and are not Privy-specific. Moving them to `@fairmint/canton-node-sdk` gives Privy SDK consumers a better shared home without re-expanding the Privy SDK API.

## Validation
- `npm test -- --runInBand test/unit/canton-response-utils.test.ts`
- `npx eslint src/utils/canton-response-utils.ts src/utils/index.ts test/unit/canton-response-utils.test.ts`
- `npx prettier --check src/utils/canton-response-utils.ts src/utils/index.ts test/unit/canton-response-utils.test.ts`
- `npx tsc --noEmit --target ES2020 --module commonjs --lib ES2020,DOM --strict --esModuleInterop --skipLibCheck --exactOptionalPropertyTypes --noUncheckedIndexedAccess --noPropertyAccessFromIndexSignature --noUnusedLocals --noUnusedParameters src/utils/canton-response-utils.ts`

## Local notes
- `npm run build:lint` is blocked in this fresh worktree by missing generated OpenAPI/client files and uninitialized submodules.
- `npm run format` reports pre-existing formatting issues outside the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only parsing/selection utilities with defensive defaults; no changes to auth, signing, or transaction submission paths.
> 
> **Overview**
> Adds shared **Canton response helpers** on `canton-response-utils` and re-exports them from `src/utils` so `@fairmint/canton-node-sdk` consumers can normalize ledger payloads and pick Canton Coin balances without Privy-specific APIs.
> 
> **`normalizeCantonContractItem`** maps flat or `contractEntry.JsActiveContract.createdEvent`-wrapped active-contract items into a stable `CantonNormalizedContract` shape, with defensive empty defaults on bad input. **`findCantonCoinBalance`** selects the Amulet token for a given DSO/admin (`expectedAdmin`), preferring exact `Amulet` over a case-insensitive `amulet` fallback.
> 
> Typed wallet/UTXO interfaces accompany the helpers. Coverage includes unit tests for normalization edge cases and Amulet selection rules, plus LocalNet integration tests against live ledger and validator wallet data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b617a9f129b17d93bc183b97841d236c018e613e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added utilities for improved handling of Canton contract creation data and wallet balance information.

* **Tests**
  * Added comprehensive unit test coverage for Canton data processing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->