### PR TITLE
[codex] Add external signer party helper

### DIFF
--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -9,6 +9,7 @@ import {
   assertCantonSha256MultihashHex,
   buildExternalPartyId,
   deriveCantonEd25519PublicKeyFingerprint,
+  hashHexToBase64,
   normalizeCantonHashToHex,
   normalizeEd25519PublicKeyForCanton,
 } from './canton-protocol';
@@ -25,6 +26,14 @@ export interface PrepareExternalPartyOnboardingOptions {
   readonly synchronizerId: string;
   readonly partyHint: string;
   readonly publicKeyBase64: string;
+  /** If true, the local participant will only observe, not confirm (default: false). */
+  readonly localParticipantObservationOnly?: boolean;
+  /** Other participant UIDs that should confirm for this party. */
+  readonly otherConfirmingParticipantUids?: readonly string[];
+  /** Confirmation threshold for multi-hosted party (default: all confirmers). */
+  readonly confirmationThreshold?: number;
+  /** Other participant UIDs that should only observe. */
+  readonly observingParticipantUids?: readonly string[];
 }
 
 export interface PreparedExternalPartyOnboarding {
@@ -61,6 +70,53 @@ export interface SubmittedExternalPartyOnboarding {
   readonly alreadyExisted: boolean;
 }
 
+export interface ExternalPartyHashSigningRequest {
+  readonly partyHint: string;
+  readonly partyId: string;
+  readonly publicKeyBase64: string;
+  readonly publicKeyFingerprint: string;
+  readonly synchronizerId: string;
+  readonly multiHashHex: string;
+  readonly multiHashBase64: string;
+  readonly topologyTransactions: readonly string[];
+  readonly signingAlgorithmSpec: typeof CANTON_ED25519_SIGNATURE_ALGORITHM;
+}
+
+export type ExternalPartyHashSignature =
+  | {
+      readonly signatureBase64: string;
+    }
+  | {
+      readonly signatureHex: string;
+    }
+  | {
+      readonly signatureBytes: Buffer | Uint8Array;
+    };
+
+export type ExternalPartyHashSigner = (
+  request: ExternalPartyHashSigningRequest
+) => ExternalPartyHashSignature | Promise<ExternalPartyHashSignature>;
+
+export interface CreateExternalPartyWithSignerOptions extends PrepareExternalPartyOnboardingOptions {
+  readonly signMultiHash: ExternalPartyHashSigner;
+  readonly identityProviderId?: string;
+  /**
+   * Treat a 409 allocation conflict as success when the party already exists and the party details endpoint confirms
+   * it.
+   */
+  readonly allowAlreadyExists?: boolean;
+}
+
+export interface CreatedExternalPartyWithSigner {
+  readonly partyId: string;
+  readonly publicKeyFingerprint: string;
+  readonly publicKeyBase64: string;
+  readonly synchronizerId: string;
+  readonly prepared: PreparedExternalPartyOnboarding;
+  readonly submitted: SubmittedExternalPartyOnboarding;
+  readonly alreadyExisted: boolean;
+}
+
 /**
  * Prepares external-party topology for a raw or DER-wrapped Ed25519 public key.
  *
@@ -81,6 +137,16 @@ export async function prepareExternalPartyOnboarding(
       keyData: normalizeEd25519PublicKeyForCanton(options.publicKeyBase64),
       keySpec: CANTON_EC_CURVE25519_PUBLIC_KEY_SPEC,
     },
+    ...(options.localParticipantObservationOnly !== undefined
+      ? { localParticipantObservationOnly: options.localParticipantObservationOnly }
+      : {}),
+    ...(options.otherConfirmingParticipantUids !== undefined
+      ? { otherConfirmingParticipantUids: options.otherConfirmingParticipantUids }
+      : {}),
+    ...(options.confirmationThreshold !== undefined ? { confirmationThreshold: options.confirmationThreshold } : {}),
+    ...(options.observingParticipantUids !== undefined
+      ? { observingParticipantUids: options.observingParticipantUids }
+      : {}),
   });
 
   const partyId = readRequiredString(topology, 'partyId', 'topology generation');
@@ -101,6 +167,68 @@ export async function prepareExternalPartyOnboarding(
     publicKeyFormat: CANTON_DER_X509_PUBLIC_KEY_FORMAT,
     signingAlgorithmSpec: CANTON_ED25519_SIGNATURE_ALGORITHM,
     raw: topology,
+  };
+}
+
+/**
+ * Creates an external party using an external Ed25519 signer.
+ *
+ * Use this when the private key is held by a wallet service or browser wallet. The SDK prepares Canton topology, passes
+ * the multihash to `signMultiHash`, validates the returned signature against the submitted public key, and submits the
+ * allocation.
+ */
+export async function createExternalPartyWithSigner(
+  options: CreateExternalPartyWithSignerOptions
+): Promise<CreatedExternalPartyWithSigner> {
+  const publicKeyBase64 = normalizeEd25519PublicKeyForCanton(options.publicKeyBase64);
+  const prepared = await prepareExternalPartyOnboarding({
+    ledgerClient: options.ledgerClient,
+    synchronizerId: options.synchronizerId,
+    partyHint: options.partyHint,
+    publicKeyBase64,
+    ...(options.localParticipantObservationOnly !== undefined
+      ? { localParticipantObservationOnly: options.localParticipantObservationOnly }
+      : {}),
+    ...(options.otherConfirmingParticipantUids !== undefined
+      ? { otherConfirmingParticipantUids: options.otherConfirmingParticipantUids }
+      : {}),
+    ...(options.confirmationThreshold !== undefined ? { confirmationThreshold: options.confirmationThreshold } : {}),
+    ...(options.observingParticipantUids !== undefined
+      ? { observingParticipantUids: options.observingParticipantUids }
+      : {}),
+  });
+  const signature = await options.signMultiHash({
+    partyHint: options.partyHint,
+    partyId: prepared.partyId,
+    publicKeyBase64,
+    publicKeyFingerprint: prepared.publicKeyFingerprint,
+    synchronizerId: prepared.synchronizerId,
+    multiHashHex: prepared.multiHashHex,
+    multiHashBase64: hashHexToBase64(prepared.multiHashHex),
+    topologyTransactions: prepared.topologyTransactions,
+    signingAlgorithmSpec: prepared.signingAlgorithmSpec,
+  });
+  const submitted = await submitExternalPartyOnboarding({
+    ledgerClient: options.ledgerClient,
+    synchronizerId: prepared.synchronizerId,
+    partyId: prepared.partyId,
+    publicKeyBase64,
+    publicKeyFingerprint: prepared.publicKeyFingerprint,
+    multiHashHex: prepared.multiHashHex,
+    topologyTransactions: prepared.topologyTransactions,
+    multiHashSignatureBase64: normalizeExternalPartyHashSignature(signature),
+    ...(options.identityProviderId !== undefined ? { identityProviderId: options.identityProviderId } : {}),
+    ...(options.allowAlreadyExists !== undefined ? { allowAlreadyExists: options.allowAlreadyExists } : {}),
+  });
+
+  return {
+    partyId: submitted.partyId,
+    publicKeyFingerprint: prepared.publicKeyFingerprint,
+    publicKeyBase64,
+    synchronizerId: prepared.synchronizerId,
+    prepared,
+    submitted,
+    alreadyExisted: submitted.alreadyExisted,
   };
 }
 
@@ -168,6 +296,51 @@ export async function submitExternalPartyOnboarding(
       alreadyExisted: true,
     };
   }
