### PR TITLE
[codex] Add party synchronizer readiness helpers

### DIFF
--- a/src/utils/amulet/external-party-transfer-offer.ts
+++ b/src/utils/amulet/external-party-transfer-offer.ts
@@ -372,6 +372,13 @@ async function readRequiredConnectedSynchronizerId(
         OperationErrorCode.MISSING_DOMAIN_ID
       );
     }
+    if (error instanceof OperationError && error.message === 'Canton party reported multiple connected synchronizers') {
+      throw new OperationError(
+        'Canton provider reported multiple connected synchronizers',
+        OperationErrorCode.MISSING_DOMAIN_ID,
+        error.context
+      );
+    }
     throw error;
   }
 }

--- a/src/utils/amulet/external-party-transfer-offer.ts
+++ b/src/utils/amulet/external-party-transfer-offer.ts
@@ -18,6 +18,7 @@ import {
   CANTON_RAW_SIGNATURE_FORMAT,
 } from '../external-signing/external-party-onboarding';
 import { prepareExternalTransaction } from '../external-signing/prepare-external-transaction';
+import { assertSingleConnectedSynchronizerId } from '../party-readiness';
 
 export const CANTON_TRANSFER_OFFER_TEMPLATE_ID = '#splice-wallet:Splice.Wallet.TransferOffer:TransferOffer';
 
