### PR TITLE
Add Scan registry metadata parity

### DIFF
--- a/src/clients/scan-api/ScanApiClient.ts
+++ b/src/clients/scan-api/ScanApiClient.ts
@@ -1,5 +1,5 @@
 import { ApiError, ConfigurationError, NetworkError, type CantonRuntime, type RequestConfig } from '../../core';
-import { resolveScanApiUrls } from './scan-endpoints';
+import { getScanHostRoot, resolveScanApiUrls } from './scan-endpoints';
 import { ScanApiClient as ScanApiClientGenerated } from './ScanApiClient.generated';
 
 export interface ScanApiClientOptions {
@@ -40,10 +40,6 @@ function resolveConfiguredScanApiUrl(runtime: CantonRuntime): string | undefined
   }
 }
 
-function getScanHostRoot(scanApiUrl: string): string {
-  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
-}
-
 interface RotatableScanUrl {
   readonly buildUrl: (baseUrl: string) => string;
 }
@@ -80,7 +76,7 @@ export class ScanApiClient extends ScanApiClientGenerated {
             auth: { grantType: 'client_credentials', clientId: '' },
           },
         },
-      }),
+      })
     );
 
     this.scanApiUrls = scanApiUrls;

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
@@ -1,12 +1,8 @@
 import { z } from 'zod';
 import { createApiOperation } from '../../../../../../../core';
 import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
-import {
-  getRegistryApiUrl,
-  normalizeRegistryInstrument,
-  publicRegistryRequestConfig,
-  type RegistryInstrument,
-} from './registry-metadata';
+import { getScanHostRoot } from '../../../../../scan-endpoints';
+import { normalizeRegistryInstrument, publicRegistryRequestConfig, type RegistryInstrument } from './registry-metadata';
 
 type ApiPath = '/registry/metadata/v1/instruments/{instrumentId}';
 
@@ -27,7 +23,7 @@ export const GetInstrument = createApiOperation<GetInstrumentParams, GetInstrume
   paramsSchema: GetInstrumentParamsSchema,
   method: 'GET',
   buildUrl: (params, apiUrl): string =>
-    `${getRegistryApiUrl(apiUrl)}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
+    `${getScanHostRoot(apiUrl)}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
   requestConfig: publicRegistryRequestConfig,
   transformResponse: normalizeRegistryInstrument,
 });

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument.ts
@@ -1,40 +1,26 @@
 import { z } from 'zod';
 import { createApiOperation } from '../../../../../../../core';
 import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
+import {
+  getRegistryApiUrl,
+  normalizeRegistryInstrument,
+  publicRegistryRequestConfig,
+  type RegistryInstrument,
+} from './registry-metadata';
 
 type ApiPath = '/registry/metadata/v1/instruments/{instrumentId}';
 
 const endpoint = '/registry/metadata/v1/instruments';
