### PR TITLE
Enforce validator request schema parity

### DIFF
--- a/src/clients/validator-api/operations/v0/admin/create-external-party-setup-proposal.ts
+++ b/src/clients/validator-api/operations/v0/admin/create-external-party-setup-proposal.ts
@@ -1,15 +1,22 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+type CreateExternalPartySetupProposalRequest =
+  operations['createExternalPartySetupProposal']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated setup-proposal request. */
+export const CreateExternalPartySetupProposalParamsSchema =
+  createRequestSchema<CreateExternalPartySetupProposalRequest>()({
+    user_party_id: z.string().min(1),
+  });
 
 /** Create an ExternalPartySetupProposal contract for an external party. */
 export const CreateExternalPartySetupProposal = createApiOperation<
-  operations['createExternalPartySetupProposal']['requestBody']['content']['application/json'],
+  CreateExternalPartySetupProposalRequest,
   operations['createExternalPartySetupProposal']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    user_party_id: z.string().min(1),
-  }) as z.ZodType<operations['createExternalPartySetupProposal']['requestBody']['content']['application/json']>,
+  paramsSchema: CreateExternalPartySetupProposalParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) => `${apiUrl}/api/validator/v0/admin/external-party/setup-proposal`,
   buildRequestData: (params) => params,

--- a/src/clients/validator-api/operations/v0/admin/create-user.ts
+++ b/src/clients/validator-api/operations/v0/admin/create-user.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+type CreateUserRequest = operations['onboardUser']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated onboard-user request. */
+export const CreateUserParamsSchema = createRequestSchema<CreateUserRequest>()({
+  name: z.string(),
+  party_id: z.string().optional(),
+  createPartyIfMissing: z.boolean().optional(),
+});
 
 /**
  * Create a new user in the system
@@ -15,13 +24,10 @@ import { type operations } from '../../../../../generated/apps/validator/src/mai
  *   ```;
  */
 export const CreateUser = createApiOperation<
-  operations['onboardUser']['requestBody']['content']['application/json'],
+  CreateUserRequest,
   operations['onboardUser']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    name: z.string(),
-    party_id: z.string().optional(),
-  }) as z.ZodType<operations['onboardUser']['requestBody']['content']['application/json']>,
+  paramsSchema: CreateUserParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) => `${apiUrl}/api/validator/v0/admin/users`,
   buildRequestData: (params) => params,

--- a/src/clients/validator-api/operations/v0/admin/generate-external-party-topology.ts
+++ b/src/clients/validator-api/operations/v0/admin/generate-external-party-topology.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+type GenerateExternalPartyTopologyRequest =
+  operations['generateExternalPartyTopology']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated topology request. */
+export const GenerateExternalPartyTopologyParamsSchema = createRequestSchema<GenerateExternalPartyTopologyRequest>()({
+  party_hint: z.string(),
+  public_key: z.string(),
+});
 
 /**
  * Generate external party topology transactions
@@ -17,13 +26,10 @@ import { type operations } from '../../../../../generated/apps/validator/src/mai
  *   ```;
  */
 export const GenerateExternalPartyTopology = createApiOperation<
-  operations['generateExternalPartyTopology']['requestBody']['content']['application/json'],
+  GenerateExternalPartyTopologyRequest,
   operations['generateExternalPartyTopology']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    party_hint: z.string(),
-    public_key: z.string(),
-  }) as z.ZodType<operations['generateExternalPartyTopology']['requestBody']['content']['application/json']>,
+  paramsSchema: GenerateExternalPartyTopologyParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) => `${apiUrl}/api/validator/v0/admin/external-party/topology/generate`,
   buildRequestData: (params) => params,

--- a/src/clients/validator-api/operations/v0/admin/prepare-accept-external-party-setup-proposal.ts
+++ b/src/clients/validator-api/operations/v0/admin/prepare-accept-external-party-setup-proposal.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
 
 type PrepareAcceptExternalPartySetupProposalRequest =
@@ -7,16 +7,20 @@ type PrepareAcceptExternalPartySetupProposalRequest =
 type PrepareAcceptExternalPartySetupProposalResponse =
   operations['prepareAcceptExternalPartySetupProposal']['responses']['200']['content']['application/json'];
 
