### PR TITLE
[codex] Add Canton error normalization helpers

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -3,6 +3,7 @@ import { RestClientError } from '@hardlydifficult/rest-client';
 /** JSON-serializable context for error details. */
 export type ErrorContext = Readonly<Record<string, unknown>>;
 
+/** Serializable details extracted from a Canton SDK-shaped error. */
 export interface NormalizedCantonErrorDetails {
   readonly name: string;
   readonly message: string;
@@ -141,6 +142,7 @@ const CANTON_SDK_ERROR_NAMES = new Set([
   'ValidationError',
 ]);
 
+/** Normalize a Canton SDK-shaped error into serializable details for logging or API responses. */
 export function normalizeCantonError(error: unknown): NormalizedCantonErrorDetails | null {
   if (!(error instanceof Error)) return null;
 
@@ -163,6 +165,7 @@ export function normalizeCantonError(error: unknown): NormalizedCantonErrorDetai
   };
 }
 
+/** Return true when a Canton error represents a non-retryable 4xx mutation rejection. */
 export function isDefiniteCantonMutationRejection(error: unknown): boolean {
   const status = normalizeCantonError(error)?.status;
   if (status === undefined) return false;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -167,9 +167,19 @@ export function normalizeCantonError(error: unknown): NormalizedCantonErrorDetai
 
 /** Return true when a Canton error represents a non-retryable 4xx mutation rejection. */
 export function isDefiniteCantonMutationRejection(error: unknown): boolean {
-  const status = normalizeCantonError(error)?.status;
+  const details = normalizeCantonError(error);
+  const status = details?.status;
   if (status === undefined) return false;
+  if (isRetryableCantonApiCode(status, details?.code)) return false;
   return status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429;
+}
+
+/** Return true when a Canton API status/code pair is known to be transient. */
+function isRetryableCantonApiCode(status: number, code: string | undefined): boolean {
+  return (
+    (status === 400 && code === 'UNKNOWN_CONTRACT_SYNCHRONIZERS') ||
+    (status === 409 && code === 'SEQUENCER_BACKPRESSURE')
+  );
 }
 
 /** Read normalized error context from current and legacy SDK error fields. */

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -184,7 +184,8 @@ function isRetryableCantonApiCode(status: number, code: string | undefined): boo
 
 /** Read normalized error context from current and legacy SDK error fields. */
 function readErrorContext(source: Record<string, unknown>): unknown {
-  if ('context' in source) return source['context'];
+  const { context } = source;
+  if (context !== undefined) return context;
   if ('response' in source) return source['response'];
   return undefined;
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -3,6 +3,21 @@ import { RestClientError } from '@hardlydifficult/rest-client';
 /** JSON-serializable context for error details. */
 export type ErrorContext = Readonly<Record<string, unknown>>;
 
+export interface NormalizedCantonErrorDetails {
+  readonly name: string;
+  readonly message: string;
+  readonly status?: number;
+  readonly statusText?: string;
+  readonly code?: string;
+  readonly context?: unknown;
+  /**
+   * Alias for `context` for compatibility with existing API-error handling code.
+   *
+   * @deprecated Use `context` instead.
+   */
+  readonly response?: unknown;
+}
+
 /** Base error codes for standard SDK errors. */
 export const ErrorCode = {
   CANTON_ERROR: 'CANTON_ERROR',
@@ -114,4 +129,66 @@ export class OperationError extends CantonError {
     super(message, code, context);
     this.name = 'OperationError';
   }
+}
+
+const CANTON_SDK_ERROR_NAMES = new Set([
+  'ApiError',
+  'AuthenticationError',
+  'CantonError',
+  'ConfigurationError',
+  'NetworkError',
+  'OperationError',
+  'ValidationError',
+]);
+
+export function normalizeCantonError(error: unknown): NormalizedCantonErrorDetails | null {
+  if (!(error instanceof Error)) return null;
+
+  const source = isObjectRecord(error) ? error : {};
+  const context = readErrorContext(source);
+  const status = readNumericErrorProperty(source, 'status') ?? readNumericErrorProperty(source, 'statusCode');
+  const statusText = readStringErrorProperty(source, 'statusText');
+  const code = readContextCode(context) ?? readStringErrorProperty(source, 'code');
+  const sdkError = error instanceof CantonError || CANTON_SDK_ERROR_NAMES.has(error.name);
+
+  if (!sdkError && status === undefined && code === undefined) return null;
+
+  return {
+    name: error.name,
+    message: error.message,
+    ...(status !== undefined ? { status } : {}),
+    ...(statusText ? { statusText } : {}),
+    ...(code ? { code } : {}),
+    ...(context !== undefined ? { context, response: context } : {}),
+  };
+}
+
+export function isDefiniteCantonMutationRejection(error: unknown): boolean {
+  const status = normalizeCantonError(error)?.status;
+  if (status === undefined) return false;
+  return status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429;
+}
+
+function readErrorContext(source: Record<string, unknown>): unknown {
+  if ('context' in source) return source['context'];
+  if ('response' in source) return source['response'];
+  return undefined;
+}
+
+function readContextCode(context: unknown): string | undefined {
+  return isObjectRecord(context) && typeof context['code'] === 'string' ? context['code'] : undefined;
+}
+
+function readNumericErrorProperty(source: Record<string, unknown>, property: string): number | undefined {
+  const value = source[property];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readStringErrorProperty(source: Record<string, unknown>, property: string): string | undefined {
+  const value = source[property];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -172,26 +172,31 @@ export function isDefiniteCantonMutationRejection(error: unknown): boolean {
   return status >= 400 && status < 500 && status !== 408 && status !== 425 && status !== 429;
 }
 
+/** Read normalized error context from current and legacy SDK error fields. */
 function readErrorContext(source: Record<string, unknown>): unknown {
   if ('context' in source) return source['context'];
   if ('response' in source) return source['response'];
   return undefined;
 }
 
+/** Read a string error code from normalized context when one is present. */
 function readContextCode(context: unknown): string | undefined {
   return isObjectRecord(context) && typeof context['code'] === 'string' ? context['code'] : undefined;
 }
 
+/** Read a finite numeric property from an SDK-shaped error object. */
 function readNumericErrorProperty(source: Record<string, unknown>, property: string): number | undefined {
   const value = source[property];
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
+/** Read a non-empty string property from an SDK-shaped error object. */
 function readStringErrorProperty(source: Record<string, unknown>, property: string): string | undefined {
   const value = source[property];
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
+/** Return true when a value can be inspected as a plain object record. */
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/test/unit/core/errors.test.ts
+++ b/test/unit/core/errors.test.ts
@@ -246,6 +246,25 @@ describe('normalizeCantonError', () => {
     });
   });
 
+  it('falls back to legacy response when context is undefined', () => {
+    const error = Object.assign(new Error('HTTP 400'), {
+      name: 'ApiError',
+      status: 400,
+      context: undefined,
+      response: { code: 'UNKNOWN_CONTRACT_SYNCHRONIZERS' },
+    });
+
+    expect(normalizeCantonError(error)).toEqual({
+      name: 'ApiError',
+      message: 'HTTP 400',
+      status: 400,
+      code: 'UNKNOWN_CONTRACT_SYNCHRONIZERS',
+      context: { code: 'UNKNOWN_CONTRACT_SYNCHRONIZERS' },
+      response: { code: 'UNKNOWN_CONTRACT_SYNCHRONIZERS' },
+    });
+    expect(isDefiniteCantonMutationRejection(error)).toBe(false);
+  });
+
   it('ignores plain errors without SDK markers', () => {
     expect(normalizeCantonError(new Error('plain failure'))).toBeNull();
   });

--- a/test/unit/core/errors.test.ts
+++ b/test/unit/core/errors.test.ts
@@ -7,6 +7,8 @@ import {
   OperationError,
   OperationErrorCode,
   ValidationError,
+  isDefiniteCantonMutationRejection,
+  normalizeCantonError,
 } from '../../../src/core/errors';
 
 describe('CantonError hierarchy', () => {
@@ -180,5 +182,90 @@ describe('error type checking', () => {
 
     const opError: CantonError = new OperationError('Missing', OperationErrorCode.MISSING_CONTRACT);
     expect(opError.code).toBe('MISSING_CONTRACT');
+  });
+});
+
+describe('normalizeCantonError', () => {
+  it('normalizes ApiError details for consumers', () => {
+    const error = new ApiError('HTTP 409: ALREADY_EXISTS', 409, 'Conflict', {
+      code: 'ALREADY_EXISTS',
+      message: 'Party already exists',
+    });
+
+    expect(normalizeCantonError(error)).toEqual({
+      name: 'ApiError',
+      message: 'HTTP 409: ALREADY_EXISTS',
+      status: 409,
+      statusText: 'Conflict',
+      code: 'ALREADY_EXISTS',
+      context: {
+        code: 'ALREADY_EXISTS',
+        message: 'Party already exists',
+      },
+      response: {
+        code: 'ALREADY_EXISTS',
+        message: 'Party already exists',
+      },
+    });
+  });
+
+  it('normalizes operation errors without HTTP status', () => {
+    const error = new OperationError('Canton transfer failed', OperationErrorCode.TRANSACTION_FAILED, {
+      senderPartyId: 'sender::fingerprint',
+    });
+
+    expect(normalizeCantonError(error)).toEqual({
+      name: 'OperationError',
+      message: 'Canton transfer failed',
+      code: OperationErrorCode.TRANSACTION_FAILED,
+      context: {
+        senderPartyId: 'sender::fingerprint',
+      },
+      response: {
+        senderPartyId: 'sender::fingerprint',
+      },
+    });
+  });
+
+  it('normalizes SDK-shaped legacy errors with statusCode and response', () => {
+    const error = Object.assign(new Error('HTTP 429'), {
+      name: 'ApiError',
+      statusCode: 429,
+      statusText: 'Too Many Requests',
+      response: { code: 'RESOURCE_EXHAUSTED' },
+    });
+
+    expect(normalizeCantonError(error)).toEqual({
+      name: 'ApiError',
+      message: 'HTTP 429',
+      status: 429,
+      statusText: 'Too Many Requests',
+      code: 'RESOURCE_EXHAUSTED',
+      context: { code: 'RESOURCE_EXHAUSTED' },
+      response: { code: 'RESOURCE_EXHAUSTED' },
+    });
+  });
+
+  it('ignores plain errors without SDK markers', () => {
+    expect(normalizeCantonError(new Error('plain failure'))).toBeNull();
+  });
+});
+
+describe('isDefiniteCantonMutationRejection', () => {
+  it('treats non-transient 4xx API responses as definite rejections', () => {
+    expect(isDefiniteCantonMutationRejection(new ApiError('bad request', 400))).toBe(true);
+    expect(isDefiniteCantonMutationRejection(new ApiError('conflict', 409))).toBe(true);
+    expect(isDefiniteCantonMutationRejection(new ApiError('not found', 404))).toBe(true);
+  });
+
+  it('does not treat retryable or non-HTTP errors as definite rejections', () => {
+    expect(isDefiniteCantonMutationRejection(new ApiError('timeout', 408))).toBe(false);
+    expect(isDefiniteCantonMutationRejection(new ApiError('too early', 425))).toBe(false);
+    expect(isDefiniteCantonMutationRejection(new ApiError('rate limited', 429))).toBe(false);
+    expect(isDefiniteCantonMutationRejection(new ApiError('server error', 503))).toBe(false);
+    expect(isDefiniteCantonMutationRejection(new NetworkError('network unavailable'))).toBe(false);
+    expect(isDefiniteCantonMutationRejection(new OperationError('failed', OperationErrorCode.TRANSACTION_FAILED))).toBe(
+      false
+    );
   });
 });

--- a/test/unit/core/errors.test.ts
+++ b/test/unit/core/errors.test.ts
@@ -256,9 +256,27 @@ describe('isDefiniteCantonMutationRejection', () => {
     expect(isDefiniteCantonMutationRejection(new ApiError('bad request', 400))).toBe(true);
     expect(isDefiniteCantonMutationRejection(new ApiError('conflict', 409))).toBe(true);
     expect(isDefiniteCantonMutationRejection(new ApiError('not found', 404))).toBe(true);
+    expect(
+      isDefiniteCantonMutationRejection(
+        new ApiError('invalid argument', 400, 'Bad Request', { code: 'INVALID_ARGUMENT' })
+      )
+    ).toBe(true);
+    expect(
+      isDefiniteCantonMutationRejection(new ApiError('conflict', 409, 'Conflict', { code: 'ALREADY_EXISTS' }))
+    ).toBe(true);
   });
 
   it('does not treat retryable or non-HTTP errors as definite rejections', () => {
+    expect(
+      isDefiniteCantonMutationRejection(
+        new ApiError('unknown contract synchronizers', 400, 'Bad Request', { code: 'UNKNOWN_CONTRACT_SYNCHRONIZERS' })
+      )
+    ).toBe(false);
+    expect(
+      isDefiniteCantonMutationRejection(
+        new ApiError('sequencer backpressure', 409, 'Conflict', { code: 'SEQUENCER_BACKPRESSURE' })
+      )
+    ).toBe(false);
     expect(isDefiniteCantonMutationRejection(new ApiError('timeout', 408))).toBe(false);
     expect(isDefiniteCantonMutationRejection(new ApiError('too early', 425))).toBe(false);
     expect(isDefiniteCantonMutationRejection(new ApiError('rate limited', 429))).toBe(false);


### PR DESCRIPTION
## Summary
- Add `normalizeCantonError` to turn SDK-shaped Canton errors into serializable consumer-facing details.
- Add `isDefiniteCantonMutationRejection` to share the non-transient 4xx classification currently duplicated by consumers.
- Cover `ApiError`, `OperationError`, legacy `statusCode`/`response`-shaped errors, and retryable-vs-definite classification.

## Validation
- `npm test -- test/unit/core/errors.test.ts --runInBand`
- `npx eslint src/core/errors.ts test/unit/core/errors.test.ts`
- `npx prettier --check src/core/errors.ts test/unit/core/errors.test.ts`
- `git diff --check`
- `npm run build:lint` currently fails in this fresh worktree before this helper is exercised because generated OpenAPI/client artifacts are unavailable or out of sync locally; the errors are missing generated client modules and generated-method types, not from `src/core/errors.ts`.

## Consumer follow-up
- `canton-privy-sdk` already has the Privy identity/email parsing helpers on `main`/`v0.0.17`, so the apiv2 simplification can consume those plus these Canton error helpers after this SDK PR lands and publishes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New exported utilities and tests only; no changes to existing error class behavior or runtime mutation paths.
> 
> **Overview**
> Adds shared helpers in `src/core/errors.ts` so callers can turn Canton SDK-shaped failures into JSON-friendly details and classify non-retryable mutation rejections in one place.
> 
> **`normalizeCantonError`** returns `NormalizedCantonErrorDetails` (name, message, optional status/statusText/code, context) for `CantonError` subclasses and legacy shapes (`status` vs `statusCode`, `context` vs `response`). Plain `Error` values without SDK markers return `null`.
> 
> **`isDefiniteCantonMutationRejection`** builds on normalization to flag definite 4xx mutation failures while excluding retry/rate-limit cases (408, 425, 429) and known transient pairs (`UNKNOWN_CONTRACT_SYNCHRONIZERS`, `SEQUENCER_BACKPRESSURE`).
> 
> Unit tests in `test/unit/core/errors.test.ts` cover normalization paths and rejection classification edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 916693b0ccab7aea3f1c2d20033e1ffdf5de8ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized, JSON-friendly error details with consistent fields for message, status, status text, and code.
  * Introduced a helper to classify “definite mutation rejection” based on non-transient 4xx responses, excluding common retry/rate-limit cases.
* **Bug Fixes**
  * Improved robustness when error responses come in different legacy or SDK-shaped formats, ensuring normalized details are extracted whenever possible.
* **Tests**
  * Expanded unit coverage for normalization and rejection classification across supported error types and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->