-const publicRequestConfig = { contentType: 'application/json', includeBearerToken: false } as const;
-
-function getRegistryApiUrl(scanApiUrl: string): string {
-  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
-}
-
-export const GetInstrumentParamsSchema = z.object({
-  instrumentId: z.string(),
-});
-
-export type GetInstrumentParams = z.infer<typeof GetInstrumentParamsSchema>;
-export type GetInstrumentResponse = paths[ApiPath]['get']['responses']['200']['content']['application/json'];
-
-type RawGetInstrumentResponse = Omit<GetInstrumentResponse, 'totalSupply' | 'totalSupplyAsOf'> & {
-  totalSupply?: string | null;
-  totalSupplyAsOf?: string | null;
+export type GetInstrumentParams = paths[ApiPath]['get']['parameters']['path'];
+type GetInstrumentParamsSchemaShape = {
+  [Key in keyof GetInstrumentParams]-?: z.ZodType<GetInstrumentParams[Key], GetInstrumentParams[Key]>;
 };
 
-function normalizeInstrumentResponse(response: GetInstrumentResponse): GetInstrumentResponse {
-  const raw = response as RawGetInstrumentResponse;
-  const { totalSupply, totalSupplyAsOf, ...instrument } = raw;
-  const normalized: GetInstrumentResponse = { ...instrument };
-  if (totalSupply != null) {
-    normalized.totalSupply = totalSupply;
-  }
-  if (totalSupplyAsOf != null) {
-    normalized.totalSupplyAsOf = totalSupplyAsOf;
-  }
-  return normalized;
-}
+export const GetInstrumentParamsSchema = z.strictObject({
+  instrumentId: z.string(),
+} satisfies GetInstrumentParamsSchemaShape);
+
+export type GetInstrumentResponse = RegistryInstrument;
 
 /** Retrieve an instrument's token metadata from the public Scan API. */
 export const GetInstrument = createApiOperation<GetInstrumentParams, GetInstrumentResponse>({
@@ -42,6 +28,6 @@ export const GetInstrument = createApiOperation<GetInstrumentParams, GetInstrume
   method: 'GET',
   buildUrl: (params, apiUrl): string =>
     `${getRegistryApiUrl(apiUrl)}${endpoint}/${encodeURIComponent(params.instrumentId)}`,
-  requestConfig: publicRequestConfig,
-  transformResponse: normalizeInstrumentResponse,
+  requestConfig: publicRegistryRequestConfig,
+  transformResponse: normalizeRegistryInstrument,
 });

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-registry-info.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-registry-info.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import { createApiOperation } from '../../../../../../../core';
 import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
-import { getRegistryApiUrl, publicRegistryRequestConfig } from './registry-metadata';
+import { getScanHostRoot } from '../../../../../scan-endpoints';
+import { publicRegistryRequestConfig } from './registry-metadata';
 
 type ApiPath = '/registry/metadata/v1/info';
 
@@ -13,6 +14,6 @@ export type GetRegistryInfoResponse = paths[ApiPath]['get']['responses']['200'][
 export const GetRegistryInfo = createApiOperation<void, GetRegistryInfoResponse>({
   paramsSchema: z.void(),
   method: 'GET',
-  buildUrl: (_params, apiUrl): string => `${getRegistryApiUrl(apiUrl)}${endpoint}`,
+  buildUrl: (_params, apiUrl): string => `${getScanHostRoot(apiUrl)}${endpoint}`,
   requestConfig: publicRegistryRequestConfig,
 });

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/get-registry-info.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/get-registry-info.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../../../core';
+import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
+import { getRegistryApiUrl, publicRegistryRequestConfig } from './registry-metadata';
+
+type ApiPath = '/registry/metadata/v1/info';
+
+const endpoint = '/registry/metadata/v1/info';
+
+export type GetRegistryInfoResponse = paths[ApiPath]['get']['responses']['200']['content']['application/json'];
+
+/** Retrieve information about the token registry and its supported standards from the public Scan API. */
+export const GetRegistryInfo = createApiOperation<void, GetRegistryInfoResponse>({
+  paramsSchema: z.void(),
+  method: 'GET',
+  buildUrl: (_params, apiUrl): string => `${getRegistryApiUrl(apiUrl)}${endpoint}`,
+  requestConfig: publicRegistryRequestConfig,
+});

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/index.ts
@@ -1,1 +1,3 @@
 export * from './get-instrument';
+export * from './get-registry-info';
+export * from './list-instruments';

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../../../core';
+import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
+import { getRegistryApiUrl, normalizeRegistryInstrument, publicRegistryRequestConfig } from './registry-metadata';
+
+type ApiPath = '/registry/metadata/v1/instruments';
+
+const endpoint = '/registry/metadata/v1/instruments';
+
+type GeneratedListInstrumentsParams = NonNullable<paths[ApiPath]['get']['parameters']['query']>;
+export type ListInstrumentsParams = GeneratedListInstrumentsParams;
+type ListInstrumentsParamsSchemaShape = {
+  [Key in keyof ListInstrumentsParams]-?: z.ZodType<ListInstrumentsParams[Key], ListInstrumentsParams[Key]>;
+};
+
+const RawListInstrumentsParamsSchema = z.strictObject({
+  pageSize: z.number().int().min(-2_147_483_648).max(2_147_483_647).optional(),
+  pageToken: z.string().optional(),
+} satisfies ListInstrumentsParamsSchemaShape);
+
+export const ListInstrumentsParamsSchema = RawListInstrumentsParamsSchema.transform((params): ListInstrumentsParams => {
+  const normalized: ListInstrumentsParams = {};
+  if (params.pageSize !== undefined) {
+    normalized.pageSize = params.pageSize;
+  }
+  if (params.pageToken !== undefined) {
+    normalized.pageToken = params.pageToken;
+  }
+  return normalized;
+});
+
+export type ListInstrumentsResponse = paths[ApiPath]['get']['responses']['200']['content']['application/json'];
+
+type RawListInstrumentsResponse = Omit<ListInstrumentsResponse, 'nextPageToken'> & {
+  nextPageToken?: string | null;
+};
+
+function normalizeListInstrumentsResponse(response: ListInstrumentsResponse): ListInstrumentsResponse {
+  const { nextPageToken, ...raw } = response as RawListInstrumentsResponse;
+  const normalized: ListInstrumentsResponse = {
+    ...raw,
+    instruments: raw.instruments.map(normalizeRegistryInstrument),
+  };
+
+  if (nextPageToken != null) {
+    normalized.nextPageToken = nextPageToken;
+  }
+
+  return normalized;
+}
+
+/** List token instruments exposed by the public Scan registry metadata API. */
+export const ListInstruments = createApiOperation<ListInstrumentsParams, ListInstrumentsResponse>({
+  paramsSchema: ListInstrumentsParamsSchema,
+  method: 'GET',
+  buildUrl: (params, apiUrl): string => {
+    const query = new URLSearchParams();
+    if (params.pageSize !== undefined) {
+      query.set('pageSize', String(params.pageSize));
+    }
+    if (params.pageToken !== undefined) {
+      query.set('pageToken', params.pageToken);
+    }
+
+    const queryString = query.toString();
+    return `${getRegistryApiUrl(apiUrl)}${endpoint}${queryString ? `?${queryString}` : ''}`;
+  },
+  requestConfig: publicRegistryRequestConfig,
+  transformResponse: normalizeListInstrumentsResponse,
+});

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments.ts
@@ -15,7 +15,7 @@ type ListInstrumentsParamsSchemaShape = {
 };
 
 const RawListInstrumentsParamsSchema = z.strictObject({
-  pageSize: z.number().int().min(-2_147_483_648).max(2_147_483_647).optional(),
+  pageSize: z.number().int().min(0).max(2_147_483_647).optional(),
   pageToken: z.string().optional(),
 } satisfies ListInstrumentsParamsSchemaShape);
 

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import { createApiOperation } from '../../../../../../../core';
 import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
-import { getRegistryApiUrl, normalizeRegistryInstrument, publicRegistryRequestConfig } from './registry-metadata';
+import { getScanHostRoot } from '../../../../../scan-endpoints';
+import { normalizeRegistryInstrument, publicRegistryRequestConfig } from './registry-metadata';
 
 type ApiPath = '/registry/metadata/v1/instruments';
 
@@ -63,7 +64,7 @@ export const ListInstruments = createApiOperation<ListInstrumentsParams, ListIns
     }
 
     const queryString = query.toString();
-    return `${getRegistryApiUrl(apiUrl)}${endpoint}${queryString ? `?${queryString}` : ''}`;
+    return `${getScanHostRoot(apiUrl)}${endpoint}${queryString ? `?${queryString}` : ''}`;
   },
   requestConfig: publicRegistryRequestConfig,
   transformResponse: normalizeListInstrumentsResponse,

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/registry-metadata.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/registry-metadata.ts
@@ -1,0 +1,34 @@
+import type { paths } from '../../../../../../../generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
+
+type GetInstrumentPath = '/registry/metadata/v1/instruments/{instrumentId}';
+
+export const publicRegistryRequestConfig = {
+  contentType: 'application/json',
+  includeBearerToken: false,
+} as const;
+
+export type RegistryInstrument = paths[GetInstrumentPath]['get']['responses']['200']['content']['application/json'];
+
+type RawRegistryInstrument = Omit<RegistryInstrument, 'totalSupply' | 'totalSupplyAsOf'> & {
+  totalSupply?: string | null;
+  totalSupplyAsOf?: string | null;
+};
+
+export function getRegistryApiUrl(scanApiUrl: string): string {
+  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
+}
+
+export function normalizeRegistryInstrument(response: RegistryInstrument): RegistryInstrument {
+  const raw = response as RawRegistryInstrument;
+  const { totalSupply, totalSupplyAsOf, ...instrument } = raw;
+  const normalized: RegistryInstrument = { ...instrument };
+
+  if (totalSupply != null) {
+    normalized.totalSupply = totalSupply;
+  }
+  if (totalSupplyAsOf != null) {
+    normalized.totalSupplyAsOf = totalSupplyAsOf;
+  }
+
+  return normalized;
+}

