### PR TITLE
[codex] Export ledger command types

### DIFF
--- a/src/clients/ledger-json-api/index.ts
+++ b/src/clients/ledger-json-api/index.ts
@@ -1,3 +1,16 @@
 export * from './completion-stream';
 export { LedgerJsonApiClient } from './LedgerJsonApiClient.generated';
-export type { TraceContext } from './schemas';
+export type {
+  AssignCommand,
+  Command,
+  CommandRequest,
+  CompositeCommand,
+  CreateAndExerciseCommand,
+  CreateCommand,
+  DisclosedContract,
+  ExerciseByKeyCommand,
+  ExerciseCommand,
+  JsCommands,
+  TraceContext,
+  UnassignCommand,
+} from './schemas';

--- a/test/unit/clients/ledger-json-api-exports.test.ts
+++ b/test/unit/clients/ledger-json-api-exports.test.ts
@@ -1,0 +1,25 @@
+import type { Command, DisclosedContract, LedgerJsonApiClient } from '../../../src';
+
+describe('ledger JSON API public exports', () => {
+  it('exports command and disclosed-contract types from the package root', () => {
+    const command: Command = {
+      CreateCommand: {
+        templateId: '#package:Module:Template',
+        createArguments: {},
+      },
+    };
+    const disclosedContract: DisclosedContract = {
+      templateId: '#package:Module:Template',
+      contractId: '00contract',
+      createdEventBlob: 'blob',
+      synchronizerId: 'sync::id',
+    };
+    const ledger: Pick<LedgerJsonApiClient, 'getActiveContracts'> = {
+      getActiveContracts: jest.fn(),
+    };
+
+    expect(command.CreateCommand.templateId).toBe('#package:Module:Template');
+    expect(disclosedContract.contractId).toBe('00contract');
+    expect(ledger.getActiveContracts).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- export ledger JSON API command/disclosed-contract types from the public SDK entrypoint
- add a unit test proving consumers can import the types from the package root

## Root cause
Consumers need `Command` and `DisclosedContract`, but the public `ledger-json-api` barrel only exported `TraceContext`. That forced downstream SDKs to import from generated `build/src/...` internals.

## Validation
- `npx prettier --check src/clients/ledger-json-api/index.ts test/unit/clients/ledger-json-api-exports.test.ts`
- `npx jest test/unit/clients/ledger-json-api-exports.test.ts --runInBand`
- `npm run build:core` after initializing `libs/splice`
- `npx jest test/unit --runInBand`
- `npx eslint src/clients/ledger-json-api/index.ts test/unit/clients/ledger-json-api-exports.test.ts`

Repo-wide `npm run lint` currently fails on unrelated existing files; this PR's changed files pass targeted ESLint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only public API expansion with no runtime or behavioral changes to ledger submission logic.
> 
> **Overview**
> The **`ledger-json-api` public barrel** now re-exports ledger JSON API **command and submission types** (`Command`, `DisclosedContract`, `CommandRequest`, variant command shapes, `JsCommands`, and related types) from `./schemas`, alongside the existing `TraceContext` export. Consumers can import these from the **package root** instead of generated `build/src/...` paths.
> 
> A **unit test** asserts that `Command`, `DisclosedContract`, and `LedgerJsonApiClient` resolve when imported from `../../../src`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad8a4686dab715220f0601dbcb97e0f39750774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->