### PR TITLE
ci: cache quickstart env setup

### DIFF
--- a/.github/workflows/test-cn-quickstart.yml
+++ b/.github/workflows/test-cn-quickstart.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Compute Quickstart Env Cache Key
+        id: quickstart-env-cache-key
+        run: |
+          set -euo pipefail
+          key="$(git ls-tree HEAD libs/splice libs/cn-quickstart | sha256sum | cut -d' ' -f1)"
+          echo "submodules=$key" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -43,6 +50,13 @@ jobs:
 
           init_submodule libs/splice --depth 1
           init_submodule libs/cn-quickstart --recursive
+
+      - name: Restore Quickstart Env Cache
+        id: quickstart-env-cache-restore
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ github.workspace }}/libs/cn-quickstart/quickstart/.env.local
+          key: quickstart-env-${{ runner.os }}-${{ hashFiles('.github/workflows/test-cn-quickstart.yml', 'package.json', 'package-lock.json', 'scripts/localnet-cloud.sh') }}-${{ steps.quickstart-env-cache-key.outputs.submodules }}
 
       - name: Restore Node Dependencies Cache
         id: node-cache-restore
@@ -72,6 +86,14 @@ jobs:
           npm run localnet:start
           echo "✓ CN-Quickstart started"
         timeout-minutes: 15
+
+      - name: Save Quickstart Env Cache
+        if: steps.quickstart-env-cache-restore.outputs.cache-hit != 'true'
+        id: quickstart-env-cache-save
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ github.workspace }}/libs/cn-quickstart/quickstart/.env.local
+          key: ${{ steps.quickstart-env-cache-restore.outputs.cache-primary-key }}
 
       - name: Save Node Dependencies Cache
         if: steps.node-cache-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- cache the generated `libs/cn-quickstart/quickstart/.env.local` in the CN quickstart workflow
- key the cache by runner OS, package files, workflow/script content, and the `libs/splice` + `libs/cn-quickstart` gitlinks
- keep the cache tiny and focused on skipping the measured setup/Gradle bootstrap path

## Baseline
Recent `main` quickstart runs still spend about 1m45-1m50 inside `cn-quickstart setup` before service startup:
- Run `28978458190`: setup begins `21:55:24`, Gradle download begins `21:55:24`, `.env.local` is ready `21:57:16`; `Start CN-Quickstart` total is 4m53s.
- Run `28978015660`: setup begins `21:47:15`, Gradle download begins `21:47:17`, `.env.local` is ready `21:49:00`; `Start CN-Quickstart` total is 4m47s.

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/test-cn-quickstart.yml`

After the first PR run populates the cache, I will rerun the workflow and post the measured cold vs warm delta.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 86885969c4b118a497139aa40f7e5fd70caa196a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved quickstart CI by caching the environment file used during CN-Quickstart runs.
  * Added automatic cache restore and save behavior to reduce repeated setup work.
  * Updated the cache key logic so it refreshes when relevant repository contents change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->