+}
+
+function normalizeExternalPartyHashSignature(signature: ExternalPartyHashSignature): string {
+  if ('signatureBase64' in signature) {
+    return encodeSignatureBytes(decodeBase64Signature(signature.signatureBase64));
+  }
+  if ('signatureHex' in signature) {
+    return encodeSignatureBytes(decodeHexSignature(signature.signatureHex));
+  }
+  return encodeSignatureBytes(Buffer.from(signature.signatureBytes));
+}
+
+function decodeBase64Signature(value: string): Buffer {
+  const normalized = value.trim().replace(/-/g, '+').replace(/_/g, '/');
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized) || normalized.length % 4 === 1) {
+    throw invalidExternalPartySignature();
+  }
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+  const decoded = Buffer.from(padded, 'base64');
+  if (decoded.toString('base64').replace(/=+$/, '') !== normalized.replace(/=+$/, '')) {
+    throw invalidExternalPartySignature();
+  }
+  return decoded;
+}
+
+function decodeHexSignature(value: string): Buffer {
+  const normalized = value.trim().replace(/^0x/i, '');
+  if (!/^[0-9a-fA-F]+$/.test(normalized) || normalized.length % 2 !== 0) {
+    throw invalidExternalPartySignature();
+  }
+  return Buffer.from(normalized, 'hex');
+}
+
+function encodeSignatureBytes(signature: Buffer): string {
+  if (signature.length !== 64) {
+    throw invalidExternalPartySignature(signature.length);
+  }
+  return signature.toString('base64');
+}
+
+function invalidExternalPartySignature(actualLength?: number): ValidationError {
+  return new ValidationError('External-party signer must return a 64-byte Ed25519 signature', {
+    ...(actualLength !== undefined ? { actualLength } : {}),
+    expectedLength: 64,
+  });
 }
 
 /** Lists party ids whose suffix matches the supplied Ed25519 public key fingerprint. */

