### PR TITLE
Fix shared-secret localnet compose auth

### DIFF
--- a/scripts/localnet-cloud.sh
+++ b/scripts/localnet-cloud.sh
@@ -212,19 +212,28 @@ run_quickstart_make() {
 
 run_infra_compose() {
   local compose_args="$1"
+  local keycloak_compose_file=""
+  local keycloak_env_file=""
+  local keycloak_profile=""
+
+  if [[ "$(current_auth_mode)" == "oauth2" ]]; then
+    keycloak_compose_file='-f "${MODULES_DIR}/keycloak/compose.yaml"'
+    keycloak_env_file='--env-file "${MODULES_DIR}/keycloak/compose.env"'
+    keycloak_profile='--profile keycloak'
+  fi
 
   run_quickstart_command "docker compose \
     -f \"\${LOCALNET_DIR}/compose.yaml\" \
-    -f \"\${MODULES_DIR}/keycloak/compose.yaml\" \
+    ${keycloak_compose_file} \
     --env-file .env \
     --env-file .env.local \
     --env-file \"\${LOCALNET_DIR}/compose.env\" \
     --env-file \"\${LOCALNET_DIR}/env/common.env\" \
-    --env-file \"\${MODULES_DIR}/keycloak/compose.env\" \
+    ${keycloak_env_file} \
     --profile app-provider \
     --profile app-user \
     --profile sv \
-    --profile keycloak \
+    ${keycloak_profile} \
     ${compose_args}"
 }
 


### PR DESCRIPTION
## Summary
- only include Keycloak compose/env files when packaged LocalNet is configured for OAuth2
- preserve the shared-secret LocalNet auth env pointers so consumer JWT tests hit the intended auth service

## Why
Consumer quickstart PRs using @fairmint/canton-node-sdk@0.0.226 reached LocalNet readiness, but shared-secret integration tests received participant 401s with `No Key ID found`. The launcher was always appending `keycloak/compose.env`, which overrides `APP_PROVIDER_AUTH_ENV`/`APP_USER_AUTH_ENV`/`SV_AUTH_ENV` back to OAuth files even after setup writes `AUTH_MODE=shared-secret`.

## Validation
- `bash -n scripts/localnet-cloud.sh bin/canton-localnet scripts/localnet/localnet-cloud.sh`
- `npm run check:package-artifacts`
- targeted shell probe: shared-secret compose command has no Keycloak refs; OAuth2 compose command still includes Keycloak compose/env/profile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in the localnet launcher script; OAuth2 path unchanged and shared-secret fixes env wiring only.
> 
> **Overview**
> **`run_infra_compose` in `scripts/localnet-cloud.sh` no longer always wires in Keycloak.** Keycloak compose file, `keycloak/compose.env`, and the `keycloak` profile are appended only when `current_auth_mode` is `oauth2`.
> 
> In **shared-secret** LocalNet, skipping those args stops `keycloak/compose.env` from overriding `APP_*_AUTH_ENV` / `SV_AUTH_ENV` after setup sets `AUTH_MODE=shared-secret`, which had been causing participant **401** responses (`No Key ID found`) in consumer JWT integration tests. OAuth2 LocalNet behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a994c3f8593308cbfe28ec3b093802141b4d25a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->