--- a/src/clients/scan-api/operations/v0/registry/metadata/v1/registry-metadata.ts
+++ b/src/clients/scan-api/operations/v0/registry/metadata/v1/registry-metadata.ts
@@ -14,10 +14,6 @@ type RawRegistryInstrument = Omit<RegistryInstrument, 'totalSupply' | 'totalSupp
   totalSupplyAsOf?: string | null;
 };
 
-export function getRegistryApiUrl(scanApiUrl: string): string {
-  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
-}
-
 export function normalizeRegistryInstrument(response: RegistryInstrument): RegistryInstrument {
   const raw = response as RawRegistryInstrument;
   const { totalSupply, totalSupplyAsOf, ...instrument } = raw;

--- a/src/clients/scan-api/scan-endpoints.ts
+++ b/src/clients/scan-api/scan-endpoints.ts
@@ -107,6 +107,11 @@ export function toScanApiUrl(hostUrl: string): string {
   return `${trimmed}/api/scan`;
 }
 
+/** Return the host root for a full Scan API base URL. */
+export function getScanHostRoot(scanApiUrl: string): string {
+  return scanApiUrl.replace(/\/api\/scan\/?$/, '').replace(/\/$/, '');
+}
+
 /**
  * Returns scan API base URLs ordered for retry.
  *

--- a/test/integration/localnet/scan-api/balance.test.ts
+++ b/test/integration/localnet/scan-api/balance.test.ts
@@ -1,10 +1,46 @@
-/**
- * ScanApiClient integration tests: Balance Information
- */
+/** ScanApiClient integration tests: token registry metadata. */
 
 import { getClient } from './setup';
 
-describe('ScanApiClient / Balance', () => {
+describe('ScanApiClient / Registry metadata', () => {
+  test('getRegistryInfo returns the LocalNet registry contract', async () => {
+    const client = getClient();
+
+    const registry = await client.getRegistryInfo();
+
+    expect(registry.adminId).toEqual(expect.any(String));
+    expect(registry.adminId).not.toHaveLength(0);
+    expect(registry.supportedApis).toMatchObject({
+      'splice-api-token-metadata-v1': 1,
+    });
+    for (const minorVersion of Object.values(registry.supportedApis)) {
+      expect(Number.isInteger(minorVersion)).toBe(true);
+    }
+  });
+
+  test('listInstruments returns normalized LocalNet instrument metadata', async () => {
+    const client = getClient();
+
+    const response = await client.listInstruments({ pageSize: 25 });
+    const instrument = response.instruments.find(({ id }) => id === 'Amulet');
+
+    expect(instrument).toBeDefined();
+    expect(instrument).toMatchObject({
+      id: 'Amulet',
+      name: expect.any(String),
+      symbol: expect.any(String),
+      decimals: 10,
+      supportedApis: expect.objectContaining({
+        'splice-api-token-metadata-v1': 1,
+        'splice-api-token-holding-v1': 1,
+        'splice-api-token-transfer-instruction-v1': 1,
+      }),
+    });
+    expect(response.nextPageToken).toBeUndefined();
+    expect(instrument?.totalSupply).not.toBeNull();
+    expect(instrument?.totalSupplyAsOf).not.toBeNull();
+  });
+
   test('getInstrument returns Amulet metadata', async () => {
     const client = getClient();
 

--- a/test/integration/localnet/scan-api/registry-metadata.test.ts
+++ b/test/integration/localnet/scan-api/registry-metadata.test.ts
@@ -25,6 +25,9 @@ describe('ScanApiClient / Registry metadata', () => {
     const instrument = response.instruments.find(({ id }) => id === 'Amulet');
 
     expect(instrument).toBeDefined();
+    if (instrument === undefined) {
+      throw new Error('LocalNet registry did not expose the Amulet instrument');
+    }
     expect(instrument).toMatchObject({
       id: 'Amulet',
       name: expect.any(String),
@@ -37,8 +40,16 @@ describe('ScanApiClient / Registry metadata', () => {
       }),
     });
     expect(response.nextPageToken).toBeUndefined();
-    expect(instrument?.totalSupply).not.toBeNull();
-    expect(instrument?.totalSupplyAsOf).not.toBeNull();
+    if (instrument.totalSupply === undefined) {
+      expect(instrument).not.toHaveProperty('totalSupply');
+    } else {
+      expect(instrument.totalSupply).toEqual(expect.any(String));
+    }
+    if (instrument.totalSupplyAsOf === undefined) {
+      expect(instrument).not.toHaveProperty('totalSupplyAsOf');
+    } else {
+      expect(Number.isNaN(Date.parse(instrument.totalSupplyAsOf))).toBe(false);
+    }
   });
 
   test('getInstrument returns Amulet metadata', async () => {

--- a/test/typecheck/scan-registry-metadata.typecheck.ts
+++ b/test/typecheck/scan-registry-metadata.typecheck.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import type { ScanApiClient } from '../../src/clients/scan-api';
+import {
+  GetInstrumentParamsSchema,
+  type GetInstrumentParams,
+  type GetInstrumentResponse,
+} from '../../src/clients/scan-api/operations/v0/registry/metadata/v1/get-instrument';
+import { type GetRegistryInfoResponse } from '../../src/clients/scan-api/operations/v0/registry/metadata/v1/get-registry-info';
+import {
+  ListInstrumentsParamsSchema,
+  type ListInstrumentsParams,
+  type ListInstrumentsResponse,
+} from '../../src/clients/scan-api/operations/v0/registry/metadata/v1/list-instruments';
+import type { paths } from '../../src/generated/token-standard/splice-api-token-metadata-v1/openapi/token-metadata-v1';
+
+type Equal<Left, Right> =
+  (<Type>() => Type extends Left ? 1 : 2) extends <Type>() => Type extends Right ? 1 : 2
+    ? (<Type>() => Type extends Right ? 1 : 2) extends <Type>() => Type extends Left ? 1 : 2
+      ? true
+      : false
+    : false;
+type Assert<Condition extends true> = Condition;
+
+type GetInstrumentPath = '/registry/metadata/v1/instruments/{instrumentId}';
+type GetRegistryInfoPath = '/registry/metadata/v1/info';
+type ListInstrumentsPath = '/registry/metadata/v1/instruments';
+
+type GeneratedGetInstrumentParams = paths[GetInstrumentPath]['get']['parameters']['path'];
+type GeneratedGetInstrumentResponse =
+  paths[GetInstrumentPath]['get']['responses']['200']['content']['application/json'];
+type GeneratedGetRegistryInfoResponse =
+  paths[GetRegistryInfoPath]['get']['responses']['200']['content']['application/json'];
+type GeneratedListInstrumentsParams = NonNullable<paths[ListInstrumentsPath]['get']['parameters']['query']>;
+type GeneratedListInstrumentsResponse =
+  paths[ListInstrumentsPath]['get']['responses']['200']['content']['application/json'];
+
+export type GetInstrumentParamsMatchSpec = Assert<Equal<GetInstrumentParams, GeneratedGetInstrumentParams>>;
+export type GetInstrumentSchemaMatchesSpec = Assert<
+  Equal<z.output<typeof GetInstrumentParamsSchema>, GeneratedGetInstrumentParams>
+>;
+export type GetInstrumentResponseMatchesSpec = Assert<Equal<GetInstrumentResponse, GeneratedGetInstrumentResponse>>;
+export type GetRegistryInfoResponseMatchesSpec = Assert<
+  Equal<GetRegistryInfoResponse, GeneratedGetRegistryInfoResponse>
+>;
+export type ListInstrumentsParamsMatchSpec = Assert<Equal<ListInstrumentsParams, GeneratedListInstrumentsParams>>;
+export type ListInstrumentsSchemaMatchesSpec = Assert<
+  Equal<z.output<typeof ListInstrumentsParamsSchema>, GeneratedListInstrumentsParams>
+>;
+export type ListInstrumentsResponseMatchesSpec = Assert<
+  Equal<ListInstrumentsResponse, GeneratedListInstrumentsResponse>
+>;
+
+function assertClientSurface(client: ScanApiClient): void {
+  void client.getRegistryInfo();
+  void client.listInstruments({ pageSize: 25, pageToken: 'next-page' });
+
+  // @ts-expect-error pageSize must be a number from the generated OpenAPI query contract.
+  void client.listInstruments({ pageSize: '25' });
+  // @ts-expect-error Unknown query parameters are not part of the generated contract.
+  void client.listInstruments({ pageSize: 25, unknown: true });
+}
+
+void assertClientSurface;

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -237,7 +237,7 @@ describe('ScanApiClient', () => {
     );
   });
 
-  it('rejects non-integer instrument page sizes before making a request', async () => {
+  it('rejects non-integer and negative instrument page sizes before making a request', async () => {
     const { client, mockAxiosInstance } = createClient(
       { network: 'mainnet' },
       {
@@ -246,6 +246,7 @@ describe('ScanApiClient', () => {
     );
 
     await expect(client.listInstruments({ pageSize: 1.5 })).rejects.toThrow('Parameter validation failed');
+    await expect(client.listInstruments({ pageSize: -1 })).rejects.toThrow('Parameter validation failed');
     expect(mockAxiosInstance.get).not.toHaveBeenCalled();
   });
 

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -25,7 +25,10 @@ interface MockAxiosInstance {
   patch: jest.Mock;
 }
 
-function createClient(config: ClientConfig, options: ScanApiClientOptions = {}): {
+function createClient(
+  config: ClientConfig,
+  options: ScanApiClientOptions = {}
+): {
   client: ScanApiClient;
   mockAxiosInstance: MockAxiosInstance;
 } {
@@ -137,6 +140,115 @@ describe('ScanApiClient', () => {
     );
   });
 
+  it('gets registry metadata information from the direct scan host root', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+
+    mockAxiosInstance.get.mockResolvedValueOnce({
+      data: {
+        adminId: 'registry::1220',
+        supportedApis: {
+          'splice-api-token-metadata-v1': 1,
+        },
+      },
+    });
+
+    await expect(client.getRegistryInfo()).resolves.toEqual({
+      adminId: 'registry::1220',
+      supportedApis: {
+        'splice-api-token-metadata-v1': 1,
+      },
+    });
+
+    expect(mockAxiosInstance.get.mock.calls[0]?.[0]).toBe('https://scan.example/registry/metadata/v1/info');
+  });
+
+  it('lists instruments with encoded pagination and normalizes nullable optional fields', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+
+    mockAxiosInstance.get.mockResolvedValueOnce({
+      data: {
+        instruments: [
+          {
+            id: 'Amulet',
+            name: 'Amulet',
+            symbol: 'AMT',
+            decimals: 10,
+            totalSupply: null,
+            totalSupplyAsOf: null,
+            supportedApis: {},
+          },
+          {
+            id: 'Amulet/USD',
+            name: 'Amulet USD',
+            symbol: 'AMT/USD',
+            decimals: 10,
+            totalSupply: '42.0',
+            totalSupplyAsOf: '2026-07-09T12:00:00Z',
+            supportedApis: {},
+          },
+        ],
+        nextPageToken: 'next/page + 2',
+      },
+    });
+
+    const response = await client.listInstruments({
+      pageSize: 25,
+      pageToken: 'Amulet/USD + next',
+    });
+
+    expect(response.instruments[0]?.totalSupply).toBeUndefined();
+    expect(response.instruments[0]?.totalSupplyAsOf).toBeUndefined();
+    expect(response.instruments[1]?.totalSupply).toBe('42.0');
+    expect(response.instruments[1]?.totalSupplyAsOf).toBe('2026-07-09T12:00:00Z');
+    expect(response.nextPageToken).toBe('next/page + 2');
+    expect(mockAxiosInstance.get.mock.calls[0]?.[0]).toBe(
+      'https://scan.example/registry/metadata/v1/instruments?pageSize=25&pageToken=Amulet%2FUSD+%2B+next'
+    );
+  });
+
+  it('preserves explicit zero and empty pagination values', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+
+    mockAxiosInstance.get.mockResolvedValueOnce({
+      data: {
+        instruments: [],
+        nextPageToken: null,
+      },
+    });
+
+    await expect(client.listInstruments({ pageSize: 0, pageToken: '' })).resolves.toEqual({ instruments: [] });
+    expect(mockAxiosInstance.get.mock.calls[0]?.[0]).toBe(
+      'https://scan.example/registry/metadata/v1/instruments?pageSize=0&pageToken='
+    );
+  });
+
+  it('rejects non-integer instrument page sizes before making a request', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+
+    await expect(client.listInstruments({ pageSize: 1.5 })).rejects.toThrow('Parameter validation failed');
+    expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+  });
+
   it('rotates token metadata registry requests across scan endpoints', async () => {
     const { client, mockAxiosInstance } = createClient(
       { network: 'mainnet' },
@@ -164,6 +276,28 @@ describe('ScanApiClient', () => {
     expect(requestedUrls).toEqual([
       'https://scan-a.example/registry/metadata/v1/instruments/Amulet',
       'https://scan-b.example/registry/metadata/v1/instruments/Amulet',
+    ]);
+    expect(client.getApiUrl()).toBe('https://scan-b.example/api/scan');
+  });
+
+  it('rotates list-instruments requests across scan endpoints', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan-a.example/api/scan', 'https://scan-b.example/api/scan'],
+      }
+    );
+
+    mockAxiosInstance.get
+      .mockRejectedValueOnce(new Error('first endpoint unavailable'))
+      .mockResolvedValueOnce({ data: { instruments: [] } });
+
+    await expect(client.listInstruments({})).resolves.toEqual({ instruments: [] });
+
+    const requestedUrls = mockAxiosInstance.get.mock.calls.map((call) => call[0] as string);
+    expect(requestedUrls).toEqual([
+      'https://scan-a.example/registry/metadata/v1/instruments',
+      'https://scan-b.example/registry/metadata/v1/instruments',
     ]);
     expect(client.getApiUrl()).toBe('https://scan-b.example/api/scan');
   });


### PR DESCRIPTION
## Summary

- add the missing public Scan `getRegistryInfo` and `listInstruments` methods from the pinned Token Metadata v1 OpenAPI
- keep registry calls at the Scan host root, with exact `pageSize` / `pageToken` query names, encoded pagination, and non-negative int32 page-size validation
- derive request and response types from generated paths and compile-check schema/client parity under `exactOptionalPropertyTypes`
- normalize Guardrail `null` values to omitted optional `totalSupply`, `totalSupplyAsOf`, and `nextPageToken` fields
- share registry URL, request-config, and instrument normalization behavior with `getInstrument`
- add unit, typecheck, failover, pagination, and LocalNet response-format coverage

## Intentional API direction

Backward compatibility is not a constraint. The public result shape follows the generated token-standard contract while removing wire-level `null` from fields typed as optional.

## Validation

- `npm run build`
- focused Scan client suite: 13/13 tests
- full unit suite after merging current `main`: 53 suites, 516 tests
- compile-time generated-type/schema/client assertions
- targeted ESLint, Prettier, and `git diff --check`
- prior bot findings fixed or dispositioned; fresh current-head bot review pending after the base refresh
- LocalNet coverage added for all three registry metadata endpoints; fresh CI is pending for base-refresh commit `fe0ee85` and is authoritative because Docker/Scan is unavailable locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public read-only API client methods with response normalization; no auth or payment paths touched.
> 
> **Overview**
> Adds **public Scan registry metadata** coverage for Token Metadata v1: **`getRegistryInfo`** and **`listInstruments`**, alongside a tightened **`getInstrument`** that shares the same building blocks.
> 
> Registry calls hit the **Scan host root** (not `/api/scan`) via exported **`getScanHostRoot`**. Shared **`registry-metadata`** holds unauthenticated request config and **`normalizeRegistryInstrument`**, which drops wire **`null`** for optional **`totalSupply`**, **`totalSupplyAsOf`**, and list **`nextPageToken`**. **`listInstruments`** uses OpenAPI-derived types, **`pageSize` / `pageToken`** query encoding, non-negative int32 **`pageSize`** validation, and per-item normalization.
> 
> **`getInstrument`** params now align with generated path types (**`z.strictObject`**) instead of **`z.infer`**. Integration tests move from **`balance.test`** to **`registry-metadata.test`**; unit, typecheck parity, and endpoint-rotation tests expand for the new methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0ee8577d50ec5645f6c37c122b91012c0feacd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

