### PR TITLE
Resolve canton-localnet package symlinks

### DIFF
--- a/bin/canton-localnet
+++ b/bin/canton-localnet
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PACKAGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+resolve_script_dir() {
+  local source="$1"
+  local dir=""
+
+  while [[ -L "${source}" ]]; do
+    dir="$(cd -P "$(dirname "${source}")" && pwd)"
+    source="$(readlink "${source}")"
+    if [[ "${source}" != /* ]]; then
+      source="${dir}/${source}"
+    fi
+  done
+
+  cd -P "$(dirname "${source}")" && pwd
+}
+
+PACKAGE_ROOT="$(cd "$(resolve_script_dir "${BASH_SOURCE[0]}")/.." && pwd)"
 LOCALNET_SCRIPT="${PACKAGE_ROOT}/scripts/localnet-cloud.sh"
 DEFAULT_QUICKSTART_REPO="https://github.com/digital-asset/cn-quickstart.git"
 DEFAULT_QUICKSTART_REF="46201cd27ee16c99f78ab97b7e6513c56f28e004"

--- a/scripts/check-package-artifacts.ts
+++ b/scripts/check-package-artifacts.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env tsx
 
 import { spawnSync, type SpawnSyncReturns } from 'child_process';
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 interface NpmPackFile {
   path: string;
@@ -86,6 +89,37 @@ function throwIfSpawnFailed(command: string, result: SpawnSyncReturns<string>): 
   throw new Error(spawnFailureDetails(command, result));
 }
 
+function verifyPackagedLocalnetBinary(): void {
+  const tempDir = mkdtempSync(join(tmpdir(), 'canton-node-sdk-package-'));
+
+  try {
+    const packageRoot = join(tempDir, 'node_modules', '@fairmint', 'canton-node-sdk');
+    const binDir = join(tempDir, 'node_modules', '.bin');
+    const localnetBin = join(packageRoot, 'bin', 'canton-localnet');
+    const localnetSymlink = join(binDir, 'canton-localnet');
+
+    mkdirSync(packageRoot, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    cpSync(join(process.cwd(), 'bin'), join(packageRoot, 'bin'), { recursive: true });
+    cpSync(join(process.cwd(), 'scripts'), join(packageRoot, 'scripts'), { recursive: true });
+    chmodSync(localnetBin, 0o755);
+    symlinkSync('../@fairmint/canton-node-sdk/bin/canton-localnet', localnetSymlink);
+
+    const logs = spawnSync(localnetSymlink, ['logs'], {
+      cwd: tempDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CANTON_LOCALNET_CACHE_DIR: join(tempDir, 'cache'),
+        HOME: join(tempDir, 'home'),
+      },
+    });
+    throwIfSpawnFailed('packaged canton-localnet logs', logs);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 const prepack = spawnSync('npm', ['run', 'prepack'], {
   encoding: 'utf8',
 });
@@ -118,7 +152,12 @@ if (result.unpackedSize > maxUnpackedBytes) {
 }
 
 const packagePaths = new Set(result.files.map((file) => file.path));
-for (const requiredPath of ['build/src/index.js', 'build/src/index.d.ts', 'bin/canton-localnet']) {
+for (const requiredPath of [
+  'build/src/index.js',
+  'build/src/index.d.ts',
+  'bin/canton-localnet',
+  'scripts/localnet-cloud.sh',
+]) {
   if (!packagePaths.has(requiredPath)) {
     errors.push(`package is missing required runtime entry ${requiredPath}`);
   }
@@ -138,6 +177,8 @@ if (errors.length > 0) {
   }
   process.exit(1);
 }
+
+verifyPackagedLocalnetBinary();
 
 console.log(
   `✓ ${result.name}@${result.version} package artifact is ${formatBytes(result.unpackedSize)} unpacked across ${result.files.length} files`


### PR DESCRIPTION
## Summary
- resolve the canton-localnet package root through npm's node_modules/.bin symlink before locating scripts/localnet-cloud.sh
- add a package-artifact guard that recreates the packaged node_modules/.bin shape and runs canton-localnet logs
- require scripts/localnet-cloud.sh in the published artifact manifest check

## Why
Consumer PRs using @fairmint/canton-node-sdk@0.0.224 invoke the binary through node_modules/.bin. The previous launcher resolved PACKAGE_ROOT from that symlink path, so CI looked for node_modules/scripts/localnet-cloud.sh instead of node_modules/@fairmint/canton-node-sdk/scripts/localnet-cloud.sh.

## Validation
- bash -n bin/canton-localnet scripts/localnet-cloud.sh
- npx prettier --check scripts/check-package-artifacts.ts
- git submodule update --init --depth 1 libs/splice
- npm run check:package-artifacts
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Launcher path resolution and publish-time smoke checks only; no auth, data, or runtime API behavior changes.
> 
> **Overview**
> Fixes **`canton-localnet`** when consumers run it via **`node_modules/.bin`**: the launcher now follows symlinks to resolve the real package directory before pointing at **`scripts/localnet-cloud.sh`**, instead of treating the `.bin` path as the package root.
> 
> **`check-package-artifacts`** now requires **`scripts/localnet-cloud.sh`** in the published tarball and runs a temp **`node_modules`** layout (mirroring npm’s `.bin` symlink) that executes **`canton-localnet logs`** so CI catches the same breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6981f531d8f563893a1f388f76cfcc5ca7e9db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->