+/** Runtime schema kept in exact key/type parity with the generated prepare-accept request. */
+export const PrepareAcceptExternalPartySetupProposalParamsSchema =
+  createRequestSchema<PrepareAcceptExternalPartySetupProposalRequest>()({
+    contract_id: z.string().min(1),
+    user_party_id: z.string().min(1),
+    verbose_hashing: z.boolean().default(false),
+  });
+
 /** Prepare an externally signed ExternalPartySetupProposal acceptance transaction. */
 export const PrepareAcceptExternalPartySetupProposal = createApiOperation<
   PrepareAcceptExternalPartySetupProposalRequest,
   PrepareAcceptExternalPartySetupProposalResponse
 >({
-  paramsSchema: z.object({
-    contract_id: z.string().min(1),
-    user_party_id: z.string().min(1),
-    verbose_hashing: z.boolean().default(false),
-  }) as z.ZodType<PrepareAcceptExternalPartySetupProposalRequest>,
+  paramsSchema: PrepareAcceptExternalPartySetupProposalParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string): string =>
     `${apiUrl}/api/validator/v0/admin/external-party/setup-proposal/prepare-accept`,

--- a/src/clients/validator-api/operations/v0/admin/prepare-transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/admin/prepare-transfer-preapproval-send.ts
@@ -1,6 +1,20 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+type PrepareTransferPreapprovalSendRequest =
+  operations['prepareTransferPreapprovalSend']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated prepare-send request. */
+export const PrepareTransferPreapprovalSendParamsSchema = createRequestSchema<PrepareTransferPreapprovalSendRequest>()({
+  sender_party_id: z.string().min(1),
+  receiver_party_id: z.string().min(1),
+  amount: z.number().positive(),
+  expires_at: z.string().min(1),
+  nonce: z.number().int().nonnegative(),
+  verbose_hashing: z.boolean().default(false),
+  description: z.string().optional(),
+});
 
 /**
  * Prepare an externally signed CC transfer
@@ -9,18 +23,10 @@ import { type operations } from '../../../../../generated/apps/validator/src/mai
  * submitTransferPreapprovalSend.
  */
 export const PrepareTransferPreapprovalSend = createApiOperation<
-  operations['prepareTransferPreapprovalSend']['requestBody']['content']['application/json'],
+  PrepareTransferPreapprovalSendRequest,
   operations['prepareTransferPreapprovalSend']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    sender_party_id: z.string().min(1),
-    receiver_party_id: z.string().min(1),
-    amount: z.number().positive(),
-    expires_at: z.string().min(1),
-    nonce: z.number().int().nonnegative(),
-    verbose_hashing: z.boolean().default(false),
-    description: z.string().optional(),
-  }) as z.ZodType<operations['prepareTransferPreapprovalSend']['requestBody']['content']['application/json']>,
+  paramsSchema: PrepareTransferPreapprovalSendParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) =>
     `${apiUrl}/api/validator/v0/admin/external-party/transfer-preapproval/prepare-send`,

--- a/src/clients/validator-api/operations/v0/admin/submit-accept-external-party-setup-proposal.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-accept-external-party-setup-proposal.ts
@@ -6,18 +6,22 @@ const HEX_BYTES_PATTERN = /^(?:[0-9a-fA-F]{2})+$/;
 
 type SubmitAcceptExternalPartySetupProposalRequest =
   operations['submitAcceptExternalPartySetupProposal']['requestBody']['content']['application/json'];
+type SubmitAcceptExternalPartySetupProposalSubmission = SubmitAcceptExternalPartySetupProposalRequest['submission'];
 type SubmitAcceptExternalPartySetupProposalResponse =
   operations['submitAcceptExternalPartySetupProposal']['responses']['200']['content']['application/json'];
+
+const SubmitAcceptExternalPartySetupProposalSubmissionSchema =
+  createRequestSchema<SubmitAcceptExternalPartySetupProposalSubmission>()({
+    party_id: z.string().min(1),
+    transaction: z.string().min(1),
+    signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
+    public_key: z.string().regex(HEX_BYTES_PATTERN),
+  });
 
 /** Runtime schema kept in exact key/type parity with the generated submit-accept request. */
 export const SubmitAcceptExternalPartySetupProposalParamsSchema =
   createRequestSchema<SubmitAcceptExternalPartySetupProposalRequest>()({
-    submission: z.object({
-      party_id: z.string().min(1),
-      transaction: z.string().min(1),
-      signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
-      public_key: z.string().regex(HEX_BYTES_PATTERN),
-    }),
+    submission: SubmitAcceptExternalPartySetupProposalSubmissionSchema,
   });
 
 /** Submit an externally signed ExternalPartySetupProposal acceptance transaction. */

--- a/src/clients/validator-api/operations/v0/admin/submit-accept-external-party-setup-proposal.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-accept-external-party-setup-proposal.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
 
 const HEX_BYTES_PATTERN = /^(?:[0-9a-fA-F]{2})+$/;
@@ -9,19 +9,23 @@ type SubmitAcceptExternalPartySetupProposalRequest =
 type SubmitAcceptExternalPartySetupProposalResponse =
   operations['submitAcceptExternalPartySetupProposal']['responses']['200']['content']['application/json'];
 