@@ -362,51 +363,17 @@ async function readRequiredConnectedSynchronizerId(
   providerPartyId: string
 ): Promise<string> {
   const raw = await ledgerClient.getConnectedSynchronizers({ party: providerPartyId });
-  const synchronizerId = parseRequiredSingleSynchronizerId(raw);
-  if (synchronizerId) return synchronizerId;
-  throw new OperationError(
-    'Canton provider did not report a connected synchronizer',
-    OperationErrorCode.MISSING_DOMAIN_ID
-  );
-}
-
-function parseRequiredSingleSynchronizerId(raw: unknown): string | null {
-  if (!isRecord(raw) && !Array.isArray(raw)) return null;
-  const direct = isRecord(raw) ? raw['connectedSynchronizers'] : undefined;
-  const itemsField = isRecord(raw) ? raw['items'] : undefined;
-  const items: unknown[] = Array.isArray(raw)
-    ? raw
-    : Array.isArray(direct)
-      ? direct
-      : Array.isArray(itemsField)
-        ? itemsField
-        : [];
-  const synchronizerIds: string[] = [];
-  for (const item of items) {
-    if (typeof item === 'string' && item.trim()) {
-      synchronizerIds.push(item);
-      continue;
+  try {
+    return assertSingleConnectedSynchronizerId(raw);
+  } catch (error) {
+    if (error instanceof OperationError && error.message === 'Canton party did not report a connected synchronizer') {
+      throw new OperationError(
+        'Canton provider did not report a connected synchronizer',
+        OperationErrorCode.MISSING_DOMAIN_ID
+      );
     }
-    if (!isRecord(item)) {
-      continue;
-    }
-    for (const key of ['synchronizerId', 'synchronizer', 'domainId', 'id']) {
-      const value = item[key];
-      if (typeof value === 'string' && value.trim()) {
-        synchronizerIds.push(value);
-        break;
-      }
-    }
+    throw error;
   }
-  const uniqueSynchronizerIds = new Set(synchronizerIds);
-  if (uniqueSynchronizerIds.size > 1) {
-    throw new OperationError(
-      'Canton provider reported multiple connected synchronizers',
-      OperationErrorCode.MISSING_DOMAIN_ID,
-      { synchronizerIds }
-    );
-  }
-  return synchronizerIds[0] ?? null;
 }
 
 function validateRequiredString(name: string, value: string): void {

--- a/src/utils/external-signing/external-party-wallet.ts
+++ b/src/utils/external-signing/external-party-wallet.ts
@@ -23,6 +23,7 @@ import {
   type SubmittedExternalPartyTransferPreapprovalSetup,
 } from '../amulet/external-party-transfer-preapproval';
 import { objectOrEmpty, readRequiredString } from '../canton-response-utils';
+import { readConnectedSynchronizers as readPartyConnectedSynchronizers } from '../party-readiness';
 import {
   assertCantonHashSignature,
   assertCantonPartyMatchesPublicKey,
@@ -949,40 +950,16 @@ export function normalizeExternalPartyWalletDescription(description: string | nu
 }
 
 export function parseExternalPartyWalletConnectedSynchronizerId(raw: unknown): string | null {
-  if (!isRecord(raw) && !Array.isArray(raw)) return null;
-  const direct = isRecord(raw) ? raw['connectedSynchronizers'] : undefined;
-  const itemsField = isRecord(raw) ? raw['items'] : undefined;
-  const items: unknown[] = Array.isArray(raw)
-    ? raw
-    : Array.isArray(direct)
-      ? direct
-      : Array.isArray(itemsField)
-        ? itemsField
-        : [];
-  const synchronizerIds: string[] = [];
-  for (const item of items) {
-    if (typeof item === 'string' && item.trim()) {
-      synchronizerIds.push(item.trim());
-      continue;
-    }
-    if (!isRecord(item)) continue;
-    for (const key of ['synchronizerId', 'synchronizer', 'domainId', 'id']) {
-      const value = item[key];
-      if (typeof value === 'string' && value.trim()) {
-        synchronizerIds.push(value.trim());
-        break;
-      }
-    }
-  }
-  const uniqueSynchronizerIds = new Set(synchronizerIds);
-  if (uniqueSynchronizerIds.size > 1) {
+  const synchronizerIds = readPartyConnectedSynchronizers(raw).map((synchronizer) => synchronizer.synchronizerId);
+  const uniqueSynchronizerIds = [...new Set(synchronizerIds)];
+  if (uniqueSynchronizerIds.length > 1) {
     throw new OperationError(
       'Canton provider reported multiple connected synchronizers',
       OperationErrorCode.MISSING_DOMAIN_ID,
       { synchronizerIds }
     );
   }
-  return synchronizerIds[0] ?? null;
+  return uniqueSynchronizerIds[0] ?? null;
 }
 
 async function prepareProviderTransferAcceptance(input: {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,5 +6,6 @@ export * from './health';
 export * from './mining';
 export * from './parsers';
 export * from './party';
+export * from './party-readiness';
 export * from './traffic';
 export * from './transactions';

--- a/src/utils/party-readiness/index.ts
+++ b/src/utils/party-readiness/index.ts
@@ -1,0 +1,352 @@
+import { OperationError, OperationErrorCode, ValidationError } from '../../core/errors';
+import { isRecord } from '../../core/utils';
+
+export interface PartySynchronizerReadinessLedgerClient {
+  readonly getConnectedSynchronizers: (params: {
+    readonly party: string;
+    readonly participantId?: string;
+  }) => Promise<unknown>;
+}
+
+export interface CantonConnectedSynchronizer {
+  readonly synchronizerId: string;
+  readonly synchronizerAlias?: string;
+  readonly permission?: string;
+  readonly raw: unknown;
+}
+
+export interface PartyConnectedSynchronizers {
+  readonly party: string;
+  readonly synchronizerIds: readonly string[];
+  readonly synchronizers: readonly CantonConnectedSynchronizer[];
+  readonly raw: unknown;
+}
+
+export interface ListConnectedSynchronizerIdsOptions {
+  readonly ledgerClient: PartySynchronizerReadinessLedgerClient;
+  readonly party: string;
+  readonly participantId?: string;
+}
+
+export interface PartySynchronizerReadinessOptions extends ListConnectedSynchronizerIdsOptions {
+  readonly synchronizerId: string;
+}
+
+export interface PartySynchronizerReadiness {
+  readonly party: string;
+  readonly synchronizerId: string;
+  readonly ready: boolean;
+  readonly connected: boolean;
+  readonly canSubmit: boolean;
+  readonly connectedSynchronizerIds: readonly string[];
+  readonly matchedSynchronizer?: CantonConnectedSynchronizer;
+  readonly reason?: 'not-connected' | 'not-submit-capable';
+  readonly raw: unknown;
+}
+
+export interface ResolveCommonSynchronizerIdsOptions {
+  readonly ledgerClient: PartySynchronizerReadinessLedgerClient;
+  readonly parties: readonly string[];
+  readonly participantId?: string;
+  /** When true, ignore connected synchronizers whose permission is explicitly observation-only. */
+  readonly requireSubmitPermission?: boolean;
+}
+
+export interface CommonPartySynchronizers {
+  readonly parties: readonly string[];
+  readonly synchronizerIds: readonly string[];
+  readonly partySynchronizers: readonly PartyConnectedSynchronizers[];
+}
+
+export interface AssertCommonSynchronizerReadyOptions extends ResolveCommonSynchronizerIdsOptions {
+  readonly synchronizerId?: string;
+}
+
+export interface CommonPartySynchronizerReadiness extends CommonPartySynchronizers {
+  readonly synchronizerId: string;
+}
+
+export async function listConnectedSynchronizerIds(
+  options: ListConnectedSynchronizerIdsOptions
+): Promise<PartyConnectedSynchronizers> {
+  const party = validateRequiredString('party', options.party);
+  const participantId =
+    options.participantId === undefined ? undefined : validateRequiredString('participantId', options.participantId);
+  const raw = await options.ledgerClient.getConnectedSynchronizers({
+    party,
+    ...(participantId !== undefined ? { participantId } : {}),
+  });
+  const synchronizers = readConnectedSynchronizers(raw);
+
+  return {
+    party,
+    synchronizerIds: synchronizers.map((synchronizer) => synchronizer.synchronizerId),
+    synchronizers,
+    raw,
+  };
+}
+
+export async function checkPartySynchronizerReadiness(
+  options: PartySynchronizerReadinessOptions
+): Promise<PartySynchronizerReadiness> {
+  const synchronizerId = validateRequiredString('synchronizerId', options.synchronizerId);
+  const connected = await listConnectedSynchronizerIds(options);
+  const matchedSynchronizer = connected.synchronizers.find(
+    (synchronizer) => synchronizer.synchronizerId === synchronizerId
+  );
+  const isConnected = matchedSynchronizer !== undefined;
+  const canSubmit = matchedSynchronizer ? canSubmitWithPermission(matchedSynchronizer.permission) : false;
+  const ready = isConnected && canSubmit;
+
+  return {
+    party: connected.party,
+    synchronizerId,
+    ready,
+    connected: isConnected,
+    canSubmit,
+    connectedSynchronizerIds: connected.synchronizerIds,
+    ...(matchedSynchronizer !== undefined ? { matchedSynchronizer } : {}),
+    ...(!isConnected
+      ? { reason: 'not-connected' as const }
+      : !canSubmit
+        ? { reason: 'not-submit-capable' as const }
+        : {}),
+    raw: connected.raw,
+  };
+}
+
+export async function assertPartySynchronizerReady(
+  options: PartySynchronizerReadinessOptions
+): Promise<PartySynchronizerReadiness> {
+  const readiness = await checkPartySynchronizerReadiness(options);
+  if (readiness.ready) return readiness;
+
+  throw new OperationError(
+    readiness.connected
+      ? 'Canton party is connected to the synchronizer without submit permission'
+      : 'Canton party is not connected to the synchronizer',
+    OperationErrorCode.MISSING_DOMAIN_ID,
+    {
+      party: readiness.party,
+      synchronizerId: readiness.synchronizerId,
+      connectedSynchronizerIds: readiness.connectedSynchronizerIds,
+      ...(readiness.matchedSynchronizer?.permission ? { permission: readiness.matchedSynchronizer.permission } : {}),
+      reason: readiness.reason,
+    }
+  );
+}
+
+export async function resolveCommonSynchronizerIds(
+  options: ResolveCommonSynchronizerIdsOptions
+): Promise<CommonPartySynchronizers> {
+  const parties = normalizePartyList(options.parties);
+  const partySynchronizers = await Promise.all(
+    parties.map(async (party) =>
+      listConnectedSynchronizerIds({
+        ledgerClient: options.ledgerClient,
+        party,
+        ...(options.participantId !== undefined ? { participantId: options.participantId } : {}),
+      })
+    )
+  );
+  const commonIds = intersectSynchronizerIds(
+    partySynchronizers.map((partyResult) =>
+      options.requireSubmitPermission === false
+        ? partyResult.synchronizers
+        : partyResult.synchronizers.filter((synchronizer) => canSubmitWithPermission(synchronizer.permission))
+    )
+  );
+
+  return {
+    parties,
+    synchronizerIds: commonIds,
+    partySynchronizers,
+  };
+}
+
+export async function assertCommonSynchronizerReady(
+  options: AssertCommonSynchronizerReadyOptions
+): Promise<CommonPartySynchronizerReadiness> {
+  const common = await resolveCommonSynchronizerIds(options);
+  const synchronizerId =
+    options.synchronizerId === undefined
+      ? common.synchronizerIds[0]
+      : validateRequiredString('synchronizerId', options.synchronizerId);
+
+  if (!synchronizerId) {
+    throw new OperationError(
+      'Canton parties do not share a connected synchronizer',
+      OperationErrorCode.MISSING_DOMAIN_ID,
+      {
+        parties: common.parties,
+        partySynchronizers: common.partySynchronizers.map((partyResult) => ({
+          party: partyResult.party,
+          synchronizerIds: partyResult.synchronizerIds,
+        })),
+      }
+    );
+  }
+
+  const missingParties = common.partySynchronizers
+    .filter((partyResult) => !partyResult.synchronizerIds.includes(synchronizerId))
+    .map((partyResult) => partyResult.party);
+  const nonSubmitParties =
+    options.requireSubmitPermission === false
+      ? []
+      : common.partySynchronizers
+          .filter((partyResult) => {
+            const match = partyResult.synchronizers.find(
+              (synchronizer) => synchronizer.synchronizerId === synchronizerId
+            );
+            return match !== undefined && !canSubmitWithPermission(match.permission);
+          })
+          .map((partyResult) => partyResult.party);
+
+  if (missingParties.length > 0 || nonSubmitParties.length > 0) {
+    throw new OperationError(
+      'Canton parties are not ready on the requested synchronizer',
+      OperationErrorCode.MISSING_DOMAIN_ID,
+      {
+        parties: common.parties,
+        synchronizerId,
+        missingParties,
+        nonSubmitParties,
+        partySynchronizers: common.partySynchronizers.map((partyResult) => ({
+          party: partyResult.party,
+          synchronizerIds: partyResult.synchronizerIds,
+        })),
+      }
+    );
+  }
+
+  return {
+    ...common,
+    synchronizerId,
+  };
+}
+
+export function assertSingleConnectedSynchronizerId(raw: unknown): string {
+  const synchronizerId = readSingleConnectedSynchronizerId(raw);
+  if (synchronizerId) return synchronizerId;
+  throw new OperationError(
+    'Canton party did not report a connected synchronizer',
+    OperationErrorCode.MISSING_DOMAIN_ID
+  );
+}
+
+export function readSingleConnectedSynchronizerId(raw: unknown): string | null {
+  const synchronizerIds = readConnectedSynchronizers(raw).map((synchronizer) => synchronizer.synchronizerId);
+  const uniqueSynchronizerIds = [...new Set(synchronizerIds)];
+  if (uniqueSynchronizerIds.length > 1) {
+    throw new OperationError(
+      'Canton party reported multiple connected synchronizers',
+      OperationErrorCode.MISSING_DOMAIN_ID,
+      { synchronizerIds }
+    );
+  }
+  return uniqueSynchronizerIds[0] ?? null;
+}
+
+export function readConnectedSynchronizers(raw: unknown): readonly CantonConnectedSynchronizer[] {
+  const items = readConnectedSynchronizerItems(raw);
+  const synchronizers: CantonConnectedSynchronizer[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    const synchronizer = readConnectedSynchronizer(item);
+    if (!synchronizer || seen.has(synchronizer.synchronizerId)) continue;
+    seen.add(synchronizer.synchronizerId);
+    synchronizers.push(synchronizer);
+  }
+
+  return synchronizers;
+}
+
+export function canSubmitWithPermission(permission: string | null | undefined): boolean {
+  if (!permission?.trim()) return true;
+  const normalized = normalizePermission(permission);
+  if (normalized.includes('observation') || normalized.includes('observer')) return false;
+  return normalized.includes('submission') || normalized.includes('confirmation');
+}
+
+function readConnectedSynchronizerItems(raw: unknown): readonly unknown[] {
+  if (Array.isArray(raw)) return raw;
+  if (!isRecord(raw)) return [];
+  for (const key of ['connectedSynchronizers', 'connected_synchronizers', 'items', 'synchronizers']) {
+    const value = raw[key];
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function readConnectedSynchronizer(item: unknown): CantonConnectedSynchronizer | null {
+  if (typeof item === 'string' && item.trim()) {
+    return {
+      synchronizerId: item.trim(),
+      raw: item,
+    };
+  }
+  if (!isRecord(item)) return null;
+
+  const synchronizerId = readFirstString(item, [
+    'synchronizerId',
+    'synchronizer_id',
+    'synchronizer',
+    'domainId',
+    'domain_id',
+    'id',
+  ]);
+  if (!synchronizerId) return null;
+  const synchronizerAlias = readFirstString(item, ['synchronizerAlias', 'synchronizer_alias', 'alias']);
+  const permission = readFirstString(item, ['permission', 'participantPermission', 'participant_permission']);
+
+  return {
+    synchronizerId,
+    ...(synchronizerAlias ? { synchronizerAlias } : {}),
+    ...(permission ? { permission } : {}),
+    raw: item,
+  };
+}
+
+function normalizePartyList(parties: readonly string[]): readonly string[] {
+  const normalized = [...new Set(parties.map((party) => validateRequiredString('parties', party)))];
+  if (normalized.length === 0) {
+    throw new ValidationError('parties must include at least one party');
+  }
+  return normalized;
+}
+
+function intersectSynchronizerIds(synchronizerGroups: ReadonlyArray<readonly CantonConnectedSynchronizer[]>): string[] {
+  const [firstGroup, ...restGroups] = synchronizerGroups;
+  if (!firstGroup) return [];
+  const common = new Set(firstGroup.map((synchronizer) => synchronizer.synchronizerId));
+
+  for (const group of restGroups) {
+    const groupIds = new Set(group.map((synchronizer) => synchronizer.synchronizerId));
+    for (const synchronizerId of [...common]) {
+      if (!groupIds.has(synchronizerId)) common.delete(synchronizerId);
+    }
+  }
+
+  return [...common].sort();
+}
+
+function validateRequiredString(name: string, value: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new ValidationError(`${name} is required`, { [name]: value });
+  }
+  return normalized;
+}
+
+function readFirstString(record: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function normalizePermission(permission: string): string {
+  return permission.toLowerCase().replace(/[^a-z]/g, '');
+}

--- a/test/unit/amulet/external-party-transfer-offer.test.ts
+++ b/test/unit/amulet/external-party-transfer-offer.test.ts
@@ -355,7 +355,7 @@ describe('external-party transfer-offer helpers', () => {
         offerContractId: offerContract.contractId,
         disclosedContract: offerContract,
       })
-    ).rejects.toThrow('multiple connected synchronizers');
+    ).rejects.toThrow('Canton provider reported multiple connected synchronizers');
 
     expect(ledgerClient.interactiveSubmissionPrepare).not.toHaveBeenCalled();
   });

--- a/test/unit/party-readiness.test.ts
+++ b/test/unit/party-readiness.test.ts
@@ -1,0 +1,268 @@
+import {
+  assertCommonSynchronizerReady,
+  assertPartySynchronizerReady,
+  canSubmitWithPermission,
+  checkPartySynchronizerReadiness,
+  listConnectedSynchronizerIds,
+  readConnectedSynchronizers,
+  readSingleConnectedSynchronizerId,
+  resolveCommonSynchronizerIds,
+  type PartySynchronizerReadinessLedgerClient,
+} from '../../src';
+
+type MockLedgerClient = PartySynchronizerReadinessLedgerClient & {
+  readonly getConnectedSynchronizers: jest.MockedFunction<
+    PartySynchronizerReadinessLedgerClient['getConnectedSynchronizers']
+  >;
+};
+
+function createMockLedgerClient(responses: Record<string, unknown>): MockLedgerClient {
+  return {
+    getConnectedSynchronizers: jest.fn(
+      async (params: { readonly party: string }) => responses[params.party] ?? { connectedSynchronizers: [] }
+    ),
+  };
+}
+
+describe('party synchronizer readiness helpers', (): void => {
+  it('parses connected synchronizers from Canton and legacy-shaped responses', (): void => {
+    expect(
+      readConnectedSynchronizers({
+        connectedSynchronizers: [
+          {
+            synchronizerAlias: 'global',
+            synchronizerId: ' global-domain::sync ',
+            permission: 'SUBMISSION',
+          },
+          {
+            synchronizer_alias: 'ignored-duplicate',
+            synchronizer_id: 'global-domain::sync',
+            permission: 'OBSERVATION',
+          },
+          ' other-domain::sync ',
+          { domainId: 'legacy-domain::sync' },
+          { id: 'id-domain::sync', participant_permission: 'CONFIRMATION' },
+          { synchronizerId: ' ' },
+        ],
+      })
+    ).toEqual([
+      {
+        synchronizerAlias: 'global',
+        synchronizerId: 'global-domain::sync',
+        permission: 'SUBMISSION',
+        raw: expect.any(Object) as object,
+      },
+      {
+        synchronizerId: 'other-domain::sync',
+        raw: ' other-domain::sync ',
+      },
+      {
+        synchronizerId: 'legacy-domain::sync',
+        raw: expect.any(Object) as object,
+      },
+      {
+        synchronizerId: 'id-domain::sync',
+        permission: 'CONFIRMATION',
+        raw: expect.any(Object) as object,
+      },
+    ]);
+
+    expect(readConnectedSynchronizers({ connected_synchronizers: [{ synchronizer: 'snake::sync' }] })).toEqual([
+      {
+        synchronizerId: 'snake::sync',
+        raw: expect.any(Object) as object,
+      },
+    ]);
+  });
+
+  it('lists connected synchronizer IDs and passes participantId when supplied', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'issuer::party': {
+        connectedSynchronizers: [{ synchronizerId: 'sync-2' }, { synchronizerId: 'sync-1' }],
+      },
+    });
+
+    await expect(
+      listConnectedSynchronizerIds({
+        ledgerClient,
+        party: ' issuer::party ',
+        participantId: ' participant::node ',
+      })
+    ).resolves.toMatchObject({
+      party: 'issuer::party',
+      synchronizerIds: ['sync-2', 'sync-1'],
+    });
+
+    expect(ledgerClient.getConnectedSynchronizers).toHaveBeenCalledWith({
+      party: 'issuer::party',
+      participantId: 'participant::node',
+    });
+  });
+
+  it('checks one party for submit readiness on a synchronizer', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'issuer::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'global-domain::sync', permission: 'Submission' },
+          { synchronizerId: 'observer-domain::sync', permission: 'Observation' },
+        ],
+      },
+    });
+
+    await expect(
+      checkPartySynchronizerReadiness({
+        ledgerClient,
+        party: 'issuer::party',
+        synchronizerId: 'global-domain::sync',
+      })
+    ).resolves.toMatchObject({
+      party: 'issuer::party',
+      synchronizerId: 'global-domain::sync',
+      ready: true,
+      connected: true,
+      canSubmit: true,
+      connectedSynchronizerIds: ['global-domain::sync', 'observer-domain::sync'],
+    });
+
+    await expect(
+      checkPartySynchronizerReadiness({
+        ledgerClient,
+        party: 'issuer::party',
+        synchronizerId: 'observer-domain::sync',
+      })
+    ).resolves.toMatchObject({
+      ready: false,
+      connected: true,
+      canSubmit: false,
+      reason: 'not-submit-capable',
+    });
+
+    await expect(
+      checkPartySynchronizerReadiness({
+        ledgerClient,
+        party: 'issuer::party',
+        synchronizerId: 'missing-domain::sync',
+      })
+    ).resolves.toMatchObject({
+      ready: false,
+      connected: false,
+      canSubmit: false,
+      reason: 'not-connected',
+    });
+  });
+
+  it('asserts party readiness with actionable failures', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'external::party': {
+        connectedSynchronizers: [{ synchronizerId: 'observer-domain::sync', permission: 'OBSERVATION' }],
+      },
+    });
+
+    await expect(
+      assertPartySynchronizerReady({
+        ledgerClient,
+        party: 'external::party',
+        synchronizerId: 'observer-domain::sync',
+      })
+    ).rejects.toThrow('without submit permission');
+
+    await expect(
+      assertPartySynchronizerReady({
+        ledgerClient,
+        party: 'external::party',
+        synchronizerId: 'global-domain::sync',
+      })
+    ).rejects.toThrow('not connected to the synchronizer');
+  });
+
+  it('resolves common submit-capable synchronizers across parties', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'transfer-agent::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'global-domain::sync', permission: 'Submission' },
+          { synchronizerId: 'read-only-domain::sync', permission: 'Observation' },
+        ],
+      },
+      'issuer::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'global-domain::sync', permission: 'Confirmation' },
+          { synchronizerId: 'read-only-domain::sync', permission: 'Observation' },
+          { synchronizerId: 'issuer-only-domain::sync', permission: 'Submission' },
+        ],
+      },
+      'external::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'global-domain::sync' },
+          { synchronizerId: 'read-only-domain::sync', permission: 'Observation' },
+        ],
+      },
+    });
+
+    await expect(
+      resolveCommonSynchronizerIds({
+        ledgerClient,
+        parties: ['transfer-agent::party', 'issuer::party', 'external::party'],
+      })
+    ).resolves.toMatchObject({
+      parties: ['transfer-agent::party', 'issuer::party', 'external::party'],
+      synchronizerIds: ['global-domain::sync'],
+    });
+
+    await expect(
+      resolveCommonSynchronizerIds({
+        ledgerClient,
+        parties: ['transfer-agent::party', 'issuer::party', 'external::party'],
+        requireSubmitPermission: false,
+      })
+    ).resolves.toMatchObject({
+      synchronizerIds: ['global-domain::sync', 'read-only-domain::sync'],
+    });
+  });
+
+  it('asserts common synchronizer readiness for an expected synchronizer', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'transfer-agent::party': {
+        connectedSynchronizers: [{ synchronizerId: 'global-domain::sync', permission: 'Submission' }],
+      },
+      'issuer::party': {
+        connectedSynchronizers: [{ synchronizerId: 'global-domain::sync', permission: 'Confirmation' }],
+      },
+      'external::party': {
+        connectedSynchronizers: [{ synchronizerId: 'other-domain::sync', permission: 'Confirmation' }],
+      },
+    });
+
+    await expect(
+      assertCommonSynchronizerReady({
+        ledgerClient,
+        parties: ['transfer-agent::party', 'issuer::party'],
+        synchronizerId: 'global-domain::sync',
+      })
+    ).resolves.toMatchObject({
+      synchronizerId: 'global-domain::sync',
+    });
+
+    await expect(
+      assertCommonSynchronizerReady({
+        ledgerClient,
+        parties: ['transfer-agent::party', 'issuer::party', 'external::party'],
+        synchronizerId: 'global-domain::sync',
+      })
+    ).rejects.toThrow('not ready on the requested synchronizer');
+  });
+
+  it('handles single-synchronizer and permission helper edge cases', (): void => {
+    expect(
+      readSingleConnectedSynchronizerId({ connectedSynchronizers: [' sync-1 ', { synchronizerId: 'sync-1' }] })
+    ).toBe('sync-1');
+    expect(readSingleConnectedSynchronizerId(null)).toBeNull();
+    expect(() => readSingleConnectedSynchronizerId({ connectedSynchronizers: ['sync-1', 'sync-2'] })).toThrow(
+      'multiple connected synchronizers'
+    );
+
+    expect(canSubmitWithPermission(undefined)).toBe(true);
+    expect(canSubmitWithPermission('SUBMISSION')).toBe(true);
+    expect(canSubmitWithPermission('Confirmation')).toBe(true);
+    expect(canSubmitWithPermission('Observation')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add generic helpers for connected synchronizer parsing and party readiness checks
- resolve/assert common submit-capable synchronizers across multiple parties
- reuse the shared parser in external-party wallet and transfer-offer utilities

## PR #311 follow-up
Moves repeated APIv2 settlement preflight logic around ledger.getConnectedSynchronizers into canton-node-sdk so transfer-agent, issuer, and external-party readiness can be validated through a shared SDK helper.

## Validation
- npm run build
- npm test -- --runInBand test/unit
- npm test -- test/unit/party-readiness.test.ts
- npx eslint src/utils/party-readiness/index.ts src/utils/index.ts src/utils/amulet/external-party-transfer-offer.ts src/utils/external-signing/external-party-wallet.ts test/unit/party-readiness.test.ts
- npx prettier --check src/utils/party-readiness/index.ts src/utils/index.ts src/utils/amulet/external-party-transfer-offer.ts src/utils/external-signing/external-party-wallet.ts test/unit/party-readiness.test.ts

Note: npm run lint still reports existing unrelated lint errors outside this change set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how synchronizer/domain IDs are derived before transfers and interactive prepare; mistakes could block or mis-route Canton operations, though behavior is largely consolidated with added permission-aware checks and unit tests.
> 
> **Overview**
> Introduces **`party-readiness`** as shared SDK utilities for parsing `ledger.getConnectedSynchronizers` responses and validating Canton settlement preflight (single-party readiness, submit permissions, and common synchronizers across multiple parties).
> 
> **External-party transfer offer** and **external-party wallet** no longer embed their own synchronizer parsers; they call `assertSingleConnectedSynchronizerId` / `readConnectedSynchronizers`, with provider-facing error messages preserved where needed. The module is re-exported from `src/utils/index.ts`.
> 
> Adds **`test/unit/party-readiness.test.ts`** and updates one transfer-offer test expectation for the remapped multi-synchronizer error string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3401bcd3ce24b003aa47a218b2e31db6caf603a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->