### PR TITLE
Support generic Token Standard registry access

### DIFF
--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -47,9 +47,6 @@ export class GetActiveContracts {
       ({ activeAtOffset } = validated);
     } else {
       const ledgerEnd = await this.client.getLedgerEnd({});
-      if (ledgerEnd.offset === undefined) {
-        throw new ApiError('Ledger end response did not include an offset');
-      }
       activeAtOffset = ledgerEnd.offset;
     }
 

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -20,7 +20,11 @@ const ActiveContractsParamsSchema = z.object({
   parties: z.array(z.string()).optional(),
   /** Optional template filters applied server-side. */
   templateIds: z.array(z.string()).optional(),
-  /** Include created event blob in TemplateFilter results (default false). */
+  /** Optional interface filters applied server-side. */
+  interfaceIds: z.array(z.string()).optional(),
+  /** Include interface views in InterfaceFilter results (default true). */
+  includeInterfaceView: z.boolean().optional(),
+  /** Include created event blobs in template and interface filter results (default false). */
   includeCreatedEventBlob: z.boolean().optional(),
   /** Allow caller to omit activeAtOffset; we'll default to ledger end */
   activeAtOffset: z.number().optional(),
@@ -57,6 +61,10 @@ export class GetActiveContracts {
     const eventFormat = buildEventFormat({
       parties: partyList,
       ...(validated.templateIds !== undefined && { templateIds: validated.templateIds }),
+      ...(validated.interfaceIds !== undefined && { interfaceIds: validated.interfaceIds }),
+      ...(validated.includeInterfaceView !== undefined && {
+        includeInterfaceView: validated.includeInterfaceView,
+      }),
       ...(validated.includeCreatedEventBlob !== undefined && {
         includeCreatedEventBlob: validated.includeCreatedEventBlob,
       }),

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -47,7 +47,11 @@ export class GetActiveContracts {
       ({ activeAtOffset } = validated);
     } else {
       const ledgerEnd = await this.client.getLedgerEnd({});
-      activeAtOffset = ledgerEnd.offset;
+      const { offset } = ledgerEnd;
+      if (offset === undefined) {
+        throw new ApiError('Ledger end response did not include an offset');
+      }
+      activeAtOffset = offset;
     }
 
     // Build party list - default to client's party list if not provided

--- a/src/clients/ledger-json-api/operations/v2/utils/event-format-builder.ts
+++ b/src/clients/ledger-json-api/operations/v2/utils/event-format-builder.ts
@@ -8,7 +8,11 @@ export interface EventFormatBuilderParams {
   parties: string[];
   /** Optional template filters applied server-side. */
   templateIds?: string[] | undefined;
-  /** Include created event blob in TemplateFilter results (default false). */
+  /** Optional interface filters applied server-side. */
+  interfaceIds?: string[] | undefined;
+  /** Include interface views in InterfaceFilter results (default true). */
+  includeInterfaceView?: boolean | undefined;
+  /** Include created event blobs in template and interface filter results (default false). */
   includeCreatedEventBlob?: boolean | undefined;
 }
 
@@ -18,6 +22,17 @@ type FilterCumulative = Array<
         TemplateFilter: {
           value: {
             templateId: string;
+            includeCreatedEventBlob: boolean;
+          };
+        };
+      };
+    }
+  | {
+      identifierFilter: {
+        InterfaceFilter: {
+          value: {
+            interfaceId: string;
+            includeInterfaceView: boolean;
             includeCreatedEventBlob: boolean;
           };
         };
@@ -52,17 +67,32 @@ export function buildEventFormat(params: EventFormatBuilderParams): {
 
   // Build the cumulative filter array
   const buildCumulative = (): FilterCumulative => {
-    if (params.templateIds && params.templateIds.length > 0) {
-      return params.templateIds.map((templateId) => ({
-        identifierFilter: {
-          TemplateFilter: {
-            value: {
-              templateId,
-              includeCreatedEventBlob: params.includeCreatedEventBlob ?? false,
-            },
+    const includeCreatedEventBlob = params.includeCreatedEventBlob ?? false;
+    const templateFilters: FilterCumulative = (params.templateIds ?? []).map((templateId) => ({
+      identifierFilter: {
+        TemplateFilter: {
+          value: {
+            templateId,
+            includeCreatedEventBlob,
           },
         },
-      }));
+      },
+    }));
+    const interfaceFilters: FilterCumulative = (params.interfaceIds ?? []).map((interfaceId) => ({
+      identifierFilter: {
+        InterfaceFilter: {
+          value: {
+            interfaceId,
+            includeInterfaceView: params.includeInterfaceView ?? true,
+            includeCreatedEventBlob,
+          },
+        },
+      },
+    }));
+    const identifierFilters = [...templateFilters, ...interfaceFilters];
+
+    if (identifierFilters.length > 0) {
+      return identifierFilters;
     }
     if (params.includeCreatedEventBlob) {
       return [

--- a/src/clients/ledger-json-api/schemas/api/event-details.ts
+++ b/src/clients/ledger-json-api/schemas/api/event-details.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 import { RecordSchema } from '../base';
+import { JsInterfaceViewSchema } from './interface-view';
+
+export * from './interface-view';
 
 /** Created event details. */
 export const CreatedEventDetailsSchema = z.object({
@@ -17,8 +20,8 @@ export const CreatedEventDetailsSchema = z.object({
   createArgument: RecordSchema,
   /** Serialized event blob for the created contract. */
   createdEventBlob: z.string(),
-  /** List of interface view names implemented by the contract. */
-  interfaceViews: z.array(z.string()),
+  /** Interface views requested by matching interface filters. */
+  interfaceViews: z.array(JsInterfaceViewSchema).optional().default([]),
   /** Parties that witnessed the creation. */
   witnessParties: z.array(z.string()),
   /** Parties that must sign the contract. */

--- a/src/clients/ledger-json-api/schemas/api/events.ts
+++ b/src/clients/ledger-json-api/schemas/api/events.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { RecordSchema } from '../base';
 import { CumulativeFilterSchema } from '../operations/updates';
+import { JsInterfaceViewSchema } from './interface-view';
 
 export const CreatedTreeEventSchema = z
   .object({
@@ -23,8 +24,8 @@ export const CreatedTreeEventSchema = z
             createArgument: RecordSchema,
             /** Serialized event blob for the created contract. */
             createdEventBlob: z.string(),
-            /** List of interface view names implemented by the contract. */
-            interfaceViews: z.array(z.string()),
+            /** Interface views requested by matching interface filters. */
+            interfaceViews: z.array(JsInterfaceViewSchema).optional().default([]),
             /** Parties that witnessed the creation. */
             witnessParties: z.array(z.string()),
             /** Parties that must sign the contract. */
@@ -171,8 +172,8 @@ export const CreatedEventSchema = z
         createArgument: RecordSchema,
         /** Serialized event blob for the created contract. */
         createdEventBlob: z.string(),
-        /** List of interface view names implemented by the contract. */
-        interfaceViews: z.array(z.string()),
+        /** Interface views requested by matching interface filters. */
+        interfaceViews: z.array(JsInterfaceViewSchema).optional().default([]),
         /** Parties that witnessed the creation. */
         witnessParties: z.array(z.string()),
         /** Parties that must sign the contract. */

--- a/src/clients/ledger-json-api/schemas/api/interface-view.ts
+++ b/src/clients/ledger-json-api/schemas/api/interface-view.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/** Status returned when the Ledger API computes an interface view. */
+export const JsInterfaceViewStatusSchema = z
+  .object({
+    code: z.number(),
+    message: z.string(),
+    details: z.array(z.unknown()).optional(),
+  })
+  .strict();
+
+/** View of a created event selected by an interface filter. */
+export const JsInterfaceViewSchema = z
+  .object({
+    interfaceId: z.string(),
+    viewStatus: JsInterfaceViewStatusSchema,
+    viewValue: z.unknown().optional(),
+  })
+  .strict();
+
+export type JsInterfaceViewStatus = z.infer<typeof JsInterfaceViewStatusSchema>;
+export type JsInterfaceView = z.infer<typeof JsInterfaceViewSchema>;

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/index.ts
@@ -1,0 +1,1 @@
+export * from './v1';

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry.ts
@@ -38,9 +38,11 @@ export type GetAllocationFactoryFromRegistryResponse =
 
 function buildRegistryEndpoint(registryUrl: string): string {
   const url = new URL(registryUrl);
+  url.username = '';
+  url.password = '';
   url.search = '';
   url.hash = '';
-  url.pathname = `${url.pathname.replace(/\/$/, '')}${endpoint}`;
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}${endpoint}`;
   return url.toString();
 }
 

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../../../../core';
+import type {
+  components,
+  paths,
+} from '../../../../../../../../generated/token-standard/splice-api-token-allocation-instruction-v1/openapi/allocation-instruction-v1';
+import { RecordSchema } from '../../../../../../../ledger-json-api/schemas/base';
+
+type ApiPath = '/registry/allocation-instruction/v1/allocation-factory';
+
+const endpoint = '/registry/allocation-instruction/v1/allocation-factory';
+const publicRequestConfig = {
+  contentType: 'application/json',
+  includeBearerToken: false,
+} as const;
+
+const RegistryUrlSchema = z.url().refine((value) => {
+  const protocol = new URL(value).protocol;
+  return protocol === 'http:' || protocol === 'https:';
+}, 'registryUrl must use http or https');
+
+export const GetAllocationFactoryFromRegistryParamsSchema = z.object({
+  /** Base URL advertised for the instrument admin's Token Standard registry. */
+  registryUrl: RegistryUrlSchema,
+  /** Complete AllocationFactory_Allocate choice argument used to derive context. */
+  choiceArguments: RecordSchema,
+  excludeDebugFields: z.boolean().optional(),
+});
+
+export type GetAllocationFactoryFromRegistryParams = z.infer<typeof GetAllocationFactoryFromRegistryParamsSchema>;
+export type GetAllocationFactoryFromRegistryRequest = components['schemas']['GetFactoryRequest'];
+export type GetAllocationFactoryFromRegistryResponse =
+  paths[ApiPath]['post']['responses']['200']['content']['application/json'];
+
+function buildRegistryEndpoint(registryUrl: string): string {
+  const url = new URL(registryUrl);
+  url.search = '';
+  url.hash = '';
+  url.pathname = `${url.pathname.replace(/\/$/, '')}${endpoint}`;
+  return url.toString();
+}
+
+/**
+ * Fetch the AllocationFactory and per-choice context from any Token Standard registry. The request is deliberately
+ * unauthenticated so Scan credentials are never forwarded to a third-party instrument registry.
+ */
+export const GetAllocationFactoryFromRegistry = createApiOperation<
+  GetAllocationFactoryFromRegistryParams,
+  GetAllocationFactoryFromRegistryResponse
+>({
+  paramsSchema: GetAllocationFactoryFromRegistryParamsSchema,
+  method: 'POST',
+  buildUrl: (params) => buildRegistryEndpoint(params.registryUrl),
+  buildRequestData: (params) => ({
+    choiceArguments: params.choiceArguments,
+    excludeDebugFields: params.excludeDebugFields ?? false,
+  }),
+  requestConfig: publicRequestConfig,
+});

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
-import { createApiOperation } from '../../../../../../../../core';
+import { createApiOperation } from '../../../../../../../core';
 import type {
   components,
   paths,
-} from '../../../../../../../../generated/token-standard/splice-api-token-allocation-instruction-v1/openapi/allocation-instruction-v1';
-import { RecordSchema } from '../../../../../../../ledger-json-api/schemas/base';
+} from '../../../../../../../generated/token-standard/splice-api-token-allocation-instruction-v1/openapi/allocation-instruction-v1';
+import { RecordSchema } from '../../../../../../ledger-json-api/schemas/base';
 
 type ApiPath = '/registry/allocation-instruction/v1/allocation-factory';
 
@@ -15,8 +15,12 @@ const publicRequestConfig = {
 } as const;
 
 const RegistryUrlSchema = z.url().refine((value) => {
-  const protocol = new URL(value).protocol;
-  return protocol === 'http:' || protocol === 'https:';
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
 }, 'registryUrl must use http or https');
 
 export const GetAllocationFactoryFromRegistryParamsSchema = z.object({

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/v1/index.ts
@@ -1,0 +1,1 @@
+export * from './get-allocation-factory-from-registry';

--- a/src/clients/scan-api/operations/v0/registry/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/index.ts
@@ -1,1 +1,2 @@
+export * from './allocation-instruction';
 export * from './metadata';

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -206,11 +206,12 @@ describe('ScanApiClient', () => {
       },
       {
         headers: {
-          Accept: 'application/json',
           'Content-Type': 'application/json',
         },
       }
     );
+    const requestHeaders = mockAxiosInstance.post.mock.calls[0]?.[2]?.headers;
+    expect(requestHeaders).not.toHaveProperty('Authorization');
   });
 
   it('rejects a malformed or non-http registry URL before making a request', async () => {

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -214,6 +214,33 @@ describe('ScanApiClient', () => {
     expect(requestHeaders).not.toHaveProperty('Authorization');
   });
 
+  it('strips embedded credentials and normalizes trailing slashes from registry URLs', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+    mockAxiosInstance.post.mockResolvedValueOnce({
+      data: {
+        factoryId: '#allocation-factory',
+        choiceContext: {
+          choiceContextData: { values: {} },
+          disclosedContracts: [],
+        },
+      },
+    });
+
+    await client.getAllocationFactoryFromRegistry({
+      registryUrl: 'https://registry-user:registry-password@cash-token.example/token-registry///',
+      choiceArguments: {},
+    });
+
+    expect(mockAxiosInstance.post.mock.calls[0]?.[0]).toBe(
+      'https://cash-token.example/token-registry/registry/allocation-instruction/v1/allocation-factory'
+    );
+  });
+
   it('rejects a malformed or non-http registry URL before making a request', async () => {
     const { client, mockAxiosInstance } = createClient(
       { network: 'mainnet' },

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -25,7 +25,10 @@ interface MockAxiosInstance {
   patch: jest.Mock;
 }
 
-function createClient(config: ClientConfig, options: ScanApiClientOptions = {}): {
+function createClient(
+  config: ClientConfig,
+  options: ScanApiClientOptions = {}
+): {
   client: ScanApiClient;
   mockAxiosInstance: MockAxiosInstance;
 } {
@@ -166,5 +169,70 @@ describe('ScanApiClient', () => {
       'https://scan-b.example/registry/metadata/v1/instruments/Amulet',
     ]);
     expect(client.getApiUrl()).toBe('https://scan-b.example/api/scan');
+  });
+
+  it('gets an allocation factory from an arbitrary Token Standard registry without auth', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+    const choiceArguments = {
+      settlement: { id: 'settlement-3' },
+      extraArgs: { context: { values: {} }, meta: { values: {} } },
+    };
+    const response = {
+      factoryId: '#allocation-factory',
+      choiceContext: {
+        choiceContextData: { values: {} },
+        disclosedContracts: [],
+      },
+    };
+    mockAxiosInstance.post.mockResolvedValueOnce({ data: response });
+
+    await expect(
+      client.getAllocationFactoryFromRegistry({
+        registryUrl: 'https://cash-token.example/token-registry/',
+        choiceArguments,
+      })
+    ).resolves.toEqual(response);
+
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+      'https://cash-token.example/token-registry/registry/allocation-instruction/v1/allocation-factory',
+      {
+        choiceArguments,
+        excludeDebugFields: false,
+      },
+      {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  });
+
+  it('rejects a malformed or non-http registry URL before making a request', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+
+    await expect(
+      client.getAllocationFactoryFromRegistry({
+        registryUrl: 'not-a-url',
+        choiceArguments: {},
+      })
+    ).rejects.toThrow('Parameter validation failed');
+    await expect(
+      client.getAllocationFactoryFromRegistry({
+        registryUrl: 'file:///tmp/token-registry',
+        choiceArguments: {},
+      })
+    ).rejects.toThrow('registryUrl must use http or https');
+    expect(mockAxiosInstance.post).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/operations/event-format-builder.test.ts
+++ b/test/unit/operations/event-format-builder.test.ts
@@ -1,0 +1,86 @@
+import { buildEventFormat } from '../../../src/clients/ledger-json-api/operations/v2/utils/event-format-builder';
+
+describe('buildEventFormat', () => {
+  it('builds interface-only filters with interface views enabled by default', () => {
+    expect(
+      buildEventFormat({
+        parties: ['Alice'],
+        interfaceIds: ['#token-standard:Splice.Api.Token.HoldingV1:Holding'],
+        includeCreatedEventBlob: true,
+      })
+    ).toEqual({
+      verbose: false,
+      filtersByParty: {
+        Alice: {
+          cumulative: [
+            {
+              identifierFilter: {
+                InterfaceFilter: {
+                  value: {
+                    interfaceId: '#token-standard:Splice.Api.Token.HoldingV1:Holding',
+                    includeInterfaceView: true,
+                    includeCreatedEventBlob: true,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('combines template and interface filters with configurable interface views', () => {
+    expect(
+      buildEventFormat({
+        parties: ['Alice'],
+        templateIds: ['#wallet:Splice.Wallet.Install:WalletAppInstall'],
+        interfaceIds: ['#token-standard:Splice.Api.Token.HoldingV1:Holding'],
+        includeInterfaceView: false,
+      }).filtersByParty['Alice']?.cumulative
+    ).toEqual([
+      {
+        identifierFilter: {
+          TemplateFilter: {
+            value: {
+              templateId: '#wallet:Splice.Wallet.Install:WalletAppInstall',
+              includeCreatedEventBlob: false,
+            },
+          },
+        },
+      },
+      {
+        identifierFilter: {
+          InterfaceFilter: {
+            value: {
+              interfaceId: '#token-standard:Splice.Api.Token.HoldingV1:Holding',
+              includeInterfaceView: false,
+              includeCreatedEventBlob: false,
+            },
+          },
+        },
+      },
+    ]);
+  });
+
+  it('preserves the existing template-only filter shape', () => {
+    expect(
+      buildEventFormat({
+        parties: ['Alice'],
+        templateIds: ['#wallet:Splice.Wallet.Install:WalletAppInstall'],
+        includeCreatedEventBlob: true,
+      }).filtersByParty['Alice']?.cumulative
+    ).toEqual([
+      {
+        identifierFilter: {
+          TemplateFilter: {
+            value: {
+              templateId: '#wallet:Splice.Wallet.Install:WalletAppInstall',
+              includeCreatedEventBlob: true,
+            },
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/test/unit/operations/get-active-contracts.test.ts
+++ b/test/unit/operations/get-active-contracts.test.ts
@@ -1,0 +1,70 @@
+import { GetActiveContracts } from '../../../src/clients/ledger-json-api/operations/v2/state/get-active-contracts';
+
+const mockConnect = jest.fn();
+
+jest.mock('../../../src/core/ws/WebSocketClient', () => ({
+  WebSocketClient: class {
+    public connect(...args: unknown[]): unknown {
+      return mockConnect(...args);
+    }
+  },
+}));
+
+describe('GetActiveContracts', () => {
+  beforeEach(() => {
+    mockConnect.mockReset();
+    mockConnect.mockImplementation(
+      async (_path: string, _request: unknown, handlers: { onClose?: (code: number, reason: string) => void }) => {
+        handlers.onClose?.(1000, 'snapshot complete');
+        return {
+          close: jest.fn(),
+          isConnected: () => false,
+          getConnectionState: () => 3,
+        };
+      }
+    );
+  });
+
+  it('forwards interface filters separately from template filters', async () => {
+    const operation = new GetActiveContracts({} as never);
+
+    await expect(
+      operation.execute({
+        parties: ['Alice'],
+        activeAtOffset: 42,
+        interfaceIds: ['#token-standard:Splice.Api.Token.HoldingV1:Holding'],
+        includeInterfaceView: false,
+        includeCreatedEventBlob: true,
+      })
+    ).resolves.toEqual([]);
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      '/v2/state/active-contracts',
+      {
+        verbose: false,
+        activeAtOffset: 42,
+        eventFormat: {
+          verbose: false,
+          filtersByParty: {
+            Alice: {
+              cumulative: [
+                {
+                  identifierFilter: {
+                    InterfaceFilter: {
+                      value: {
+                        interfaceId: '#token-standard:Splice.Api.Token.HoldingV1:Holding',
+                        includeInterfaceView: false,
+                        includeCreatedEventBlob: true,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      expect.any(Object)
+    );
+  });
+});

--- a/test/unit/schemas/interface-view.test.ts
+++ b/test/unit/schemas/interface-view.test.ts
@@ -1,0 +1,43 @@
+import { CreatedEventDetailsSchema } from '../../../src/clients/ledger-json-api/schemas/api/event-details';
+
+describe('CreatedEventDetailsSchema interface views', () => {
+  it('parses an interface view returned by the Ledger JSON API', () => {
+    const result = CreatedEventDetailsSchema.parse({
+      offset: 42,
+      nodeId: 0,
+      contractId: 'contract-1',
+      templateId: '#amulet:Splice.Amulet:Amulet',
+      contractKey: null,
+      createArgument: { owner: 'Alice' },
+      createdEventBlob: '',
+      interfaceViews: [
+        {
+          interfaceId: '#token-standard:Splice.Api.Token.HoldingV1:Holding',
+          viewStatus: {
+            code: 0,
+            message: '',
+            details: [],
+          },
+          viewValue: {
+            amount: '1000.0000000000',
+            instrumentId: { admin: 'DSO', id: 'Amulet' },
+          },
+        },
+      ],
+      witnessParties: ['Alice'],
+      signatories: ['Alice'],
+      observers: [],
+      createdAt: '2026-07-09T00:00:00Z',
+      packageName: 'splice-amulet',
+    });
+
+    expect(result.interfaceViews[0]).toEqual({
+      interfaceId: '#token-standard:Splice.Api.Token.HoldingV1:Holding',
+      viewStatus: { code: 0, message: '', details: [] },
+      viewValue: {
+        amount: '1000.0000000000',
+        instrumentId: { admin: 'DSO', id: 'Amulet' },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add an unauthenticated allocation-factory lookup for any Token Standard registry URL
- add Ledger JSON API `InterfaceFilter` support to active-contract queries
- expose correctly typed interface-view payloads so consumers can read standard `HoldingV2` views without knowing concrete token templates
- preserve the existing validator scan-proxy path for Canton Coin/Amulet

## Why

CIP-112 permits apps to interoperate with independently administered assets. The current SDK only exposes the validator's Amulet-specific allocation registry proxy and only builds template filters for ACS queries, which prevents generic cash-token allocation and holding discovery.

## Validation

- focused Jest: 4 suites, 12 tests
- `npm run tsc7 -- --noEmit`
- targeted ESLint and Prettier
- `npm run check:package-artifacts`
- `git diff --check`

## Local baseline note

`npm run build` completes `build:core`; `build:lint` then reports the existing TypeScript 7 errors in `paid-traffic-cost.test.ts` and `updates.test.ts`, which are outside this diff. CI remains the authoritative full-repo check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public API shapes (`interfaceViews` typing) and outbound HTTP to user-supplied registry URLs; behavior is guarded by URL validation and no auth forwarding, but consumers parsing old string-only interface views may need updates.
> 
> **Overview**
> Adds **generic Token Standard registry** support so apps can resolve allocation factories from any instrument admin’s registry URL, and extends **Ledger JSON API** active-contract queries to filter and return **interface views** (e.g. standard holdings) without hard-coding concrete templates.
> 
> **Scan API:** New `getAllocationFactoryFromRegistry` posts to `{registryUrl}/registry/allocation-instruction/v1/allocation-factory` with **no bearer token** (Scan credentials are not sent to third-party registries). `registryUrl` is validated (http/https only), credentials in the URL are stripped, and trailing slashes are normalized.
> 
> **Ledger JSON API:** `getActiveContracts` and `buildEventFormat` accept `interfaceIds`, `includeInterfaceView` (default true), and shared `includeCreatedEventBlob` for template and interface filters. Created-event schemas now model `interfaceViews` as structured `JsInterfaceView` objects (`interfaceId`, `viewStatus`, optional `viewValue`) instead of string names.
> 
> **Tests:** Unit coverage for event-format builder, active-contract forwarding, interface-view parsing, and scan registry client behavior (auth omission, URL normalization, validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30cc313a9cb51711c6a9f4901f84727b5125860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->