### PR TITLE
[codex] Add synchronizer usability helpers

### DIFF
--- a/src/utils/party-readiness/index.ts
+++ b/src/utils/party-readiness/index.ts
@@ -66,6 +66,26 @@ export interface CommonPartySynchronizerReadiness extends CommonPartySynchronize
   readonly synchronizerId: string;
 }
 
+export interface ResolveActiveSubmissionSynchronizerOptions {
+  readonly ledgerClient: PartySynchronizerReadinessLedgerClient;
+  readonly anchorParty: string;
+  readonly parties?: readonly string[];
+  readonly participantId?: string;
+}
+
+export interface WaitForPartyCanSubmitOptions extends PartySynchronizerReadinessOptions {
+  readonly delaysMs?: readonly number[];
+  readonly onCheckError?: (
+    error: unknown,
+    context: {
+      readonly party: string;
+      readonly synchronizerId: string;
+      readonly delayMs: number;
+      readonly attempt: number;
+    }
+  ) => void | Promise<void>;
+}
+
 export async function listConnectedSynchronizerIds(
   options: ListConnectedSynchronizerIdsOptions
 ): Promise<PartyConnectedSynchronizers> {
@@ -113,6 +133,10 @@ export async function checkPartySynchronizerReadiness(
         : {}),
     raw: connected.raw,
   };
+}
+
+export async function partyCanSubmitOnSynchronizer(options: PartySynchronizerReadinessOptions): Promise<boolean> {
+  return (await checkPartySynchronizerReadiness(options)).ready;
 }
 
 export async function assertPartySynchronizerReady(
@@ -225,6 +249,106 @@ export async function assertCommonSynchronizerReady(
   };
 }
 
+export async function resolveActiveSubmissionSynchronizer(
+  options: ResolveActiveSubmissionSynchronizerOptions
+): Promise<string> {
+  const anchorParty = validateRequiredString('anchorParty', options.anchorParty);
+  const parties = normalizeOptionalPartyList(options.parties);
+  const participantId =
+    options.participantId === undefined ? undefined : validateRequiredString('participantId', options.participantId);
+  const anchorSynchronizers = await listConnectedSynchronizerIds({
+    ledgerClient: options.ledgerClient,
+    party: anchorParty,
+    ...(participantId !== undefined ? { participantId } : {}),
+  });
+  const anchorSubmissionSynchronizerIds = anchorSynchronizers.synchronizers
+    .filter((synchronizer) => canSubmitWithPermission(synchronizer.permission))
+    .map((synchronizer) => synchronizer.synchronizerId);
+
+  if (anchorSubmissionSynchronizerIds.length === 0) {
+    throw new OperationError(
+      'Canton anchor party is not connected to a submission-capable synchronizer',
+      OperationErrorCode.MISSING_DOMAIN_ID,
+      {
+        anchorParty,
+        connectedSynchronizerIds: anchorSynchronizers.synchronizerIds,
+      }
+    );
+  }
+
+  const uniqueParties = parties.filter((party) => party !== anchorParty);
+  const partySynchronizers = await Promise.all(
+    uniqueParties.map(async (party) =>
+      listConnectedSynchronizerIds({
+        ledgerClient: options.ledgerClient,
+        party,
+        ...(participantId !== undefined ? { participantId } : {}),
+      })
+    )
+  );
+  const partySubmissionSynchronizerIdSets = partySynchronizers.map(
+    (partyResult) =>
+      new Set(
+        partyResult.synchronizers
+          .filter((synchronizer) => canSubmitWithPermission(synchronizer.permission))
+          .map((synchronizer) => synchronizer.synchronizerId)
+      )
+  );
+  const synchronizerId = anchorSubmissionSynchronizerIds.find((candidate) =>
+    partySubmissionSynchronizerIdSets.every((ids) => ids.has(candidate))
+  );
+
+  if (!synchronizerId) {
+    throw new OperationError(
+      'Canton parties do not share a submission-capable synchronizer with the anchor party',
+      OperationErrorCode.MISSING_DOMAIN_ID,
+      {
+        anchorParty,
+        parties,
+        anchorSynchronizerIds: anchorSynchronizers.synchronizerIds,
+        partySynchronizers: partySynchronizers.map((partyResult) => ({
+          party: partyResult.party,
+          synchronizerIds: partyResult.synchronizerIds,
+        })),
+      }
+    );
+  }
+
+  return synchronizerId;
+}
+
+export async function waitForPartyCanSubmit(options: WaitForPartyCanSubmitOptions): Promise<boolean> {
+  const party = validateRequiredString('party', options.party);
+  const synchronizerId = validateRequiredString('synchronizerId', options.synchronizerId);
+  const delaysMs = normalizeWaitDelays(options.delaysMs);
+
+  for (let attempt = 0; attempt < delaysMs.length; attempt += 1) {
+    const delayMs = delaysMs[attempt] ?? 0;
+    if (delayMs > 0) await delay(delayMs);
+    try {
+      if (
+        await partyCanSubmitOnSynchronizer({
+          ledgerClient: options.ledgerClient,
+          party,
+          synchronizerId,
+          ...(options.participantId !== undefined ? { participantId: options.participantId } : {}),
+        })
+      ) {
+        return true;
+      }
+    } catch (error) {
+      await options.onCheckError?.(error, {
+        party,
+        synchronizerId,
+        delayMs,
+        attempt,
+      });
+    }
+  }
+
+  return false;
+}
+
 export function assertSingleConnectedSynchronizerId(raw: unknown): string {
   const synchronizerId = readSingleConnectedSynchronizerId(raw);
   if (synchronizerId) return synchronizerId;
@@ -316,6 +440,11 @@ function normalizePartyList(parties: readonly string[]): readonly string[] {
   return normalized;
 }
 
+function normalizeOptionalPartyList(parties: readonly string[] | undefined): readonly string[] {
+  if (parties === undefined) return [];
+  return [...new Set(parties.map((party) => validateRequiredString('parties', party)))];
+}
+
 function intersectSynchronizerIds(synchronizerGroups: ReadonlyArray<readonly CantonConnectedSynchronizer[]>): string[] {
   const [firstGroup, ...restGroups] = synchronizerGroups;
   if (!firstGroup) return [];
@@ -329,6 +458,23 @@ function intersectSynchronizerIds(synchronizerGroups: ReadonlyArray<readonly Can
   }
 
   return [...common].sort();
+}
+
+function normalizeWaitDelays(delaysMs: readonly number[] | undefined): readonly number[] {
+  const delays = delaysMs ?? [0, 1_000, 2_000, 4_000];
+  if (delays.length === 0) {
+    throw new ValidationError('delaysMs must include at least one delay');
+  }
+  for (const delayMs of delays) {
+    if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+      throw new ValidationError('delaysMs entries must be non-negative safe integers', { delayMs });
+    }
+  }
+  return delays;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function validateRequiredString(name: string, value: string): string {

--- a/test/unit/party-readiness.test.ts
+++ b/test/unit/party-readiness.test.ts
@@ -4,9 +4,12 @@ import {
   canSubmitWithPermission,
   checkPartySynchronizerReadiness,
   listConnectedSynchronizerIds,
+  partyCanSubmitOnSynchronizer,
   readConnectedSynchronizers,
   readSingleConnectedSynchronizerId,
+  resolveActiveSubmissionSynchronizer,
   resolveCommonSynchronizerIds,
+  waitForPartyCanSubmit,
   type PartySynchronizerReadinessLedgerClient,
 } from '../../src';
 
@@ -151,6 +154,32 @@ describe('party synchronizer readiness helpers', (): void => {
     });
   });
 
