### PR TITLE
Harden canton-node-sdk package artifact

### DIFF
--- a/.github/workflows/package-artifacts.yml
+++ b/.github/workflows/package-artifacts.yml
@@ -1,0 +1,33 @@
+name: Check Package Artifacts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-package-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.14'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Initialize Splice Submodule
+        run: git submodule update --init --depth 1 libs/splice
+
+      - name: Build package
+        run: npm run build
+
+      - name: Check package artifacts
+        run: npm run check:package-artifacts

--- a/.github/workflows/package-artifacts.yml
+++ b/.github/workflows/package-artifacts.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-package-artifacts:
     runs-on: ubuntu-latest
@@ -20,6 +23,10 @@ jobs:
         with:
           node-version: '22.14'
 
+      - name: Upgrade npm
+        # Keep PR package checks aligned with the trusted-publishing npm CLI.
+        run: npm install --global npm@^11.10.0
+
       - name: Install dependencies
         run: npm i
 
@@ -29,5 +36,5 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Check package artifacts
+      - name: Prepack and check package artifacts
         run: npm run check:package-artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Check package artifacts
+      - name: Prepack and check package artifacts
         run: npm run check:package-artifacts
 
       - name: Prepare release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Check package artifacts
+        run: npm run check:package-artifacts
+
       - name: Prepare release
         run: npm run prepare-release
 
@@ -63,4 +66,3 @@ jobs:
           git config --local user.name "GitHub Action"
           git tag -a "v$NEW_VERSION" -m "$CHANGELOG"
           git push origin "v$NEW_VERSION"
-

--- a/package.json
+++ b/package.json
@@ -21,12 +21,16 @@
   "author": "Fairmint",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