-/** Submit an externally signed ExternalPartySetupProposal acceptance transaction. */
-export const SubmitAcceptExternalPartySetupProposal = createApiOperation<
-  SubmitAcceptExternalPartySetupProposalRequest,
-  SubmitAcceptExternalPartySetupProposalResponse
->({
-  paramsSchema: z.object({
+/** Runtime schema kept in exact key/type parity with the generated submit-accept request. */
+export const SubmitAcceptExternalPartySetupProposalParamsSchema =
+  createRequestSchema<SubmitAcceptExternalPartySetupProposalRequest>()({
     submission: z.object({
       party_id: z.string().min(1),
       transaction: z.string().min(1),
       signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
       public_key: z.string().regex(HEX_BYTES_PATTERN),
     }),
-  }) as z.ZodType<SubmitAcceptExternalPartySetupProposalRequest>,
+  });
+
+/** Submit an externally signed ExternalPartySetupProposal acceptance transaction. */
+export const SubmitAcceptExternalPartySetupProposal = createApiOperation<
+  SubmitAcceptExternalPartySetupProposalRequest,
+  SubmitAcceptExternalPartySetupProposalResponse
+>({
+  paramsSchema: SubmitAcceptExternalPartySetupProposalParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string): string =>
     `${apiUrl}/api/validator/v0/admin/external-party/setup-proposal/submit-accept`,

--- a/src/clients/validator-api/operations/v0/admin/submit-external-party-topology.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-external-party-topology.ts
@@ -4,16 +4,17 @@ import { type operations } from '../../../../../generated/apps/validator/src/mai
 
 type SubmitExternalPartyTopologyRequest =
   operations['submitExternalPartyTopology']['requestBody']['content']['application/json'];
+type SignedTopologyTransaction = SubmitExternalPartyTopologyRequest['signed_topology_txs'][number];
+
+const SignedTopologyTransactionSchema = createRequestSchema<SignedTopologyTransaction>()({
+  topology_tx: z.string(),
+  signed_hash: z.string(),
+});
 
 /** Runtime schema kept in exact key/type parity with the generated topology-submission request. */
 export const SubmitExternalPartyTopologyParamsSchema = createRequestSchema<SubmitExternalPartyTopologyRequest>()({
   public_key: z.string(),
-  signed_topology_txs: z.array(
-    z.object({
-      topology_tx: z.string(),
-      signed_hash: z.string(),
-    })
-  ),
+  signed_topology_txs: z.array(SignedTopologyTransactionSchema),
 });
 
 /**

--- a/src/clients/validator-api/operations/v0/admin/submit-external-party-topology.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-external-party-topology.ts
@@ -1,6 +1,20 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
+
+type SubmitExternalPartyTopologyRequest =
+  operations['submitExternalPartyTopology']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated topology-submission request. */
+export const SubmitExternalPartyTopologyParamsSchema = createRequestSchema<SubmitExternalPartyTopologyRequest>()({
+  public_key: z.string(),
+  signed_topology_txs: z.array(
+    z.object({
+      topology_tx: z.string(),
+      signed_hash: z.string(),
+    })
+  ),
+});
 
 /**
  * Submit signed external party topology transactions
@@ -21,18 +35,10 @@ import { type operations } from '../../../../../generated/apps/validator/src/mai
  *   ```;
  */
 export const SubmitExternalPartyTopology = createApiOperation<
-  operations['submitExternalPartyTopology']['requestBody']['content']['application/json'],
+  SubmitExternalPartyTopologyRequest,
   operations['submitExternalPartyTopology']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    public_key: z.string(),
-    signed_topology_txs: z.array(
-      z.object({
-        topology_tx: z.string(),
-        signed_hash: z.string(),
-      })
-    ),
-  }) as z.ZodType<operations['submitExternalPartyTopology']['requestBody']['content']['application/json']>,
+  paramsSchema: SubmitExternalPartyTopologyParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) => `${apiUrl}/api/validator/v0/admin/external-party/topology/submit`,
   buildRequestData: (params) => params,

--- a/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
@@ -6,15 +6,18 @@ const HEX_BYTES_PATTERN = /^(?:[0-9a-fA-F]{2})+$/;
 
 type SubmitTransferPreapprovalSendRequest =
   operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json'];
+type SubmitTransferPreapprovalSendSubmission = SubmitTransferPreapprovalSendRequest['submission'];
+
+const SubmitTransferPreapprovalSendSubmissionSchema = createRequestSchema<SubmitTransferPreapprovalSendSubmission>()({
+  party_id: z.string().min(1),
+  transaction: z.string().min(1),
+  signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
+  public_key: z.string().regex(HEX_BYTES_PATTERN),
+});
 
 /** Runtime schema kept in exact key/type parity with the generated transfer-submission request. */
 export const SubmitTransferPreapprovalSendParamsSchema = createRequestSchema<SubmitTransferPreapprovalSendRequest>()({
-  submission: z.object({
-    party_id: z.string().min(1),
-    transaction: z.string().min(1),
-    signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
-    public_key: z.string().regex(HEX_BYTES_PATTERN),
-  }),
+  submission: SubmitTransferPreapprovalSendSubmissionSchema,
 });
 
 /**

--- a/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send.ts
@@ -1,8 +1,21 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/validator-internal';
 
 const HEX_BYTES_PATTERN = /^(?:[0-9a-fA-F]{2})+$/;
+
+type SubmitTransferPreapprovalSendRequest =
+  operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated transfer-submission request. */
+export const SubmitTransferPreapprovalSendParamsSchema = createRequestSchema<SubmitTransferPreapprovalSendRequest>()({
+  submission: z.object({
+    party_id: z.string().min(1),
+    transaction: z.string().min(1),
+    signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
+    public_key: z.string().regex(HEX_BYTES_PATTERN),
+  }),
+});
 
 /**
  * Submit an externally signed CC transfer
@@ -10,17 +23,10 @@ const HEX_BYTES_PATTERN = /^(?:[0-9a-fA-F]{2})+$/;
  * Submits the signed transaction returned by prepareTransferPreapprovalSend.
  */
 export const SubmitTransferPreapprovalSend = createApiOperation<