+  it('exposes a boolean helper for submit readiness on a synchronizer', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'issuer::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'global-domain::sync', permission: 'PARTICIPANT_PERMISSION_SUBMISSION' },
+          { synchronizerId: 'observer-domain::sync', permission: 'PARTICIPANT_PERMISSION_OBSERVATION' },
+        ],
+      },
+    });
+
+    await expect(
+      partyCanSubmitOnSynchronizer({
+        ledgerClient,
+        party: 'issuer::party',
+        synchronizerId: 'global-domain::sync',
+      })
+    ).resolves.toBe(true);
+    await expect(
+      partyCanSubmitOnSynchronizer({
+        ledgerClient,
+        party: 'issuer::party',
+        synchronizerId: 'observer-domain::sync',
+      })
+    ).resolves.toBe(false);
+  });
+
   it('asserts party readiness with actionable failures', async (): Promise<void> => {
     const ledgerClient = createMockLedgerClient({
       'external::party': {
@@ -219,6 +248,71 @@ describe('party synchronizer readiness helpers', (): void => {
     });
   });
 
+  it('resolves the active submission synchronizer using anchor-party order', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'transfer-agent::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'sync-b', permission: 'Submission' },
+          { synchronizerId: 'sync-a', permission: 'Submission' },
+        ],
+      },
+      'issuer::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'sync-a', permission: 'Submission' },
+          { synchronizerId: 'sync-b', permission: 'Submission' },
+        ],
+      },
+      'external::party': {
+        connectedSynchronizers: [{ synchronizerId: 'sync-b', permission: 'Submission' }],
+      },
+    });
+
+    await expect(
+      resolveActiveSubmissionSynchronizer({
+        ledgerClient,
+        anchorParty: 'transfer-agent::party',
+        parties: ['issuer::party', 'external::party'],
+      })
+    ).resolves.toBe('sync-b');
+  });
+
+  it('resolves the active submission synchronizer for an anchor party without counterparties', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'transfer-agent::party': {
+        connectedSynchronizers: [
+          { synchronizerId: 'observer-domain::sync', permission: 'Observation' },
+          { synchronizerId: 'global-domain::sync', permission: 'Submission' },
+        ],
+      },
+    });
+
+    await expect(
+      resolveActiveSubmissionSynchronizer({
+        ledgerClient,
+        anchorParty: 'transfer-agent::party',
+      })
+    ).resolves.toBe('global-domain::sync');
+  });
+
+  it('reports active submission synchronizer failures with party context', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'transfer-agent::party': {
+        connectedSynchronizers: [{ synchronizerId: 'sync-a', permission: 'Submission' }],
+      },
+      'external::party': {
+        connectedSynchronizers: [{ synchronizerId: 'sync-b', permission: 'Submission' }],
+      },
+    });
+
+    await expect(
+      resolveActiveSubmissionSynchronizer({
+        ledgerClient,
+        anchorParty: 'transfer-agent::party',
+        parties: ['external::party'],
+      })
+    ).rejects.toThrow('do not share a submission-capable synchronizer');
+  });
+
   it('asserts common synchronizer readiness for an expected synchronizer', async (): Promise<void> => {
     const ledgerClient = createMockLedgerClient({
       'transfer-agent::party': {
@@ -249,6 +343,53 @@ describe('party synchronizer readiness helpers', (): void => {
         synchronizerId: 'global-domain::sync',
       })
     ).rejects.toThrow('not ready on the requested synchronizer');
+  });
+
+  it('waits for a party to become submission-capable and ignores transient check errors', async (): Promise<void> => {
+    const onCheckError = jest.fn();
+    const ledgerClient: MockLedgerClient = {
+      getConnectedSynchronizers: jest
+        .fn<
+          ReturnType<PartySynchronizerReadinessLedgerClient['getConnectedSynchronizers']>,
+          [{ readonly party: string }]
+        >()
+        .mockRejectedValueOnce(new Error('ledger unavailable'))
+        .mockResolvedValueOnce({
+          connectedSynchronizers: [{ synchronizerId: 'global-domain::sync', permission: 'Observation' }],
+        })
+        .mockResolvedValueOnce({
+          connectedSynchronizers: [{ synchronizerId: 'global-domain::sync', permission: 'Submission' }],
+        }),
+    };
+
+    await expect(
+      waitForPartyCanSubmit({
+        ledgerClient,
+        party: 'external::party',
+        synchronizerId: 'global-domain::sync',
+        delaysMs: [0, 0, 0],
+        onCheckError,
+      })
+    ).resolves.toBe(true);
+    expect(onCheckError).toHaveBeenCalledTimes(1);
+    expect(ledgerClient.getConnectedSynchronizers).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false when party submit readiness does not settle within the wait window', async (): Promise<void> => {
+    const ledgerClient = createMockLedgerClient({
+      'external::party': {
+        connectedSynchronizers: [{ synchronizerId: 'global-domain::sync', permission: 'Observation' }],
+      },
+    });
+
+    await expect(
+      waitForPartyCanSubmit({
+        ledgerClient,
+        party: 'external::party',
+        synchronizerId: 'global-domain::sync',
+        delaysMs: [0, 0],
+      })
+    ).resolves.toBe(false);
   });
 
   it('handles single-synchronizer and permission helper edge cases', (): void => {


### PR DESCRIPTION
## Summary
- add partyCanSubmitOnSynchronizer, resolveActiveSubmissionSynchronizer, and waitForPartyCanSubmit on top of party-readiness
- preserve anchor-party ordering when resolving an active submission synchronizer
- add unit coverage for boolean readiness, active synchronizer resolution, and bounded wait behavior

## Validation
- npm test -- --runTestsByPath test/unit/party-readiness.test.ts
- npm run build
- npx prettier --check src/utils/party-readiness/index.ts test/unit/party-readiness.test.ts

Note: full npm run format still reports pre-existing formatting drift in unrelated origin/main files, so this PR keeps the diff scoped to readiness helpers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New synchronizer selection and polling logic affects where Canton submissions are routed; mistakes could block or mis-target ledger operations, though behavior is covered by unit tests and reuses existing readiness checks.
> 
> **Overview**
> Adds **party-readiness** helpers for choosing a synchronizer and waiting until a party can submit.
> 
> **`partyCanSubmitOnSynchronizer`** returns a boolean from existing readiness checks. **`resolveActiveSubmissionSynchronizer`** picks the first submission-capable synchronizer on an anchor party that every optional counterparty can also submit on (anchor list order preserved), with **`OperationError`** context when none match. **`waitForPartyCanSubmit`** polls with configurable delays (default 0/1s/2s/4s), optional **`onCheckError`** for transient ledger failures, and returns **`false`** if readiness never settles.
> 
> Unit tests cover the boolean helper, anchor ordering, failure messages, and wait success/timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e381747faf07a78390df10c949204eac123e683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->