### PR TITLE
Wrap submit-and-wait transaction command envelopes

### DIFF
--- a/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction.ts
+++ b/src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction.ts
@@ -21,10 +21,17 @@ export const SubmitAndWaitForTransaction = createApiOperation<
   paramsSchema: SubmitAndWaitForTransactionParamsSchema,
   method: 'POST',
   buildUrl: (_params, apiUrl) => `${apiUrl}${endpoint}`,
-  buildRequestData: (params, client) => ({
-    ...params,
-    commandId:
-      params.commandId ?? `submit-and-wait-for-transaction-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
-    actAs: params.actAs ?? [client.getPartyId()],
-  }),
+  buildRequestData: (params, client) => {
+    const { transactionFormat, ...commands } = params;
+    return {
+      commands: {
+        ...commands,
+        commandId:
+          params.commandId ??
+          `submit-and-wait-for-transaction-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`,
+        actAs: params.actAs ?? [client.getPartyId()],
+      },
+      ...(transactionFormat !== undefined ? { transactionFormat } : {}),
+    };
+  },
 });

--- a/test/unit/operations/submit-and-wait-for-transaction.test.ts
+++ b/test/unit/operations/submit-and-wait-for-transaction.test.ts
@@ -1,4 +1,7 @@
-import { SubmitAndWaitForTransaction } from '../../../src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction';
+import {
+  SubmitAndWaitForTransaction,
+  type SubmitAndWaitForTransactionParams,
+} from '../../../src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction';
 import type { BaseClient } from '../../../src/core';
 
 const createCommand = (): { CreateCommand: { templateId: string; createArguments: Record<string, never> } } => ({
@@ -37,6 +40,48 @@ describe('SubmitAndWaitForTransaction', () => {
           actAs: ['alice::123'],
           readAs: ['reader::123'],
         },
+      },
+      expect.objectContaining({
+        contentType: 'application/json',
+        includeBearerToken: true,
+      })
+    );
+  });
+
+  it('keeps transactionFormat at the top level of the request envelope', async () => {
+    const command = createCommand();
+    const transactionFormat: NonNullable<SubmitAndWaitForTransactionParams['transactionFormat']> = {
+      eventFormat: {
+        filtersByParty: {},
+      },
+      transactionShape: 'TRANSACTION_SHAPE_ACS_DELTA',
+    };
+    const makePostRequest = jest.fn().mockResolvedValue({
+      transaction: {
+        updateId: 'update-123',
+      },
+    });
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      getPartyId: () => 'alice::123',
+      makePostRequest,
+    } as unknown as BaseClient;
+
+    await new SubmitAndWaitForTransaction(client).execute({
+      commands: [command],
+      commandId: 'cmd-123',
+      transactionFormat,
+    });
+
+    expect(makePostRequest).toHaveBeenCalledWith(
+      'https://ledger.example/v2/commands/submit-and-wait-for-transaction',
+      {
+        commands: {
+          commands: [command],
+          commandId: 'cmd-123',
+          actAs: ['alice::123'],
+        },
+        transactionFormat,
       },
       expect.objectContaining({
         contentType: 'application/json',

--- a/test/unit/operations/submit-and-wait-for-transaction.test.ts
+++ b/test/unit/operations/submit-and-wait-for-transaction.test.ts
@@ -1,0 +1,47 @@
+import { SubmitAndWaitForTransaction } from '../../../src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction';
+import type { BaseClient } from '../../../src/core';
+
+const createCommand = (): { CreateCommand: { templateId: string; createArguments: Record<string, never> } } => ({
+  CreateCommand: {
+    templateId: '#pkg:Module:Template',
+    createArguments: {},
+  },
+});
+
+describe('SubmitAndWaitForTransaction', () => {
+  it('wraps command fields in the Canton request envelope', async () => {
+    const command = createCommand();
+    const makePostRequest = jest.fn().mockResolvedValue({
+      transaction: {
+        updateId: 'update-123',
+      },
+    });
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      getPartyId: () => 'alice::123',
+      makePostRequest,
+    } as unknown as BaseClient;
+
+    await new SubmitAndWaitForTransaction(client).execute({
+      commands: [command],
+      commandId: 'cmd-123',
+      readAs: ['reader::123'],
+    });
+
+    expect(makePostRequest).toHaveBeenCalledWith(
+      'https://ledger.example/v2/commands/submit-and-wait-for-transaction',
+      {
+        commands: {
+          commands: [command],
+          commandId: 'cmd-123',
+          actAs: ['alice::123'],
+          readAs: ['reader::123'],
+        },
+      },
+      expect.objectContaining({
+        contentType: 'application/json',
+        includeBearerToken: true,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- serialize `/v2/commands/submit-and-wait-for-transaction` as `{ commands: JsCommands, transactionFormat }` per the checked-in Canton OpenAPI
- retain the existing flat public method parameters and default `commandId` / `actAs` behavior
- add a complete wire-shape regression test

## Validation
- `npx jest test/unit/operations/submit-and-wait-for-transaction.test.ts --runInBand`
- `npm run tsc7 -- --noEmit` after the OpenAPI/client generators
- targeted ESLint and Prettier checks pass for both changed files
- current-main `npm run build:core` and package rebuild pass

## Existing main-branch baseline
- full `npm run lint` reports 14 unrelated TypeScript 7 lint errors outside this diff

## Live DevNet validation
The old flat body was rejected before sequencing with missing `commands.commands`, `commands.commandId`, and `commands.actAs`. With this serializer, the same ledger client successfully submitted:
- Bravo v05 registry creation: update `122081a90f5f832a6a888bd11d17b1e10880e76948d4a70fdfa914f3122e22c0b910`
- 500-share v05 holding mint: update `1220eeafab3492095848bc1aa36f025857cb276bf120a016ca54636865d5793d1a7a`

Both updates are present in the DevNet operations database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ledger command submissions are serialized on a critical write path; wrong shape would break all submit-and-wait-for-transaction calls, though scope is limited to one operation and is covered by new regression tests.
> 
> **Overview**
> Fixes **`SubmitAndWaitForTransaction`** so the POST body matches Canton’s envelope instead of sending command fields flat at the root (which caused ledger validation errors for missing nested `commands.commands`, `commands.commandId`, and `commands.actAs`).
> 
> **`buildRequestData`** now nests command-related params under a **`commands`** object (still applying the same default **`commandId`** and **`actAs`** from the client party), and puts optional **`transactionFormat`** on the top level only when provided. Caller-facing params are unchanged.
> 
> Adds unit tests that assert the exact wire shape for both with and without **`transactionFormat`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f12184abb50b1cae0c88880093a6d7bc114c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->