--- a/test/unit/external-signing/external-party-onboarding.test.ts
+++ b/test/unit/external-signing/external-party-onboarding.test.ts
@@ -11,6 +11,7 @@ import {
   CANTON_EC_CURVE25519_PUBLIC_KEY_SPEC,
   CANTON_ED25519_SIGNATURE_ALGORITHM,
   CANTON_RAW_SIGNATURE_FORMAT,
+  createExternalPartyWithSigner,
   getExternalPartyIdForHintAndPublicKey,
   listExternalPartyIdsForPublicKey,
   prepareExternalPartyOnboarding,
@@ -24,6 +25,7 @@ const createSigningFixture = (): {
   readonly publicKeyFingerprint: string;
   readonly partyId: string;
   readonly signMultiHash: () => string;
+  readonly signMultiHashHex: () => string;
 } => {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519');
   const publicKeyBase64 = Buffer.from(publicKey.export({ format: 'der', type: 'spki' }))
@@ -35,34 +37,36 @@ const createSigningFixture = (): {
     publicKeyFingerprint,
     partyId: buildExternalPartyId('privy-test', publicKeyFingerprint),
     signMultiHash: () => sign(null, Buffer.from(MULTI_HASH_HEX, 'hex'), privateKey).toString('base64'),
+    signMultiHashHex: () => sign(null, Buffer.from(MULTI_HASH_HEX, 'hex'), privateKey).toString('hex'),
   };
 };
 
-const createMockLedgerClient = (fixture = createSigningFixture()): jest.Mocked<LedgerJsonApiClient> =>
-  ({
-    generateExternalPartyTopology: jest.fn().mockResolvedValue({
-      partyId: fixture.partyId,
-      multiHash: Buffer.from(MULTI_HASH_HEX, 'hex').toString('base64'),
-      topologyTransactions: ['topology-tx-1', 'topology-tx-2'],
-    }),
-    allocateExternalParty: jest.fn().mockResolvedValue({
-      partyId: fixture.partyId,
-    }),
-    getPartyDetails: jest.fn().mockResolvedValue({
-      partyDetails: {
-        party: fixture.partyId,
-        isLocal: true,
-      },
-    }),
-    listParties: jest.fn().mockResolvedValue({
-      partyDetails: [
-        { party: fixture.partyId },
-        { party: buildExternalPartyId('another-prefix', fixture.publicKeyFingerprint) },
-        { party: `other::1220${'aa'.repeat(32)}` },
-        { party: fixture.partyId },
-      ],
-    }),
-  }) as unknown as jest.Mocked<LedgerJsonApiClient>;
+const createMockLedgerClient = (fixture = createSigningFixture()): jest.Mocked<LedgerJsonApiClient> => {
+  const ledgerClient = Object.create(null) as jest.Mocked<LedgerJsonApiClient>;
+  ledgerClient.generateExternalPartyTopology = jest.fn().mockResolvedValue({
+    partyId: fixture.partyId,
+    multiHash: Buffer.from(MULTI_HASH_HEX, 'hex').toString('base64'),
+    topologyTransactions: ['topology-tx-1', 'topology-tx-2'],
+  });
+  ledgerClient.allocateExternalParty = jest.fn().mockResolvedValue({
+    partyId: fixture.partyId,
+  });
+  ledgerClient.getPartyDetails = jest.fn().mockResolvedValue({
+    partyDetails: {
+      party: fixture.partyId,
+      isLocal: true,
+    },
+  });
+  ledgerClient.listParties = jest.fn().mockResolvedValue({
+    partyDetails: [
+      { party: fixture.partyId },
+      { party: buildExternalPartyId('another-prefix', fixture.publicKeyFingerprint) },
+      { party: `other::1220${'aa'.repeat(32)}` },
+      { party: fixture.partyId },
+    ],
+  });
+  return ledgerClient;
+};
 
 describe('external-party onboarding helpers', () => {
   it('prepares topology with normalized Canton public key metadata', async () => {
@@ -107,7 +111,7 @@ describe('external-party onboarding helpers', () => {
       partyId: `wrong::1220${'aa'.repeat(32)}`,
       multiHash: MULTI_HASH_HEX,
       topologyTransactions: ['topology-tx'],
-    } as never);
+    });
 
     await expect(
       prepareExternalPartyOnboarding({
@@ -152,6 +156,96 @@ describe('external-party onboarding helpers', () => {
       raw: { partyId: fixture.partyId },
       alreadyExisted: false,
     });
+  });
+
+  it('creates an external party with an external signer callback returning hex', async () => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const signMultiHash = jest.fn(() => ({ signatureHex: fixture.signMultiHashHex() }));
+
+    const created = await createExternalPartyWithSigner({
+      ledgerClient,
+      synchronizerId: 'global-domain::sync',
+      partyHint: 'privy-test',
+      publicKeyBase64: fixture.publicKeyBase64,
+      identityProviderId: 'custom-idp',
+      signMultiHash,
+    });
+
+    expect(signMultiHash).toHaveBeenCalledWith({
+      partyHint: 'privy-test',
+      partyId: fixture.partyId,
+      publicKeyBase64: normalizeEd25519PublicKeyForCanton(fixture.publicKeyBase64),
+      publicKeyFingerprint: fixture.publicKeyFingerprint,
+      synchronizerId: 'global-domain::sync',
+      multiHashHex: MULTI_HASH_HEX,
+      multiHashBase64: Buffer.from(MULTI_HASH_HEX, 'hex').toString('base64'),
+      topologyTransactions: ['topology-tx-1', 'topology-tx-2'],
+      signingAlgorithmSpec: CANTON_ED25519_SIGNATURE_ALGORITHM,
+    });
+    expect(ledgerClient.allocateExternalParty).toHaveBeenCalledWith({
+      synchronizer: 'global-domain::sync',
+      identityProviderId: 'custom-idp',
+      onboardingTransactions: [{ transaction: 'topology-tx-1' }, { transaction: 'topology-tx-2' }],
+      multiHashSignatures: [
+        {
+          format: CANTON_RAW_SIGNATURE_FORMAT,
+          signature: fixture.signMultiHash(),
+          signedBy: fixture.publicKeyFingerprint,
+          signingAlgorithmSpec: CANTON_ED25519_SIGNATURE_ALGORITHM,
+        },
+      ],
+    });
+    expect(created).toMatchObject({
+      partyId: fixture.partyId,
+      publicKeyFingerprint: fixture.publicKeyFingerprint,
+      publicKeyBase64: normalizeEd25519PublicKeyForCanton(fixture.publicKeyBase64),
+      synchronizerId: 'global-domain::sync',
+      alreadyExisted: false,
+    });
+  });
+
+  it('forwards multi-hosting options through external signer party creation', async () => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+
+    await createExternalPartyWithSigner({
+      ledgerClient,
+      synchronizerId: 'global-domain::sync',
+      partyHint: 'privy-test',
+      publicKeyBase64: fixture.publicKeyBase64,
+      localParticipantObservationOnly: true,
+      otherConfirmingParticipantUids: ['participant-1'],
+      confirmationThreshold: 1,
+      observingParticipantUids: ['observer-1'],
+      signMultiHash: () => ({ signatureBase64: fixture.signMultiHash() }),
+    });
+
+    expect(ledgerClient.generateExternalPartyTopology).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localParticipantObservationOnly: true,
+        otherConfirmingParticipantUids: ['participant-1'],
+        confirmationThreshold: 1,
+        observingParticipantUids: ['observer-1'],
+      })
+    );
+  });
+
+  it('rejects invalid external signer output before allocating', async () => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+
+    await expect(
+      createExternalPartyWithSigner({
+        ledgerClient,
+        synchronizerId: 'global-domain::sync',
+        partyHint: 'privy-test',
+        publicKeyBase64: fixture.publicKeyBase64,
+        signMultiHash: () => ({ signatureHex: 'deadbeef' }),
+      })
+    ).rejects.toThrow('External-party signer must return a 64-byte Ed25519 signature');
+
+    expect(ledgerClient.allocateExternalParty).not.toHaveBeenCalled();
   });
 
   it('does not allocate when the submitted multi-hash signature is invalid', async () => {

--- a/test/unit/external-signing/external-party-onboarding.test.ts
+++ b/test/unit/external-signing/external-party-onboarding.test.ts
@@ -109,6 +109,7 @@ describe('external-party onboarding helpers', () => {
     const ledgerClient = createMockLedgerClient(fixture);
     ledgerClient.generateExternalPartyTopology.mockResolvedValueOnce({
       partyId: `wrong::1220${'aa'.repeat(32)}`,
+      publicKeyFingerprint: `1220${'aa'.repeat(32)}`,
       multiHash: MULTI_HASH_HEX,
       topologyTransactions: ['topology-tx'],
     });


### PR DESCRIPTION
## Summary

- Add `createExternalPartyWithSigner` for wallet-service/browser-wallet external-party onboarding.
- Normalize signer output from base64, hex, or raw bytes into the Canton allocation signature shape.
- Forward multi-hosting topology options through `prepareExternalPartyOnboarding`.
- Extend external-party onboarding unit coverage for the external signer path.

## Context

This lets API consumers keep wallet-specific lifecycle and persistence in the app while relying on `canton-node-sdk` for the reusable Canton topology/signature/allocation sequence.

## Validation

- `npm test -- test/unit/external-signing/external-party-onboarding.test.ts --runInBand`
- `npm test -- test/unit/external-signing --runInBand`
- `npx prettier --check src/utils/external-signing/external-party-onboarding.ts test/unit/external-signing/external-party-onboarding.test.ts`
- `npx eslint src/utils/external-signing/external-party-onboarding.ts test/unit/external-signing/external-party-onboarding.test.ts`

## Known local validation gap

- `npm run build:core` and `npm run build:lint` are blocked in this fresh worktree by missing generated OpenAPI source modules under `generated/...` after running the generation scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Canton external-party allocation and signature validation; mistakes could block onboarding or accept bad signatures, though existing verify/submit paths are reused and invalid signatures are rejected before allocate.
> 
> **Overview**
> Adds **`createExternalPartyWithSigner`**, a single entry point for wallet-held Ed25519 keys: prepare topology, invoke a **`signMultiHash`** callback with hash context (hex + base64), normalize signer output, verify, and allocate. Signer results may be **base64, hex, or raw bytes**; invalid lengths fail before allocation.
> 
> **`prepareExternalPartyOnboarding`** (and the new helper) now accept optional **multi-hosting** fields—local observation-only, confirming/observing participant UIDs, and confirmation threshold—and pass them into topology generation.
> 
> Unit tests cover the signer path, multi-host forwarding, and invalid signer output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bad89ddffac0478349837afb01dfc22bb418d916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->