+  "files": [
+    "build/**"
+  ],
   "scripts": {
     "artifacts:manifest": "mkdir -p artifacts && npm pack --dry-run --json --ignore-scripts > /tmp/npm-pack.json 2>/dev/null && jq -r '.[0].files[].path' /tmp/npm-pack.json | sort | tsx scripts/collapse-manifest.ts > artifacts/npm-manifest.txt",
     "build": "npm run build:core && npm run build:lint",
     "build:core": "npm run generate:openapi-types && npm run build:core:generate-client-methods && tsc",
     "build:core:generate-client-methods": "tsx scripts/generate-all-client-methods.ts",
     "build:lint": "tsc -p tsconfig.lint.json",
+    "check:package-artifacts": "tsx scripts/check-package-artifacts.ts",
     "clean": "rm -rf build",
     "example:connect": "tsx examples/localnet-with-oauth2.ts",
     "fix": "npm run lint:fix && npm run format:fix",

--- a/scripts/check-package-artifacts.ts
+++ b/scripts/check-package-artifacts.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 
-import { spawnSync } from 'child_process';
+import { spawnSync, type SpawnSyncReturns } from 'child_process';
 
 interface NpmPackFile {
   path: string;
@@ -20,10 +20,20 @@ interface NpmPackResult {
 
 const DEFAULT_MAX_UNPACKED_BYTES = 15 * 1024 * 1024;
 const configuredMaxUnpackedBytes = process.env['MAX_PACKAGE_UNPACKED_BYTES'];
-const maxUnpackedBytes = Number.parseInt(configuredMaxUnpackedBytes ?? String(DEFAULT_MAX_UNPACKED_BYTES), 10);
+const maxUnpackedBytes = parseMaxUnpackedBytes(configuredMaxUnpackedBytes);
 
 function formatBytes(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function parseMaxUnpackedBytes(rawValue: string | undefined): number {
+  const parsedValue = rawValue === undefined ? DEFAULT_MAX_UNPACKED_BYTES : Number(rawValue);
+
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(`MAX_PACKAGE_UNPACKED_BYTES must be a positive integer in bytes, got ${JSON.stringify(rawValue)}`);
+  }
+
+  return parsedValue;
 }
 
 function forbiddenPackagePathReason(packagePath: string): string | null {
@@ -48,14 +58,43 @@ function parsePackResults(stdout: string): NpmPackResult[] {
   }
 }
 
+function spawnFailureDetails(command: string, result: SpawnSyncReturns<string>): string {
+  const details = [`status ${result.status ?? 'unknown'}`];
+
+  if (result.signal) {
+    details.push(`signal ${result.signal}`);
+  }
+  if (result.error) {
+    details.push(`error ${result.error.message}`);
+  }
+
+  return `${command} failed (${details.join(', ')})`;
+}
+
+function throwIfSpawnFailed(command: string, result: SpawnSyncReturns<string>): void {
+  if (result.status === 0 && !result.signal && !result.error) {
+    return;
+  }
+
+  if (result.stderr) {
+    console.error(result.stderr);
+  }
+  if (result.stdout) {
+    console.error(result.stdout);
+  }
+
+  throw new Error(spawnFailureDetails(command, result));
+}
+
+const prepack = spawnSync('npm', ['run', 'prepack'], {
+  encoding: 'utf8',
+});
+throwIfSpawnFailed('npm run prepack', prepack);
+
 const pack = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
   encoding: 'utf8',
 });
-
-if (pack.status !== 0) {
-  console.error(pack.stderr || pack.stdout);
-  throw new Error(`npm pack failed with status ${pack.status ?? 'unknown'}`);
-}
+throwIfSpawnFailed('npm pack --dry-run --json --ignore-scripts', pack);
 
 const [result] = parsePackResults(pack.stdout);
 if (!result) {
@@ -64,11 +103,7 @@ if (!result) {
 
 const errors: string[] = [];
 
-if (Number.isNaN(maxUnpackedBytes) || maxUnpackedBytes <= 0) {
-  errors.push(
-    `MAX_PACKAGE_UNPACKED_BYTES must be a positive integer, got ${JSON.stringify(configuredMaxUnpackedBytes)}`
-  );
-} else if (result.unpackedSize > maxUnpackedBytes) {
+if (result.unpackedSize > maxUnpackedBytes) {
   errors.push(
     `package unpacked size ${formatBytes(result.unpackedSize)} exceeds limit ${formatBytes(maxUnpackedBytes)}`
   );

--- a/scripts/check-package-artifacts.ts
+++ b/scripts/check-package-artifacts.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env tsx
+
+import { spawnSync } from 'child_process';
+
+interface NpmPackFile {
+  path: string;
+  size: number;
+  mode: number;
+}
+
+interface NpmPackResult {
+  id: string;
+  name: string;
+  version: string;
+  size: number;
+  unpackedSize: number;
+  filename: string;
+  files: NpmPackFile[];
+}
+
+const DEFAULT_MAX_UNPACKED_BYTES = 15 * 1024 * 1024;
+const configuredMaxUnpackedBytes = process.env['MAX_PACKAGE_UNPACKED_BYTES'];
+const maxUnpackedBytes = Number.parseInt(configuredMaxUnpackedBytes ?? String(DEFAULT_MAX_UNPACKED_BYTES), 10);
+
+function formatBytes(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function forbiddenPackagePathReason(packagePath: string): string | null {
+  if (packagePath.endsWith('.dar')) return 'DAML DAR files are not runtime SDK artifacts';
+  if (packagePath === 'libs' || packagePath.startsWith('libs/')) {
+    return 'submodules under libs/ must not be published';
+  }
+  if (packagePath === 'node_modules' || packagePath.startsWith('node_modules/')) {
+    return 'node_modules must not be published';
+  }
+  if (packagePath === 'core' || packagePath.startsWith('core.')) {
+    return 'crash dumps must not be published';
+  }
+  return null;
+}
+
+function parsePackResults(stdout: string): NpmPackResult[] {
+  try {
+    return JSON.parse(stdout) as NpmPackResult[];
+  } catch (error) {
+    throw new Error(`npm pack did not return valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+const pack = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+  encoding: 'utf8',
+});
+
+if (pack.status !== 0) {
+  console.error(pack.stderr || pack.stdout);
+  throw new Error(`npm pack failed with status ${pack.status ?? 'unknown'}`);
+}
+
+const [result] = parsePackResults(pack.stdout);
+if (!result) {
+  throw new Error('npm pack returned no package metadata');
+}
+
+const errors: string[] = [];
+
+if (Number.isNaN(maxUnpackedBytes) || maxUnpackedBytes <= 0) {
+  errors.push(
+    `MAX_PACKAGE_UNPACKED_BYTES must be a positive integer, got ${JSON.stringify(configuredMaxUnpackedBytes)}`
+  );
+} else if (result.unpackedSize > maxUnpackedBytes) {
+  errors.push(
+    `package unpacked size ${formatBytes(result.unpackedSize)} exceeds limit ${formatBytes(maxUnpackedBytes)}`
+  );
+}
+
+const packagePaths = new Set(result.files.map((file) => file.path));
+for (const requiredPath of ['build/src/index.js', 'build/src/index.d.ts']) {
+  if (!packagePaths.has(requiredPath)) {
+    errors.push(`package is missing required runtime entry ${requiredPath}`);
+  }
+}
+
+for (const file of result.files) {
+  const reason = forbiddenPackagePathReason(file.path);
+  if (reason) {
+    errors.push(`${file.path}: ${reason}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`\n${result.name}@${result.version} package artifact check failed:\n`);
+  for (const error of errors) {
+    console.error(`  ✗ ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `✓ ${result.name}@${result.version} package artifact is ${formatBytes(result.unpackedSize)} unpacked across ${result.files.length} files`
+);

--- a/scripts/check-package-artifacts.ts
+++ b/scripts/check-package-artifacts.ts
@@ -91,10 +91,18 @@ const prepack = spawnSync('npm', ['run', 'prepack'], {
 });
 throwIfSpawnFailed('npm run prepack', prepack);
 
-const pack = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+const packArgs = [
+  'pack',
+  '--dry-run',
+  '--json',
+  // prepack already produced the publish-time build; keep this inspection step JSON-only.
+  '--ignore-scripts',
+];
+
+const pack = spawnSync('npm', packArgs, {
   encoding: 'utf8',
 });
-throwIfSpawnFailed('npm pack --dry-run --json --ignore-scripts', pack);
+throwIfSpawnFailed(`npm ${packArgs.join(' ')}`, pack);
 
 const [result] = parsePackResults(pack.stdout);
 if (!result) {


### PR DESCRIPTION
## Summary
- add an explicit `files` whitelist so the npm package only publishes `build/**` plus npm's automatic metadata files
- add `npm run check:package-artifacts` to fail on `.dar`, `libs/**`, `node_modules/**`, `core`/`core.*`, missing runtime entries, or package size over 15 MB
- run the guard in PR CI and before publish

## Validation
- `npm run build`
- `npm run check:package-artifacts` -> 7.28 MB unpacked, 1579 files

## Note
- `npm run lint:npm:check` still fails when the Splice submodule is checked out because upstream `libs/splice/**/package.json` files do not declare versions; this is unrelated to the publish artifact and pre-existing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to publish manifest whitelisting and CI/release gates; they do not alter runtime SDK code paths.
> 
> **Overview**
> Restricts what gets published to npm by whitelisting **`build/**`** in `package.json` and adding **`npm run check:package-artifacts`**, which runs `prepack`, inspects a dry-run pack, and fails if the tarball is over **15 MB** (configurable), is missing **`build/src/index.js`** / **`.d.ts`**, or includes forbidden paths (`.dar`, `libs/**`, `node_modules/**`, `core`/`core.*`).
> 
> A dedicated **Check Package Artifacts** workflow runs this on pull requests and pushes to `main`; the **publish** workflow runs the same check after build and before release prep and `npm publish`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b649d8dc54ecca7679c736185e0b8d9bcd6282d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->