### PR TITLE
[codex] Add explicit Canton runtime credential helpers

### DIFF
--- a/src/core/config/CantonRuntimeCredentials.ts
+++ b/src/core/config/CantonRuntimeCredentials.ts
@@ -1,0 +1,221 @@
+import { ConfigurationError } from '../errors';
+import { type ApiConfig, type AuthConfig, type ClientConfig, type NetworkType, type ProviderType } from '../types';
+
+const CANTON_RUNTIME_ENV_SEGMENT_REGEX = /^[A-Za-z0-9_]+$/;
+
+/** Env-var suffixes used for explicit Canton runtime credentials. */
+export const CANTON_RUNTIME_CREDENTIAL_ENV_SUFFIXES = [
+  'PARTY_ID',
+  'USER_ID',
+  'VALIDATOR_ADMIN_TOKEN',
+  'VALIDATOR_JSON_API_ENDPOINT',
+  'LEDGER_JSON_API_ENDPOINT',
+  'SPLICE_SCAN_API_ENDPOINT',
+] as const;
+
+/** Supported env-var suffix for explicit Canton runtime credentials. */
+export type CantonRuntimeCredentialEnvSuffix = (typeof CANTON_RUNTIME_CREDENTIAL_ENV_SUFFIXES)[number];
+
+/** Env-var prefix emitted for one network/provider runtime credential set. */
+export type CantonRuntimeCredentialEnvPrefix = `CANTON_${string}_${string}`;
+
+/** Env-var key emitted for one network/provider runtime credential set. */
+export type CantonRuntimeCredentialEnvKey = `${CantonRuntimeCredentialEnvPrefix}_${CantonRuntimeCredentialEnvSuffix}`;
+
+/** Env-var map for one explicit Canton runtime credential set. */
+export type CantonRuntimeCredentialEnvMap = Readonly<Record<CantonRuntimeCredentialEnvKey, string>>;
+
+/** Raw Canton runtime credential values loaded by an application from SSM, env, or another explicit source. */
+export interface CantonRuntimeCredentialsInput {
+  readonly partyId: string;
+  readonly userId: string;
+  readonly validatorAdminToken: string;
+  readonly validatorJsonApiEndpoint: string;
+  readonly ledgerJsonApiEndpoint: string;
+  readonly spliceScanApiEndpoint: string;
+}
+
+/** Normalized, validated Canton runtime credential values. */
+export interface CantonRuntimeCredentials {
+  readonly partyId: string;
+  readonly userId: string;
+  readonly validatorAdminToken: string;
+  readonly validatorJsonApiEndpoint: string;
+  readonly ledgerJsonApiEndpoint: string;
+  readonly spliceScanApiEndpoint: string;
+}
+
+/** Target network/provider prefix for emitted Canton runtime credential env keys. */
+export interface CantonRuntimeCredentialTarget {
+  readonly network: NetworkType;
+  readonly provider: ProviderType;
+}
+
+/** Options for emitting a Canton runtime credential env map. */
+export interface CantonRuntimeCredentialEnvMapOptions extends CantonRuntimeCredentialTarget {
+  readonly credentials: CantonRuntimeCredentialsInput;
+}
+
+/** Options for building an explicit SDK client config from Canton runtime credentials. */
+export interface CantonRuntimeCredentialClientConfigOptions extends CantonRuntimeCredentialTarget {
+  readonly credentials: CantonRuntimeCredentialsInput;
+}
+
+const CANTON_RUNTIME_CREDENTIAL_FIELD_BY_SUFFIX: Record<
+  CantonRuntimeCredentialEnvSuffix,
+  keyof CantonRuntimeCredentials
+> = {
+  PARTY_ID: 'partyId',
+  USER_ID: 'userId',
+  VALIDATOR_ADMIN_TOKEN: 'validatorAdminToken',
+  VALIDATOR_JSON_API_ENDPOINT: 'validatorJsonApiEndpoint',
+  LEDGER_JSON_API_ENDPOINT: 'ledgerJsonApiEndpoint',
+  SPLICE_SCAN_API_ENDPOINT: 'spliceScanApiEndpoint',
+};
+
+/**
+ * Normalize and validate one explicit Canton runtime credential set.
+ *
+ * This helper is intentionally pure: it does not read from or write to `process.env`.
+ */
+export function normalizeCantonRuntimeCredentials(
+  credentials: CantonRuntimeCredentialsInput
+): CantonRuntimeCredentials {
+  return {
+    partyId: normalizeRequiredString('partyId', credentials.partyId),
+    userId: normalizeRequiredString('userId', credentials.userId),
+    validatorAdminToken: normalizeRequiredString('validatorAdminToken', credentials.validatorAdminToken),
+    validatorJsonApiEndpoint: normalizeHttpEndpoint('validatorJsonApiEndpoint', credentials.validatorJsonApiEndpoint),
+    ledgerJsonApiEndpoint: normalizeHttpEndpoint('ledgerJsonApiEndpoint', credentials.ledgerJsonApiEndpoint),
+    spliceScanApiEndpoint: normalizeHttpEndpoint('spliceScanApiEndpoint', credentials.spliceScanApiEndpoint),
+  };
+}
+
+/** Build the env-var keys for one network/provider Canton runtime credential prefix. */
+export function buildCantonRuntimeCredentialEnvKeys(
+  target: CantonRuntimeCredentialTarget
+): readonly CantonRuntimeCredentialEnvKey[] {
+  const prefix = buildCantonRuntimeCredentialEnvPrefix(target);
+  return CANTON_RUNTIME_CREDENTIAL_ENV_SUFFIXES.map((suffix) => buildCantonRuntimeCredentialEnvKey(prefix, suffix));
+}
+
+/**
+ * Emit an env-var map for one explicit Canton runtime credential set.
+ *
+ * Callers can pass the returned map through their own runtime boundary without mutating global process state.
+ */
+export function buildCantonRuntimeCredentialEnvMap(
+  options: CantonRuntimeCredentialEnvMapOptions
+): CantonRuntimeCredentialEnvMap {
+  const credentials = normalizeCantonRuntimeCredentials(options.credentials);
+  const prefix = buildCantonRuntimeCredentialEnvPrefix(options);
+  const envMap: Partial<Record<CantonRuntimeCredentialEnvKey, string>> = {};
+
+  for (const suffix of CANTON_RUNTIME_CREDENTIAL_ENV_SUFFIXES) {
+    const envKey = buildCantonRuntimeCredentialEnvKey(prefix, suffix);
+    const credentialField = CANTON_RUNTIME_CREDENTIAL_FIELD_BY_SUFFIX[suffix];
+    envMap[envKey] = credentials[credentialField];
+  }
+
+  return envMap as CantonRuntimeCredentialEnvMap;
+}
+
+/**
+ * Build an explicit SDK client config from Canton runtime credentials.
+ *
+ * This avoids environment lookup entirely for the SDK clients configured here.
+ */
+export function buildCantonRuntimeCredentialClientConfig(
+  options: CantonRuntimeCredentialClientConfigOptions
+): ClientConfig {
+  const credentials = normalizeCantonRuntimeCredentials(options.credentials);
+  const adminTokenAuth = buildBearerTokenAuth(credentials.validatorAdminToken);
+
+  return {
+    network: options.network,
+    provider: options.provider,
+    partyId: credentials.partyId,
+    userId: credentials.userId,
+    apis: {
+      LEDGER_JSON_API: buildApiConfig(credentials.ledgerJsonApiEndpoint, credentials, adminTokenAuth),
+      VALIDATOR_API: buildApiConfig(credentials.validatorJsonApiEndpoint, credentials, adminTokenAuth),
+      SCAN_API: buildApiConfig(credentials.spliceScanApiEndpoint, credentials, buildNoAuthConfig()),
+    },
+  };
+}
+
+function buildCantonRuntimeCredentialEnvPrefix(
+  target: CantonRuntimeCredentialTarget
+): CantonRuntimeCredentialEnvPrefix {
+  const network = normalizeEnvSegment('network', target.network);
+  const provider = normalizeEnvSegment('provider', target.provider);
+  return `CANTON_${network}_${provider}`;
+}
+
+function buildCantonRuntimeCredentialEnvKey(
+  prefix: CantonRuntimeCredentialEnvPrefix,
+  suffix: CantonRuntimeCredentialEnvSuffix
+): CantonRuntimeCredentialEnvKey {
+  return `${prefix}_${suffix}`;
+}
+
+function buildApiConfig(apiUrl: string, credentials: CantonRuntimeCredentials, auth: AuthConfig): ApiConfig {
+  return {
+    apiUrl,
+    auth,
+    partyId: credentials.partyId,
+    userId: credentials.userId,
+  };
+}
+
+function buildBearerTokenAuth(token: string): AuthConfig {
+  return {
+    grantType: 'client_credentials',
+    clientId: '',
+    bearerToken: token,
+  };
+}
+
+function buildNoAuthConfig(): AuthConfig {
+  return {
+    grantType: 'client_credentials',
+    clientId: '',
+  };
+}
+
+function normalizeHttpEndpoint(name: string, value: string): string {
+  const normalized = trimTrailingSlashes(normalizeRequiredString(name, value));
+
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Unsupported protocol');
+    }
+  } catch {
+    throw new ConfigurationError(`Invalid Canton runtime credential ${name}: expected an http(s) URL`);
+  }
+
+  return normalized;
+}
+
+function normalizeRequiredString(name: string, value: string): string {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) {
+    throw new ConfigurationError(`Missing Canton runtime credential: ${name}`);
+  }
+  return normalized;
+}
+
+function normalizeEnvSegment(name: string, value: string): string {
+  const normalized = normalizeRequiredString(name, value).toUpperCase();
+  if (!CANTON_RUNTIME_ENV_SEGMENT_REGEX.test(normalized)) {
+    throw new ConfigurationError(
+      `Invalid Canton runtime credential ${name}: expected only letters, numbers, and underscores`
+    );
+  }
+  return normalized;
+}
+
+function trimTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, '');
+}