-  operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json'],
+  SubmitTransferPreapprovalSendRequest,
   operations['submitTransferPreapprovalSend']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    submission: z.object({
-      party_id: z.string().min(1),
-      transaction: z.string().min(1),
-      signed_tx_hash: z.string().regex(HEX_BYTES_PATTERN),
-      public_key: z.string().regex(HEX_BYTES_PATTERN),
-    }),
-  }) as z.ZodType<operations['submitTransferPreapprovalSend']['requestBody']['content']['application/json']>,
+  paramsSchema: SubmitTransferPreapprovalSendParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) =>
     `${apiUrl}/api/validator/v0/admin/external-party/transfer-preapproval/submit-send`,

--- a/src/clients/validator-api/operations/v0/ans/get-rules.ts
+++ b/src/clients/validator-api/operations/v0/ans/get-rules.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/validator/src/main/openapi/scan-proxy';
 
-// Create Zod schema for the request parameters
-const GetAnsRulesParamsSchema = z.object({
+type GetAnsRulesRequest = operations['getAnsRules']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated ANS-rules request. */
+export const GetAnsRulesParamsSchema = createRequestSchema<GetAnsRulesRequest>()({
   cached_ans_rules_contract_id: z.string().optional(),
   cached_ans_rules_domain_id: z.string().optional(),
 });
@@ -21,12 +23,10 @@ const GetAnsRulesParamsSchema = z.object({
  *   ```;
  */
 export const GetAnsRules = createApiOperation<
-  operations['getAnsRules']['requestBody']['content']['application/json'],
+  GetAnsRulesRequest,
   operations['getAnsRules']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: GetAnsRulesParamsSchema as z.ZodType<
-    operations['getAnsRules']['requestBody']['content']['application/json']
-  >,
+  paramsSchema: GetAnsRulesParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) => `${apiUrl}/api/validator/v0/scan-proxy/ans-rules`,
   buildRequestData: (params) => params,

--- a/src/clients/validator-api/operations/v0/wallet/token-standard/transfers/create.ts
+++ b/src/clients/validator-api/operations/v0/wallet/token-standard/transfers/create.ts
@@ -1,6 +1,18 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../../../core';
 import { type operations } from '../../../../../../../generated/apps/wallet/src/main/openapi/wallet-internal';
+
+type CreateTokenStandardTransferRequest =
+  operations['createTokenStandardTransfer']['requestBody']['content']['application/json'];
+
+/** Runtime schema kept in exact key/type parity with the generated token-transfer request. */
+export const CreateTokenStandardTransferParamsSchema = createRequestSchema<CreateTokenStandardTransferRequest>()({
+  receiver_party_id: z.string(),
+  amount: z.string(),
+  description: z.string(),
+  expires_at: z.number(),
+  tracking_id: z.string(),
+});
 
 /**
  * Create a new token standard transfer to send tokens to another party
@@ -18,16 +30,10 @@ import { type operations } from '../../../../../../../generated/apps/wallet/src/
  *   ```;
  */
 export const CreateTokenStandardTransfer = createApiOperation<
-  operations['createTokenStandardTransfer']['requestBody']['content']['application/json'],
+  CreateTokenStandardTransferRequest,
   operations['createTokenStandardTransfer']['responses']['200']['content']['application/json']
 >({
-  paramsSchema: z.object({
-    receiver_party_id: z.string(),
-    amount: z.string(),
-    description: z.string(),
-    expires_at: z.number(),
-    tracking_id: z.string(),
-  }) as z.ZodType<operations['createTokenStandardTransfer']['requestBody']['content']['application/json']>,
+  paramsSchema: CreateTokenStandardTransferParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string) => `${apiUrl}/api/validator/v0/wallet/token-standard/transfers`,
   buildRequestData: (params) => params,

--- a/src/clients/validator-api/operations/v0/wallet/transfer-preapproval-send.ts
+++ b/src/clients/validator-api/operations/v0/wallet/transfer-preapproval-send.ts
@@ -1,22 +1,21 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../core';
+import { createApiOperation, createRequestSchema } from '../../../../../core';
 import { type operations } from '../../../../../generated/apps/wallet/src/main/openapi/wallet-internal';
 
 type TransferPreapprovalSendRequest =
   operations['transferPreapprovalSend']['requestBody']['content']['application/json'];
-type TransferPreapprovalSendResponse = operations['transferPreapprovalSend']['responses']['200'];
+
+/** Runtime schema kept in exact key/type parity with the generated transfer-preapproval request. */
+export const TransferPreapprovalSendParamsSchema = createRequestSchema<TransferPreapprovalSendRequest>()({
+  receiver_party_id: z.string().min(1),
+  amount: z.string().min(1),
+  deduplication_id: z.string().min(1),
+  description: z.string().optional(),
+});
 
 /** Send CC from the authenticated wallet to a party with transfer preapproval. */
-export const TransferPreapprovalSend = createApiOperation<
-  TransferPreapprovalSendRequest,
-  TransferPreapprovalSendResponse
->({
-  paramsSchema: z.object({
-    receiver_party_id: z.string().min(1),
-    amount: z.string().min(1),
-    deduplication_id: z.string().min(1),
-    description: z.string().optional(),
-  }) as z.ZodType<TransferPreapprovalSendRequest>,
+export const TransferPreapprovalSend = createApiOperation<TransferPreapprovalSendRequest, void>({
+  paramsSchema: TransferPreapprovalSendParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl: string): string => `${apiUrl}/api/validator/v0/wallet/transfer-preapproval/send`,
   buildRequestData: (params): TransferPreapprovalSendRequest => params,

--- a/src/core/operations/ApiOperationFactory.ts
+++ b/src/core/operations/ApiOperationFactory.ts
@@ -6,12 +6,26 @@ import { ApiOperation } from './ApiOperation';
 /**
  * Exact Zod object shape for a generated request type.
  *
- * Used by {@link createRequestSchema} to make every generated request property—including optional properties—explicit
- * in the runtime schema and reject keys that are not part of the generated contract.
+ * Used by {@link createRequestSchema} to make every generated request property—including optional properties—explicit in
+ * the runtime schema and reject keys that are not part of the generated contract.
  */
-export type ZodObjectShapeFor<T extends object> = {
-  readonly [Key in keyof T]-?: z.ZodType<T[Key]>;
+type ZodPropertyFor<Value, Schema extends z.ZodType> = [z.output<Schema>] extends [Value]
+  ? [Value] extends [z.input<Schema>]
+    ? Schema
+    : never
+  : never;
+
+export type ZodObjectShapeFor<T extends object, Shape extends z.ZodRawShape> = {
+  readonly [Key in keyof T]-?: Key extends keyof Shape
+    ? Shape[Key] extends z.ZodType
+      ? ZodPropertyFor<T[Key], Shape[Key]>
+      : never
+    : never;
 };
+
+export type RequestSchemaBuilder<T extends object> = <Shape extends z.ZodRawShape>(
+  shape: Shape & ZodObjectShapeFor<T, Shape> & Record<Exclude<keyof Shape, keyof T>, never>
+) => z.ZodType<T>;
 
 /**
  * Creates an exact runtime schema for a generated JSON request object.
@@ -20,18 +34,16 @@ export type ZodObjectShapeFor<T extends object> = {
  * to the generated property type. Undefined top-level properties are removed so the result honors
  * `exactOptionalPropertyTypes` and mirrors JSON serialization.
  */
-export function createRequestSchema<T extends object>(): <Shape extends z.ZodRawShape>(
-  shape: Shape & ZodObjectShapeFor<T> & Record<Exclude<keyof Shape, keyof T>, never>
-) => z.ZodType<T> {
-  return <Shape extends z.ZodRawShape>(
-    shape: Shape & ZodObjectShapeFor<T> & Record<Exclude<keyof Shape, keyof T>, never>
-  ): z.ZodType<T> =>
-    z.object(shape).transform((value): T => {
+export function createRequestSchema<T extends object>(): RequestSchemaBuilder<T> {
+  const createSchema: RequestSchemaBuilder<T> = (shape) =>
+    z.strictObject(shape).transform((value): T => {
       const definedEntries = Object.entries(value).filter(
         (entry): entry is [string, unknown] => entry[1] !== undefined
       );
       return Object.fromEntries(definedEntries) as T;
     });
+
+  return createSchema;
 }
 
 /**

--- a/src/core/operations/ApiOperationFactory.ts
+++ b/src/core/operations/ApiOperationFactory.ts
@@ -1,7 +1,38 @@
-import { type z } from 'zod';
+import { z } from 'zod';
 import { type BaseClient } from '../BaseClient';
 import { type RequestConfig } from '../types';
 import { ApiOperation } from './ApiOperation';
+
+/**
+ * Exact Zod object shape for a generated request type.
+ *
+ * Used by {@link createRequestSchema} to make every generated request property—including optional properties—explicit
+ * in the runtime schema and reject keys that are not part of the generated contract.
+ */
+export type ZodObjectShapeFor<T extends object> = {
+  readonly [Key in keyof T]-?: z.ZodType<T[Key]>;
+};
+
+/**
+ * Creates an exact runtime schema for a generated JSON request object.
+ *
+ * The shape must include every generated key (including optional keys), cannot add keys, and must decode each property
+ * to the generated property type. Undefined top-level properties are removed so the result honors
+ * `exactOptionalPropertyTypes` and mirrors JSON serialization.
+ */
+export function createRequestSchema<T extends object>(): <Shape extends z.ZodRawShape>(
+  shape: Shape & ZodObjectShapeFor<T> & Record<Exclude<keyof Shape, keyof T>, never>
+) => z.ZodType<T> {
+  return <Shape extends z.ZodRawShape>(
+    shape: Shape & ZodObjectShapeFor<T> & Record<Exclude<keyof Shape, keyof T>, never>
+  ): z.ZodType<T> =>
+    z.object(shape).transform((value): T => {
+      const definedEntries = Object.entries(value).filter(
+        (entry): entry is [string, unknown] => entry[1] !== undefined
+      );
+      return Object.fromEntries(definedEntries) as T;
+    });
+}
 
 /**
  * Builds the request body from validated params. Return `undefined` for endpoints that don't send a body. Only called

--- a/src/utils/amulet/external-party-transfer-preapproval.ts
+++ b/src/utils/amulet/external-party-transfer-preapproval.ts
@@ -1,7 +1,7 @@
 import { type ValidatorApiClient } from '../../clients/validator-api';
 import { ApiError, ValidationError } from '../../core/errors';
 import { isRecord } from '../../core/utils';
-import { objectOrEmpty, readContractWithStateContractId, readOptionalCantonUpdateId } from '../canton-response-utils';
+import { objectOrEmpty, readContractWithStateContractId } from '../canton-response-utils';
 import {
   assertCantonHashSignature,
   assertCantonPartyMatchesPublicKey,
@@ -74,8 +74,6 @@ export interface SentWalletTransferToPreapprovedParty {
   readonly amount: string;
   readonly description: string | null;
   readonly deduplicationId: string;
-  readonly updateId: string | null;
-  readonly raw: unknown;
 }
 
 export async function lookupExternalPartyTransferPreapproval(
@@ -209,7 +207,7 @@ export async function sendWalletTransferToPreapprovedParty(
     throw new ValidationError('deduplicationId is required');
   }
 
-  const raw = await validatorClient.transferPreapprovalSend({
+  await validatorClient.transferPreapprovalSend({
     receiver_party_id: params.receiverPartyId,
     amount,
     deduplication_id: deduplicationId,
@@ -221,8 +219,6 @@ export async function sendWalletTransferToPreapprovedParty(
     amount,
     description,
     deduplicationId,
-    updateId: readOptionalCantonUpdateId(raw),
-    raw,
   };
 }
 

--- a/src/utils/canton-response-utils.ts
+++ b/src/utils/canton-response-utils.ts
@@ -75,7 +75,7 @@ export function readRequiredString(source: unknown, key: string, operation: stri
 
 export function readContractWithStateContractId(contractWithState: unknown): string | null {
   if (!isRecord(contractWithState)) return null;
-  const contract = contractWithState['contract'];
+  const { contract } = contractWithState;
   if (!isRecord(contract)) return null;
   const contractId = contract['contract_id'];
   return typeof contractId === 'string' && contractId.trim() ? contractId : null;

--- a/src/utils/external-signing/external-party-wallet.ts
+++ b/src/utils/external-signing/external-party-wallet.ts
@@ -252,11 +252,9 @@ export interface ExternalPartyWalletProviderTransferToPreapproved {
   readonly amount: string;
   readonly description: string | null;
   readonly transferPreapprovalContractId: string;
-  readonly updateId: string | null;
   readonly sourceBalanceAfter: unknown | null;
   readonly raw: {
     readonly transferPreapproval: unknown;
-    readonly transferPreapprovalSend: unknown;
   };
 }
 
@@ -812,7 +810,7 @@ export function createExternalPartyWalletBridge(options: ExternalPartyWalletOpti
           { receiverPartyId: input.receiverPartyId }
         );
       }
-      const sent = await sendWalletTransferToPreapprovedParty(validatorClient, {
+      await sendWalletTransferToPreapprovedParty(validatorClient, {
         receiverPartyId: input.receiverPartyId,
         amount,
         deduplicationId: input.idempotencyKey,
@@ -825,11 +823,9 @@ export function createExternalPartyWalletBridge(options: ExternalPartyWalletOpti
         amount,
         description,
         transferPreapprovalContractId: transferPreapproval.contractId,
-        updateId: sent.updateId,
         sourceBalanceAfter,
         raw: {
           transferPreapproval: transferPreapproval.raw,
-          transferPreapprovalSend: sent.raw,
         },
       };
     },

--- a/test/integration/localnet/canton-response-utils.test.ts
+++ b/test/integration/localnet/canton-response-utils.test.ts
@@ -78,9 +78,9 @@ describe('Canton response helpers / LocalNet', (): void => {
       tokens: [
         {
           instrumentId: { admin: dsoPartyId, id: 'Amulet' },
-          totalUnlockedBalance: String(walletBalance.effective_unlocked_qty ?? '0'),
+          totalUnlockedBalance: String(walletBalance.effective_unlocked_qty),
           totalLockedBalance: '0',
-          totalBalance: String(walletBalance.effective_unlocked_qty ?? '0'),
+          totalBalance: String(walletBalance.effective_unlocked_qty),
           unlockedUtxos: unlockedAmulets.map(toUtxo),
           lockedUtxos: lockedAmulets.map(toUtxo),
         },

--- a/test/typecheck/request-schema.typecheck.ts
+++ b/test/typecheck/request-schema.typecheck.ts
@@ -35,3 +35,33 @@ createExampleRequestSchema({
   // @ts-expect-error An optional generated property requires a validator that accepts undefined input.
   optional: z.boolean(),
 });
+
+interface NestedExampleRequest {
+  readonly nested: {
+    readonly required: string;
+    readonly optional?: boolean;
+  };
+}
+
+type NestedExample = NestedExampleRequest['nested'];
+const createNestedExampleSchema = createRequestSchema<NestedExample>();
+
+const nestedExampleSchema = createNestedExampleSchema({
+  required: z.string(),
+  optional: z.boolean().optional(),
+});
+
+createRequestSchema<NestedExampleRequest>()({
+  nested: nestedExampleSchema,
+});
+
+// Nested generated properties must still have a runtime validator.
+// @ts-expect-error The nested optional key is intentionally missing.
+createNestedExampleSchema({ required: z.string() });
+
+createNestedExampleSchema({
+  required: z.string(),
+  optional: z.boolean().optional(),
+  // @ts-expect-error Nested runtime schemas cannot add keys absent from the generated contract.
+  extra: z.string(),
+});

--- a/test/typecheck/request-schema.typecheck.ts
+++ b/test/typecheck/request-schema.typecheck.ts
@@ -29,3 +29,9 @@ createExampleRequestSchema({
   // @ts-expect-error The validator output must match the generated property type.
   optional: z.string().optional(),
 });
+
+createExampleRequestSchema({
+  required: z.string(),
+  // @ts-expect-error An optional generated property requires a validator that accepts undefined input.
+  optional: z.boolean(),
+});

--- a/test/typecheck/request-schema.typecheck.ts
+++ b/test/typecheck/request-schema.typecheck.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { createRequestSchema } from '../../src/core';
+
+interface ExampleRequest {
+  readonly required: string;
+  readonly optional?: boolean;
+}
+
+const createExampleRequestSchema = createRequestSchema<ExampleRequest>();
+
+createExampleRequestSchema({
+  required: z.string(),
+  optional: z.boolean().optional(),
+});
+
+// Generated optional properties must still have a runtime validator.
+// @ts-expect-error The optional key is intentionally missing.
+createExampleRequestSchema({ required: z.string() });
+
+createExampleRequestSchema({
+  required: z.string(),
+  optional: z.boolean().optional(),
+  // @ts-expect-error Runtime schemas cannot add keys absent from the generated contract.
+  extra: z.string(),
+});
+
+createExampleRequestSchema({
+  required: z.string(),
+  // @ts-expect-error The validator output must match the generated property type.
+  optional: z.string().optional(),
+});

--- a/test/unit/external-signing/external-party-wallet.test.ts
+++ b/test/unit/external-signing/external-party-wallet.test.ts
@@ -108,9 +108,7 @@ const createMockValidatorClient = (): jest.Mocked<ValidatorApiClient> =>
       transfer_preapproval_contract_id: 'transfer-preapproval-contract-id',
       update_id: 'transfer-preapproval-update-1',
     }),
-    transferPreapprovalSend: jest.fn().mockResolvedValue({
-      transaction_id: 'provider-preapproval-send-update-1',
-    }),
+    transferPreapprovalSend: jest.fn().mockResolvedValue(undefined),
     getWalletBalance: jest.fn().mockResolvedValue({ effective_unlocked_qty: '100.0' }),
     createTransferOffer: jest.fn().mockResolvedValue({
       offer_contract_id: OFFER_CONTRACT_ID,
@@ -531,16 +529,12 @@ describe('external-party wallet bridge', (): void => {
       amount: '3.5',
       description: 'preapproved funding',
       transferPreapprovalContractId: 'transfer-preapproval-contract-id',
-      updateId: 'provider-preapproval-send-update-1',
       sourceBalanceAfter: { effective_unlocked_qty: '100.0' },
       raw: {
         transferPreapproval: {
           contract: {
             contract_id: 'transfer-preapproval-contract-id',
           },
-        },
-        transferPreapprovalSend: {
-          transaction_id: 'provider-preapproval-send-update-1',
         },
       },
     });

--- a/test/unit/operations/validator-request-schema-integrity.test.ts
+++ b/test/unit/operations/validator-request-schema-integrity.test.ts
@@ -42,6 +42,15 @@ describe('validator request schema integrity', () => {
     ).toEqual({ name: 'Alice' });
   });
 
+  it('rejects request keys that are absent from the generated contract', () => {
+    expect(() =>
+      CreateUserParamsSchema.parse({
+        name: 'Alice',
+        createPartyIfMising: true,
+      })
+    ).toThrow();
+  });
+
   it('models transfer-preapproval send as a no-content response', async () => {
     const request = {
       receiver_party_id: 'bob::namespace',

--- a/test/unit/operations/validator-request-schema-integrity.test.ts
+++ b/test/unit/operations/validator-request-schema-integrity.test.ts
@@ -1,4 +1,5 @@
 import { CreateUser, CreateUserParamsSchema } from '../../../src/clients/validator-api/operations/v0/admin/create-user';
+import { SubmitTransferPreapprovalSendParamsSchema } from '../../../src/clients/validator-api/operations/v0/admin/submit-transfer-preapproval-send';
 import {
   TransferPreapprovalSend,
   TransferPreapprovalSendParamsSchema,
@@ -47,6 +48,20 @@ describe('validator request schema integrity', () => {
       CreateUserParamsSchema.parse({
         name: 'Alice',
         createPartyIfMising: true,
+      })
+    ).toThrow();
+  });
+
+  it('rejects request keys that are absent from a nested generated contract', () => {
+    expect(() =>
+      SubmitTransferPreapprovalSendParamsSchema.parse({
+        submission: {
+          party_id: 'alice::namespace',
+          transaction: 'prepared-transaction',
+          signed_tx_hash: 'abcd',
+          public_key: '1234',
+          signed_transaction_hash: 'silent-typo',
+        },
       })
     ).toThrow();
   });

--- a/test/unit/operations/validator-request-schema-integrity.test.ts
+++ b/test/unit/operations/validator-request-schema-integrity.test.ts
@@ -1,0 +1,67 @@
+import { CreateUser, CreateUserParamsSchema } from '../../../src/clients/validator-api/operations/v0/admin/create-user';
+import {
+  TransferPreapprovalSend,
+  TransferPreapprovalSendParamsSchema,
+} from '../../../src/clients/validator-api/operations/v0/wallet/transfer-preapproval-send';
+import type { BaseClient } from '../../../src/core';
+
+function createClient(makePostRequest: jest.Mock): BaseClient {
+  return {
+    getApiUrl: () => 'https://validator.example',
+    makePostRequest,
+  } as unknown as BaseClient;
+}
+
+describe('validator request schema integrity', () => {
+  it('preserves createPartyIfMissing while validating onboard-user requests', async () => {
+    const request = {
+      name: 'Alice',
+      party_id: 'alice::namespace',
+      createPartyIfMissing: true,
+    };
+
+    expect(CreateUserParamsSchema.parse(request)).toEqual(request);
+
+    const makePostRequest = jest.fn().mockResolvedValue({ party_id: request.party_id });
+    await new CreateUser(createClient(makePostRequest)).execute(request);
+
+    expect(makePostRequest).toHaveBeenCalledWith('https://validator.example/api/validator/v0/admin/users', request, {
+      contentType: 'application/json',
+      includeBearerToken: true,
+    });
+  });
+
+  it('keeps createPartyIfMissing optional', () => {
+    expect(CreateUserParamsSchema.parse({ name: 'Alice' })).toEqual({ name: 'Alice' });
+    expect(
+      CreateUserParamsSchema.parse({
+        name: 'Alice',
+        party_id: undefined,
+        createPartyIfMissing: undefined,
+      })
+    ).toEqual({ name: 'Alice' });
+  });
+
+  it('models transfer-preapproval send as a no-content response', async () => {
+    const request = {
+      receiver_party_id: 'bob::namespace',
+      amount: '10.5',
+      deduplication_id: 'payment-123',
+      description: 'Invoice 123',
+    };
+
+    expect(TransferPreapprovalSendParamsSchema.parse(request)).toEqual(request);
+
+    const makePostRequest = jest.fn().mockResolvedValue(undefined);
+    await new TransferPreapprovalSend(createClient(makePostRequest)).execute(request);
+
+    expect(makePostRequest).toHaveBeenCalledWith(
+      'https://validator.example/api/validator/v0/wallet/transfer-preapproval/send',
+      request,
+      {
+        contentType: 'application/json',
+        includeBearerToken: true,
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a generated-contract-aware request schema builder that requires every request key, rejects extra keys, and normalizes optional `undefined` values for `exactOptionalPropertyTypes`
- apply exact parity recursively to nested submission objects and topology-transaction items
- replace all validator request-schema assertions with compile-checked named schemas
- preserve the validator `createPartyIfMissing` request field instead of silently stripping it
- model `transferPreapprovalSend` as `Promise<void>`, matching the pinned Wallet OpenAPI response, and remove downstream update/raw fields that could never be returned
- add compile-time drift tests and focused runtime regressions

## Root cause

Eleven validator operations asserted handwritten Zod schemas as generated request types. Those assertions hid contract drift: optional generated fields could be omitted from the runtime schema while TypeScript still compiled. In the onboard-user operation, Zod therefore stripped `createPartyIfMissing` before the request was sent.

Nested submission objects and topology transaction items also used permissive `z.object` schemas, so their keys could drift or be silently stripped independently of the top-level contract.

The transfer-preapproval send wrapper also used the generated HTTP response envelope as its public response value even though the endpoint's 200 response has no body.

## Impact

Request schemas now fail compilation when generated keys, optional-input behavior, or property types drift. Unknown request keys fail validation at both top-level and nested generated object boundaries, and `createUser()` correctly forwards `createPartyIfMissing`.

This intentionally changes `transferPreapprovalSend()` to return `Promise<void>`. Provider-transfer helper results no longer expose a fabricated update ID or raw send response.

## Validation

- `npm run fix`
- `npm run build` (TypeScript 7 core and lint configs)
- changed-file ESLint and Prettier
- focused schema and downstream regressions
- full unit suite: 48 suites, 500 tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter, reusable request validation across validator and wallet operations.
  * Validation now preserves optional fields and rejects unknown or incorrectly named properties.
* **Bug Fixes**
  * Simplified transfer results by removing internal update identifiers and raw response metadata.
  * Improved handling of no-content transfer responses.
* **Tests**
  * Added coverage for request schema type safety, field preservation, invalid inputs, and transfer requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->