--- a/src/core/config/CantonRuntimeCredentials.ts
+++ b/src/core/config/CantonRuntimeCredentials.ts
@@ -217,5 +217,9 @@ function normalizeEnvSegment(name: string, value: string): string {
 }
 
 function trimTrailingSlashes(value: string): string {
-  return value.replace(/\/+$/, '');
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
 }

--- a/src/core/config/CantonRuntimeCredentials.ts
+++ b/src/core/config/CantonRuntimeCredentials.ts
@@ -1,7 +1,7 @@
 import { ConfigurationError } from '../errors';
 import { type ApiConfig, type AuthConfig, type ClientConfig, type NetworkType, type ProviderType } from '../types';
 
-const CANTON_RUNTIME_ENV_SEGMENT_REGEX = /^[A-Za-z0-9_]+$/;
+const CANTON_RUNTIME_ENV_SEGMENT_REGEX = /^[A-Za-z0-9_-]+$/;
 
 /** Env-var suffixes used for explicit Canton runtime credentials. */
 export const CANTON_RUNTIME_CREDENTIAL_ENV_SUFFIXES = [
@@ -210,7 +210,7 @@ function normalizeEnvSegment(name: string, value: string): string {
   const normalized = normalizeRequiredString(name, value).toUpperCase();
   if (!CANTON_RUNTIME_ENV_SEGMENT_REGEX.test(normalized)) {
     throw new ConfigurationError(
-      `Invalid Canton runtime credential ${name}: expected only letters, numbers, and underscores`
+      `Invalid Canton runtime credential ${name}: expected only letters, numbers, underscores, and hyphens`
     );
   }
   return normalized;

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -1,1 +1,2 @@
+export * from './CantonRuntimeCredentials';
 export * from './EnvLoader';

--- a/test/unit/core/canton-runtime-credentials.test.ts
+++ b/test/unit/core/canton-runtime-credentials.test.ts
@@ -31,13 +31,18 @@ describe('Canton runtime credential helpers', () => {
   });
 
   it('emits stable env keys for a network/provider prefix', () => {
-    expect(buildCantonRuntimeCredentialEnvKeys({ network: 'devnet', provider: '5n' })).toEqual([
-      'CANTON_DEVNET_5N_PARTY_ID',
-      'CANTON_DEVNET_5N_USER_ID',
-      'CANTON_DEVNET_5N_VALIDATOR_ADMIN_TOKEN',
-      'CANTON_DEVNET_5N_VALIDATOR_JSON_API_ENDPOINT',
-      'CANTON_DEVNET_5N_LEDGER_JSON_API_ENDPOINT',
-      'CANTON_DEVNET_5N_SPLICE_SCAN_API_ENDPOINT',
+    expect(
+      buildCantonRuntimeCredentialEnvKeys({
+        network: 'localnet',
+        provider: 'app-provider',
+      })
+    ).toEqual([
+      'CANTON_LOCALNET_APP-PROVIDER_PARTY_ID',
+      'CANTON_LOCALNET_APP-PROVIDER_USER_ID',
+      'CANTON_LOCALNET_APP-PROVIDER_VALIDATOR_ADMIN_TOKEN',
+      'CANTON_LOCALNET_APP-PROVIDER_VALIDATOR_JSON_API_ENDPOINT',
+      'CANTON_LOCALNET_APP-PROVIDER_LEDGER_JSON_API_ENDPOINT',
+      'CANTON_LOCALNET_APP-PROVIDER_SPLICE_SCAN_API_ENDPOINT',
     ]);
   });
 
@@ -137,9 +142,9 @@ describe('Canton runtime credential helpers', () => {
     expect(() =>
       buildCantonRuntimeCredentialEnvMap({
         network: 'devnet',
-        provider: 'app-provider',
+        provider: 'app provider',
         credentials: rawCredentials,
       })
-    ).toThrow('expected only letters, numbers, and underscores');
+    ).toThrow('expected only letters, numbers, underscores, and hyphens');
   });
 });

--- a/test/unit/core/canton-runtime-credentials.test.ts
+++ b/test/unit/core/canton-runtime-credentials.test.ts
@@ -30,6 +30,15 @@ describe('Canton runtime credential helpers', () => {
     expect(normalizeCantonRuntimeCredentials(rawCredentials)).toEqual(normalizedCredentials);
   });
 
+  it('normalizes long trailing slash runs without regex backtracking', () => {
+    const credentials = normalizeCantonRuntimeCredentials({
+      ...rawCredentials,
+      ledgerJsonApiEndpoint: `https://ledger.example${'/'.repeat(10_000)}`,
+    });
+
+    expect(credentials.ledgerJsonApiEndpoint).toBe('https://ledger.example');
+  });
+
   it('emits stable env keys for a network/provider prefix', () => {
     expect(
       buildCantonRuntimeCredentialEnvKeys({

--- a/test/unit/core/canton-runtime-credentials.test.ts
+++ b/test/unit/core/canton-runtime-credentials.test.ts
@@ -1,0 +1,145 @@
+import {
+  buildCantonRuntimeCredentialClientConfig,
+  buildCantonRuntimeCredentialEnvKeys,
+  buildCantonRuntimeCredentialEnvMap,
+  normalizeCantonRuntimeCredentials,
+  type CantonRuntimeCredentialsInput,
+} from '../../../src/core/config/CantonRuntimeCredentials';
+import { ConfigurationError } from '../../../src/core/errors';
+
+const rawCredentials: CantonRuntimeCredentialsInput = {
+  partyId: ' transfer-agent::party ',
+  userId: ' transfer-agent-user ',
+  validatorAdminToken: ' validator-admin-token ',
+  validatorJsonApiEndpoint: ' https://validator.example/api/validator/ ',
+  ledgerJsonApiEndpoint: ' https://ledger.example/ ',
+  spliceScanApiEndpoint: ' https://scan.example/api/scan/// ',
+};
+
+const normalizedCredentials = {
+  partyId: 'transfer-agent::party',
+  userId: 'transfer-agent-user',
+  validatorAdminToken: 'validator-admin-token',
+  validatorJsonApiEndpoint: 'https://validator.example/api/validator',
+  ledgerJsonApiEndpoint: 'https://ledger.example',
+  spliceScanApiEndpoint: 'https://scan.example/api/scan',
+};
+
+describe('Canton runtime credential helpers', () => {
+  it('normalizes required strings and endpoint URLs', () => {
+    expect(normalizeCantonRuntimeCredentials(rawCredentials)).toEqual(normalizedCredentials);
+  });
+
+  it('emits stable env keys for a network/provider prefix', () => {
+    expect(buildCantonRuntimeCredentialEnvKeys({ network: 'devnet', provider: '5n' })).toEqual([
+      'CANTON_DEVNET_5N_PARTY_ID',
+      'CANTON_DEVNET_5N_USER_ID',
+      'CANTON_DEVNET_5N_VALIDATOR_ADMIN_TOKEN',
+      'CANTON_DEVNET_5N_VALIDATOR_JSON_API_ENDPOINT',
+      'CANTON_DEVNET_5N_LEDGER_JSON_API_ENDPOINT',
+      'CANTON_DEVNET_5N_SPLICE_SCAN_API_ENDPOINT',
+    ]);
+  });
+
+  it('builds an env map without mutating process.env', () => {
+    const envKey = 'CANTON_DEVNET_5N_PARTY_ID';
+    const previousValue = process.env[envKey];
+    delete process.env[envKey];
+
+    try {
+      const envMap = buildCantonRuntimeCredentialEnvMap({
+        network: 'devnet',
+        provider: '5n',
+        credentials: rawCredentials,
+      });
+
+      expect(envMap).toEqual({
+        CANTON_DEVNET_5N_PARTY_ID: normalizedCredentials.partyId,
+        CANTON_DEVNET_5N_USER_ID: normalizedCredentials.userId,
+        CANTON_DEVNET_5N_VALIDATOR_ADMIN_TOKEN: normalizedCredentials.validatorAdminToken,
+        CANTON_DEVNET_5N_VALIDATOR_JSON_API_ENDPOINT: normalizedCredentials.validatorJsonApiEndpoint,
+        CANTON_DEVNET_5N_LEDGER_JSON_API_ENDPOINT: normalizedCredentials.ledgerJsonApiEndpoint,
+        CANTON_DEVNET_5N_SPLICE_SCAN_API_ENDPOINT: normalizedCredentials.spliceScanApiEndpoint,
+      });
+      expect(process.env[envKey]).toBeUndefined();
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = previousValue;
+      }
+    }
+  });
+
+  it('builds an explicit client config for SDK runtimes', () => {
+    expect(
+      buildCantonRuntimeCredentialClientConfig({
+        network: 'devnet',
+        provider: '5n',
+        credentials: rawCredentials,
+      })
+    ).toEqual({
+      network: 'devnet',
+      provider: '5n',
+      partyId: normalizedCredentials.partyId,
+      userId: normalizedCredentials.userId,
+      apis: {
+        LEDGER_JSON_API: {
+          apiUrl: normalizedCredentials.ledgerJsonApiEndpoint,
+          auth: {
+            grantType: 'client_credentials',
+            clientId: '',
+            bearerToken: normalizedCredentials.validatorAdminToken,
+          },
+          partyId: normalizedCredentials.partyId,
+          userId: normalizedCredentials.userId,
+        },
+        VALIDATOR_API: {
+          apiUrl: normalizedCredentials.validatorJsonApiEndpoint,
+          auth: {
+            grantType: 'client_credentials',
+            clientId: '',
+            bearerToken: normalizedCredentials.validatorAdminToken,
+          },
+          partyId: normalizedCredentials.partyId,
+          userId: normalizedCredentials.userId,
+        },
+        SCAN_API: {
+          apiUrl: normalizedCredentials.spliceScanApiEndpoint,
+          auth: {
+            grantType: 'client_credentials',
+            clientId: '',
+          },
+          partyId: normalizedCredentials.partyId,
+          userId: normalizedCredentials.userId,
+        },
+      },
+    });
+  });
+
+  it('rejects missing values and invalid endpoints', () => {
+    expect(() =>
+      normalizeCantonRuntimeCredentials({
+        ...rawCredentials,
+        partyId: ' ',
+      })
+    ).toThrow(ConfigurationError);
+
+    expect(() =>
+      normalizeCantonRuntimeCredentials({
+        ...rawCredentials,
+        ledgerJsonApiEndpoint: 'ftp://ledger.example',
+      })
+    ).toThrow('expected an http(s) URL');
+  });
+
+  it('rejects env prefixes that cannot form portable env var names', () => {
+    expect(() =>
+      buildCantonRuntimeCredentialEnvMap({
+        network: 'devnet',
+        provider: 'app-provider',
+        credentials: rawCredentials,
+      })
+    ).toThrow('expected only letters, numbers, and underscores');
+  });
+});


### PR DESCRIPTION
## Summary
- add pure typed helpers for explicit Canton runtime credential sets
- emit CANTON_<NETWORK>_<PROVIDER> env maps without mutating process.env
- build an explicit ClientConfig from SSM/env-loaded credentials for APIv2 settlement runtime wiring

## PR #311 follow-up
Moves the process-env credential mapping shape from APIv2 settlement config into canton-node-sdk so APIv2 can load secrets and pass explicit typed config/env maps instead of owning SDK-specific key construction.

## Validation
- npm test -- test/unit/core/canton-runtime-credentials.test.ts
- npx eslint src/core/config/CantonRuntimeCredentials.ts test/unit/core/canton-runtime-credentials.test.ts
- npx prettier --check src/core/config/CantonRuntimeCredentials.ts test/unit/core/canton-runtime-credentials.test.ts

Note: npm run build:core is currently blocked in this fresh worktree by existing missing generated OpenAPI modules under src/clients/generated, matching the repo setup issue noted during implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New code paths shape validator admin tokens and SDK client auth/endpoints; risk is limited because behavior is additive, validated, and covered by unit tests with no changes to existing env loading.
> 
> **Overview**
> Adds **pure, typed helpers** in `canton-node-sdk` so callers can supply Canton runtime secrets explicitly instead of duplicating `CANTON_<NETWORK>_<PROVIDER>_*` key logic (follow-up to APIv2 settlement wiring).
> 
> **`normalizeCantonRuntimeCredentials`** trims and validates party/user IDs, admin token, and http(s) API endpoints (including safe trailing-slash trimming). **`buildCantonRuntimeCredentialEnvKeys`** / **`buildCantonRuntimeCredentialEnvMap`** emit the six standard env keys for a network/provider **without touching `process.env`**. **`buildCantonRuntimeCredentialClientConfig`** maps the same inputs into an explicit **`ClientConfig`** (ledger + validator APIs use bearer admin token; scan API has no bearer).
> 
> The module is re-exported from `src/core/config/index.ts`, with unit coverage for normalization, env-map shape, client config, and validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8709da8dba2c40b1d347fb368c1030405c6fe286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->