### PR TITLE
Add Token Standard V2 allocation helpers

### DIFF
--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/index.ts
@@ -1,1 +1,2 @@
 export * from './v1';
+export * from './v2';

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/v2/get-allocation-factory-v2-from-registry.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/v2/get-allocation-factory-v2-from-registry.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import { createApiOperation } from '../../../../../../../core';
+import { RecordSchema } from '../../../../../../ledger-json-api/schemas/base';
+
+const endpoint = '/registry/allocation-instruction/v2/allocation-factory';
+const publicRequestConfig = {
+  contentType: 'application/json',
+  includeBearerToken: false,
+} as const;
+
+const RegistryUrlSchema = z.url().refine((value) => {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}, 'registryUrl must use http or https');
+
+export const GetAllocationFactoryV2FromRegistryParamsSchema = z.object({
+  /** Base URL advertised for the instrument admin's Token Standard registry. */
+  registryUrl: RegistryUrlSchema,
+  /** Complete AllocationFactory_Allocate choice argument with empty context and metadata. */
+  choiceArguments: RecordSchema,
+  excludeDebugFields: z.boolean().optional(),
+});
+
+export type GetAllocationFactoryV2FromRegistryParams = z.infer<typeof GetAllocationFactoryV2FromRegistryParamsSchema>;
+
+export interface GetAllocationFactoryV2FromRegistryRequest {
+  readonly choiceArguments: Readonly<Record<string, unknown>>;
+  readonly excludeDebugFields: boolean;
+}
+
+export interface GetAllocationFactoryV2FromRegistryDisclosedContract {
+  readonly templateId: string;
+  readonly contractId: string;
+  readonly createdEventBlob: string;
+  readonly synchronizerId: string;
+}
+
+export interface GetAllocationFactoryV2FromRegistryResponse {
+  readonly factoryId: string;
+  readonly choiceContext: {
+    readonly choiceContextData: Readonly<Record<string, unknown>>;
+    readonly disclosedContracts: readonly GetAllocationFactoryV2FromRegistryDisclosedContract[];
+  };
+}
+
+function buildRegistryEndpoint(registryUrl: string): string {
+  const url = new URL(registryUrl);
+  url.username = '';
+  url.password = '';
+  url.search = '';
+  url.hash = '';
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}${endpoint}`;
+  return url.toString();
+}
+
+/**
+ * Fetch the CIP-112 V2 AllocationFactory and its per-choice context. Scan credentials are deliberately not forwarded to
+ * the third-party instrument registry.
+ */
+export const GetAllocationFactoryV2FromRegistry = createApiOperation<
+  GetAllocationFactoryV2FromRegistryParams,
+  GetAllocationFactoryV2FromRegistryResponse
+>({
+  paramsSchema: GetAllocationFactoryV2FromRegistryParamsSchema,
+  method: 'POST',
+  buildUrl: (params) => buildRegistryEndpoint(params.registryUrl),
+  buildRequestData: (params) =>
+    ({
+      choiceArguments: params.choiceArguments,
+      excludeDebugFields: params.excludeDebugFields ?? false,
+    }) satisfies GetAllocationFactoryV2FromRegistryRequest,
+  requestConfig: publicRequestConfig,
+});

--- a/src/clients/scan-api/operations/v0/registry/allocation-instruction/v2/index.ts
+++ b/src/clients/scan-api/operations/v0/registry/allocation-instruction/v2/index.ts
@@ -1,0 +1,1 @@
+export * from './get-allocation-factory-v2-from-registry';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,5 +7,6 @@ export * from './mining';
 export * from './parsers';
 export * from './party';
 export * from './party-readiness';
+export * from './token-standard';
 export * from './traffic';
 export * from './transactions';

--- a/src/utils/token-standard/index.ts
+++ b/src/utils/token-standard/index.ts
@@ -1,0 +1,1 @@
+export * from './v2';

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -587,6 +587,14 @@ export async function prepareTokenStandardV2AllocationCommand(
   params: PrepareTokenStandardV2AllocationCommandParams
 ): Promise<PreparedTokenStandardV2AllocationCommand> {
   requireInputRecord(params, 'params');
+  requireInputRecord(params.scan, 'scan');
+  if (typeof params.scan.getAllocationFactoryV2FromRegistry !== 'function') {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'scan.getAllocationFactoryV2FromRegistry must be a function.',
+      { field: 'scan.getAllocationFactoryV2FromRegistry' }
+    );
+  }
   const registryUrl = requireNonEmpty(params.registryUrl, 'registryUrl');
   const registryChoiceArgument = buildTokenStandardV2AllocationChoiceArgument({
     ...params,
@@ -722,8 +730,30 @@ function readTransactionTreeUpdateId(response: unknown): string | undefined {
 export async function submitPreparedTokenStandardV2Allocation(
   params: SubmitPreparedTokenStandardV2AllocationParams
 ): Promise<SubmitPreparedTokenStandardV2AllocationResult> {
+  requireInputRecord(params, 'params');
+  requireInputRecord(params.prepared, 'prepared');
+  requireInputRecord(params.ledger, 'ledger');
+  if (typeof params.ledger.submitAndWaitForTransactionTree !== 'function') {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'ledger.submitAndWaitForTransactionTree must be a function.',
+      { field: 'ledger.submitAndWaitForTransactionTree' }
+    );
+  }
+  requireInputRecord(params.prepared.command, 'prepared.command');
+  if (!Array.isArray(params.prepared.disclosedContracts)) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'prepared.disclosedContracts must be an array.',
+      { field: 'prepared.disclosedContracts' }
+    );
+  }
+  const allocationFactoryContractId = requireNonEmpty(
+    params.prepared.allocationFactoryContractId,
+    'prepared.allocationFactoryContractId'
+  );
   const actAs = normalizeStrings(params.actAs, 'actAs');
-  const readAs = params.readAs ? normalizeStrings(params.readAs, 'readAs', true) : [];
+  const readAs = params.readAs === undefined ? [] : normalizeStrings(params.readAs, 'readAs', true);
   const submitParams: SubmitAndWaitForTransactionTreeParams = {
     commands: [params.prepared.command],
     actAs,
@@ -741,7 +771,7 @@ export async function submitPreparedTokenStandardV2Allocation(
     ...(params.workflowId !== undefined ? { workflowId: requireNonEmpty(params.workflowId, 'workflowId') } : {}),
   };
   const response = await params.ledger.submitAndWaitForTransactionTree(submitParams);
-  const result = findTokenStandardV2AllocationInstructionResult(response, params.prepared.allocationFactoryContractId);
+  const result = findTokenStandardV2AllocationInstructionResult(response, allocationFactoryContractId);
   if (!result) {
     throw new TokenStandardV2AllocationError(
       TokenStandardV2AllocationErrorCode.RESULT_NOT_FOUND,

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -1,0 +1,436 @@
+import type {
+  SubmitAndWaitForTransactionTreeParams,
+  SubmitAndWaitForTransactionTreeResponse,
+} from '../../../clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree';
+import type { Command, DisclosedContract, ExerciseCommand } from '../../../clients/ledger-json-api/schemas';
+import type { GetAllocationFactoryFromRegistryParams } from '../../../clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry';
+import { CantonError, type ErrorContext } from '../../../core/errors';
+import { isRecord } from '../../../core/utils';
+import { extractEventsFromTransaction } from '../../parsers';
+import type { TokenStandardV2Account, TokenStandardV2InstrumentId, TokenStandardV2Metadata } from './types';
+
+export const TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID =
+  '#splice-api-token-allocation-instruction-v2:Splice.Api.Token.AllocationInstructionV2:AllocationFactory';
+
+export const TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE = 'AllocationFactory_Allocate';
+
+export const TokenStandardV2AllocationErrorCode = {
+  INPUT_INVALID: 'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+  FACTORY_RESPONSE_INVALID: 'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
+  RESULT_INVALID: 'TOKEN_STANDARD_V2_ALLOCATION_RESULT_INVALID',
+  RESULT_NOT_FOUND: 'TOKEN_STANDARD_V2_ALLOCATION_RESULT_NOT_FOUND',
+} as const;
+
+export type TokenStandardV2AllocationErrorCode =
+  (typeof TokenStandardV2AllocationErrorCode)[keyof typeof TokenStandardV2AllocationErrorCode];
+
+export class TokenStandardV2AllocationError extends CantonError {
+  public override readonly name = 'TokenStandardV2AllocationError';
+
+  public constructor(code: TokenStandardV2AllocationErrorCode, message: string, context?: ErrorContext) {
+    super(message, code, context);
+  }
+}
+
+export type TokenStandardV2ChoiceContext = Readonly<Record<string, unknown>>;
+
+export interface TokenStandardV2ExtraArgs {
+  readonly context: TokenStandardV2ChoiceContext;
+  readonly meta: TokenStandardV2Metadata;
+}
+
+export interface TokenStandardV2SettlementInfo {
+  readonly executors: readonly string[];
+  readonly id: string;
+  readonly cid: string | null;
+  readonly meta?: TokenStandardV2Metadata;
+}
+
+export type TokenStandardV2TransferSide = 'SenderSide' | 'ReceiverSide';
+
+export interface TokenStandardV2TransferLegSide {
+  readonly transferLegId: string;
+  readonly side: TokenStandardV2TransferSide;
+  readonly otherside: TokenStandardV2Account;
+  readonly amount: string;
+  readonly instrumentId: TokenStandardV2InstrumentId['id'];
+  readonly meta?: TokenStandardV2Metadata;
+}
+
+export interface TokenStandardV2AllocationSpecification {
+  readonly admin: TokenStandardV2InstrumentId['admin'];
+  readonly authorizer: TokenStandardV2Account;
+  readonly transferLegSides: readonly TokenStandardV2TransferLegSide[];
+  readonly settlementDeadline: string | null;
+  /** Undefined selects the helper default; null is the Token Standard optional value sent to the ledger. */
+  readonly nextIterationFunding?: Readonly<Record<string, string>> | null;
+  /** Token Standard V2 allocation instructions are committed by default. */
+  readonly committed?: boolean;
+  readonly meta?: TokenStandardV2Metadata;
+}
+
+export interface TokenStandardV2AllocationChoiceArgument {
+  readonly settlement: TokenStandardV2SettlementInfo & { readonly meta: TokenStandardV2Metadata };
+  readonly allocation: Omit<
+    TokenStandardV2AllocationSpecification,
+    'committed' | 'meta' | 'nextIterationFunding' | 'transferLegSides'
+  > & {
+    readonly transferLegSides: ReadonlyArray<
+      TokenStandardV2TransferLegSide & { readonly meta: TokenStandardV2Metadata }
+    >;
+    readonly nextIterationFunding: Readonly<Record<string, string>> | null;
+    readonly committed: boolean;
+    readonly meta: TokenStandardV2Metadata;
+  };
+  readonly requestedAt: string;
+  readonly inputHoldingCids: readonly string[];
+  readonly extraArgs: TokenStandardV2ExtraArgs;
+  readonly actors: readonly string[];
+}
+
+export interface BuildTokenStandardV2AllocationChoiceArgumentParams {
+  readonly settlement: TokenStandardV2SettlementInfo;
+  readonly allocation: TokenStandardV2AllocationSpecification;
+  readonly requestedAt: string;
+  readonly inputHoldingCids: readonly string[];
+  readonly actors: readonly string[];
+  readonly extraArgs?: TokenStandardV2ExtraArgs;
+}
+
+export interface BuildTokenStandardV2AllocationCommandParams extends BuildTokenStandardV2AllocationChoiceArgumentParams {
+  readonly allocationFactoryContractId: string;
+  /** Override only when the registry advertises a compatible V2 interface identifier. */
+  readonly allocationFactoryInterfaceId?: string;
+}
+
+export interface TokenStandardV2AllocationRegistryClient {
+  getAllocationFactoryFromRegistry(params: GetAllocationFactoryFromRegistryParams): Promise<unknown>;
+}
+
+export interface PrepareTokenStandardV2AllocationCommandParams extends BuildTokenStandardV2AllocationChoiceArgumentParams {
+  readonly registryUrl: string;
+  readonly scan: TokenStandardV2AllocationRegistryClient;
+  readonly allocationFactoryInterfaceId?: string;
+  readonly excludeDebugFields?: boolean;
+}
+
+export interface PreparedTokenStandardV2AllocationCommand {
+  readonly command: Command;
+  readonly allocationFactoryContractId: string;
+  readonly disclosedContracts: readonly DisclosedContract[];
+  readonly choiceArgument: TokenStandardV2AllocationChoiceArgument;
+}
+
+export interface TokenStandardV2AllocationLedgerClient {
+  submitAndWaitForTransactionTree(
+    params: SubmitAndWaitForTransactionTreeParams
+  ): Promise<SubmitAndWaitForTransactionTreeResponse>;
+}
+
+export interface SubmitPreparedTokenStandardV2AllocationParams {
+  readonly ledger: TokenStandardV2AllocationLedgerClient;
+  readonly prepared: PreparedTokenStandardV2AllocationCommand;
+  readonly actAs: readonly string[];
+  readonly readAs?: readonly string[];
+  readonly commandId?: string;
+  readonly submissionId?: string;
+}
+
+export interface TokenStandardV2AllocationInstructionCompleted {
+  readonly type: 'Completed';
+  readonly allocationCid: string;
+}
+
+export interface TokenStandardV2AllocationInstructionPending {
+  readonly type: 'Pending';
+  readonly allocationInstructionCid: string;
+}
+
+export interface TokenStandardV2AllocationInstructionFailed {
+  readonly type: 'Failed';
+}
+
+export type TokenStandardV2AllocationInstructionResult =
+  | TokenStandardV2AllocationInstructionCompleted
+  | TokenStandardV2AllocationInstructionPending
+  | TokenStandardV2AllocationInstructionFailed;
+
+export interface SubmitPreparedTokenStandardV2AllocationResult {
+  readonly updateId: string;
+  readonly result: TokenStandardV2AllocationInstructionResult;
+  readonly response: SubmitAndWaitForTransactionTreeResponse;
+}
+
+function requireNonEmpty(value: string, fieldName: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be non-empty.`,
+      { field: fieldName }
+    );
+  }
+  return normalized;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeStrings(values: readonly string[], fieldName: string, allowEmpty = false): string[] {
+  if (!allowEmpty && values.length === 0) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must contain at least one value.`,
+      { field: fieldName }
+    );
+  }
+  return values.map((value, index) => requireNonEmpty(value, `${fieldName}[${index}]`));
+}
+
+function emptyTokenStandardV2ExtraArgs(): TokenStandardV2ExtraArgs {
+  return {
+    context: { values: {} },
+    meta: { values: {} },
+  };
+}
+
+function withDefaultTokenStandardV2Metadata<T extends { readonly meta?: TokenStandardV2Metadata }>(
+  value: T
+): Omit<T, 'meta'> & { readonly meta: TokenStandardV2Metadata } {
+  return {
+    ...value,
+    meta: value.meta ?? { values: {} },
+  };
+}
+
+export function buildTokenStandardV2AllocationChoiceArgument(
+  params: BuildTokenStandardV2AllocationChoiceArgumentParams
+): TokenStandardV2AllocationChoiceArgument {
+  const extraArgs = params.extraArgs ?? emptyTokenStandardV2ExtraArgs();
+  return {
+    settlement: withDefaultTokenStandardV2Metadata(params.settlement),
+    allocation: {
+      ...withDefaultTokenStandardV2Metadata(params.allocation),
+      admin: requireNonEmpty(params.allocation.admin, 'allocation.admin'),
+      transferLegSides: params.allocation.transferLegSides.map((transferLegSide) =>
+        withDefaultTokenStandardV2Metadata(transferLegSide)
+      ),
+      nextIterationFunding: params.allocation.nextIterationFunding ?? null,
+      committed: params.allocation.committed ?? true,
+    },
+    requestedAt: requireNonEmpty(params.requestedAt, 'requestedAt'),
+    inputHoldingCids: normalizeStrings(params.inputHoldingCids, 'inputHoldingCids', true),
+    extraArgs: {
+      context: extraArgs.context,
+      meta: extraArgs.meta,
+    },
+    actors: normalizeStrings(params.actors, 'actors'),
+  };
+}
+
+function buildTokenStandardV2AllocationCommandFromChoiceArgument(params: {
+  readonly allocationFactoryContractId: string;
+  readonly allocationFactoryInterfaceId?: string;
+  readonly choiceArgument: TokenStandardV2AllocationChoiceArgument;
+}): Command {
+  const templateId =
+    params.allocationFactoryInterfaceId === undefined
+      ? TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID
+      : requireNonEmpty(params.allocationFactoryInterfaceId, 'allocationFactoryInterfaceId');
+  return {
+    ExerciseCommand: {
+      templateId,
+      contractId: requireNonEmpty(params.allocationFactoryContractId, 'allocationFactoryContractId'),
+      choice: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE,
+      choiceArgument: params.choiceArgument as unknown as ExerciseCommand['ExerciseCommand']['choiceArgument'],
+    },
+  };
+}
+
+export function buildTokenStandardV2AllocationCommand(params: BuildTokenStandardV2AllocationCommandParams): Command {
+  return buildTokenStandardV2AllocationCommandFromChoiceArgument({
+    allocationFactoryContractId: params.allocationFactoryContractId,
+    ...(params.allocationFactoryInterfaceId === undefined
+      ? {}
+      : { allocationFactoryInterfaceId: params.allocationFactoryInterfaceId }),
+    choiceArgument: buildTokenStandardV2AllocationChoiceArgument(params),
+  });
+}
+
+function parseDisclosedContract(value: unknown): DisclosedContract {
+  const record = isRecord(value) ? value : undefined;
+  const templateId = readNonEmptyString(record?.['templateId']);
+  const contractId = readNonEmptyString(record?.['contractId']);
+  const createdEventBlob = readNonEmptyString(record?.['createdEventBlob']);
+  const synchronizerId = readNonEmptyString(record?.['synchronizerId']);
+  if (!templateId || !contractId || !createdEventBlob || !synchronizerId) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
+      'Token Standard V2 allocation registry returned an invalid disclosed contract.',
+      { value }
+    );
+  }
+  return {
+    templateId,
+    contractId,
+    createdEventBlob,
+    synchronizerId,
+  };
+}
+
+function parseAllocationFactoryResponse(value: unknown): {
+  readonly factoryId: string;
+  readonly choiceContextData: TokenStandardV2ChoiceContext;
+  readonly disclosedContracts: readonly DisclosedContract[];
+} {
+  const response = isRecord(value) ? value : undefined;
+  const choiceContext = isRecord(response?.['choiceContext']) ? response['choiceContext'] : undefined;
+  const choiceContextData = isRecord(choiceContext?.['choiceContextData'])
+    ? choiceContext['choiceContextData']
+    : undefined;
+  const disclosedContracts = choiceContext?.['disclosedContracts'];
+  const factoryId = readNonEmptyString(response?.['factoryId']);
+  if (!factoryId || !choiceContextData || !Array.isArray(disclosedContracts)) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
+      'Token Standard V2 allocation registry returned an invalid factory choice context.',
+      { value }
+    );
+  }
+  return {
+    factoryId,
+    choiceContextData,
+    disclosedContracts: disclosedContracts.map(parseDisclosedContract),
+  };
+}
+
+export async function prepareTokenStandardV2AllocationCommand(
+  params: PrepareTokenStandardV2AllocationCommandParams
+): Promise<PreparedTokenStandardV2AllocationCommand> {
+  const registryUrl = requireNonEmpty(params.registryUrl, 'registryUrl');
+  const initialChoiceArgument = buildTokenStandardV2AllocationChoiceArgument(params);
+  const request: GetAllocationFactoryFromRegistryParams = {
+    registryUrl,
+    choiceArguments: initialChoiceArgument as unknown as GetAllocationFactoryFromRegistryParams['choiceArguments'],
+    ...(params.excludeDebugFields === undefined ? {} : { excludeDebugFields: params.excludeDebugFields }),
+  };
+  const factory = parseAllocationFactoryResponse(await params.scan.getAllocationFactoryFromRegistry(request));
+  const choiceArgument: TokenStandardV2AllocationChoiceArgument = {
+    ...initialChoiceArgument,
+    extraArgs: {
+      ...initialChoiceArgument.extraArgs,
+      context: factory.choiceContextData,
+    },
+  };
+  return {
+    allocationFactoryContractId: factory.factoryId,
+    disclosedContracts: factory.disclosedContracts,
+    choiceArgument,
+    command: buildTokenStandardV2AllocationCommandFromChoiceArgument({
+      allocationFactoryContractId: factory.factoryId,
+      ...(params.allocationFactoryInterfaceId === undefined
+        ? {}
+        : { allocationFactoryInterfaceId: params.allocationFactoryInterfaceId }),
+      choiceArgument,
+    }),
+  };
+}
+
+function tryParseTokenStandardV2AllocationInstructionResult(
+  value: unknown
+): TokenStandardV2AllocationInstructionResult | undefined {
+  const record = isRecord(value) ? value : undefined;
+  const output = isRecord(record?.['output']) ? record['output'] : undefined;
+  const tag = readNonEmptyString(output?.['tag']);
+  if (!tag) return undefined;
+  const variant = isRecord(output?.['value']) ? output['value'] : undefined;
+  switch (tag) {
+    case 'AllocationInstructionResult_Completed': {
+      const allocationCid = readNonEmptyString(variant?.['allocationCid']);
+      return allocationCid ? { type: 'Completed', allocationCid } : undefined;
+    }
+    case 'AllocationInstructionResult_Pending': {
+      const allocationInstructionCid = readNonEmptyString(variant?.['allocationInstructionCid']);
+      return allocationInstructionCid ? { type: 'Pending', allocationInstructionCid } : undefined;
+    }
+    case 'AllocationInstructionResult_Failed':
+      return { type: 'Failed' };
+    default:
+      return undefined;
+  }
+}
+
+export function parseTokenStandardV2AllocationInstructionResult(
+  value: unknown
+): TokenStandardV2AllocationInstructionResult {
+  const parsed = tryParseTokenStandardV2AllocationInstructionResult(value);
+  if (!parsed) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_RESULT_INVALID',
+      'Token Standard V2 AllocationInstructionResult is malformed.',
+      { value }
+    );
+  }
+  return parsed;
+}
+
+export function findTokenStandardV2AllocationInstructionResult(
+  input: unknown
+): TokenStandardV2AllocationInstructionResult | undefined {
+  const direct = tryParseTokenStandardV2AllocationInstructionResult(input);
+  if (direct) return direct;
+
+  const { exercised } = extractEventsFromTransaction(input);
+  for (const event of exercised) {
+    if (event.choice !== TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE) continue;
+    const parsed = tryParseTokenStandardV2AllocationInstructionResult(event.exerciseResult);
+    if (parsed) return parsed;
+  }
+  return undefined;
+}
+
+function readTransactionTreeUpdateId(response: unknown): string | undefined {
+  if (!isRecord(response)) return undefined;
+  const transactionTree = isRecord(response['transactionTree']) ? response['transactionTree'] : undefined;
+  return readNonEmptyString(transactionTree?.['updateId']);
+}
+
+export async function submitPreparedTokenStandardV2Allocation(
+  params: SubmitPreparedTokenStandardV2AllocationParams
+): Promise<SubmitPreparedTokenStandardV2AllocationResult> {
+  const actAs = normalizeStrings(params.actAs, 'actAs');
+  const readAs = params.readAs ? normalizeStrings(params.readAs, 'readAs', true) : [];
+  const submitParams: SubmitAndWaitForTransactionTreeParams = {
+    commands: [params.prepared.command],
+    actAs,
+    ...(readAs.length > 0 ? { readAs } : {}),
+    disclosedContracts: [...params.prepared.disclosedContracts],
+    ...(params.commandId ? { commandId: params.commandId } : {}),
+    ...(params.submissionId ? { submissionId: params.submissionId } : {}),
+  };
+  const response = await params.ledger.submitAndWaitForTransactionTree(submitParams);
+  const result = findTokenStandardV2AllocationInstructionResult(response);
+  if (!result) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_RESULT_NOT_FOUND',
+      `${TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE} result was not found in the transaction tree.`,
+      { updateId: readTransactionTreeUpdateId(response) }
+    );
+  }
+  const updateId = readTransactionTreeUpdateId(response);
+  if (!updateId) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_RESULT_INVALID',
+      'Token Standard V2 allocation submission response did not include transactionTree.updateId.',
+      { response }
+    );
+  }
+  return {
+    updateId,
+    result,
+    response,
+  };
+}

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -366,18 +366,6 @@ function normalizePositiveDecimal(value: unknown, fieldName: string): string {
   return decimal.text;
 }
 
-function normalizeNonNegativeDecimal(value: unknown, fieldName: string): string {
-  const decimal = parseDecimalText(value, fieldName);
-  if (decimal.sign === -1) {
-    throw new TokenStandardV2AllocationError(
-      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
-      `${fieldName} must be non-negative.`,
-      { field: fieldName }
-    );
-  }
-  return decimal.text;
-}
-
 function normalizeFunding(
   value: Readonly<Record<string, string>> | null | undefined,
   fieldName: string
@@ -387,7 +375,7 @@ function normalizeFunding(
   const normalized = Object.create(null) as Record<string, string>;
   for (const [key, amount] of Object.entries(funding)) {
     Object.defineProperty(normalized, key, {
-      value: normalizeNonNegativeDecimal(amount, `${fieldName}.${key}`),
+      value: normalizePositiveDecimal(amount, `${fieldName}.${key}`),
       enumerable: true,
       configurable: true,
       writable: false,

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -331,7 +331,7 @@ function normalizeAccount(value: unknown, fieldName: string): TokenStandardV2Acc
 
 function parseDecimalText(value: unknown, fieldName: string): { readonly text: string; readonly sign: -1 | 0 | 1 } {
   const text = requireNonEmpty(value, fieldName);
-  const match = /^([+-]?)(\d{1,28})(?:\.(\d{1,10}))?$/.exec(text);
+  const match = /^(-?)(\d{1,28})(?:\.(\d{1,10}))?$/.exec(text);
   if (!match) {
     throw new TokenStandardV2AllocationError(
       TokenStandardV2AllocationErrorCode.INPUT_INVALID,

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -330,15 +330,15 @@ function normalizeAccount(value: unknown, fieldName: string): TokenStandardV2Acc
 
 function parseDecimalText(value: unknown, fieldName: string): { readonly text: string; readonly sign: -1 | 0 | 1 } {
   const text = requireNonEmpty(value, fieldName);
-  const match = /^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))$/.exec(text);
+  const match = /^([+-]?)(\d{1,28})(?:\.(\d{1,10}))?$/.exec(text);
   if (!match) {
     throw new TokenStandardV2AllocationError(
       'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
-      `${fieldName} must be a base-10 decimal string.`,
+      `${fieldName} must be a valid Daml Decimal string.`,
       { field: fieldName }
     );
   }
-  const digits = `${match[2] ?? ''}${match[3] ?? ''}${match[4] ?? ''}`;
+  const digits = `${match[2]}${match[3] ?? ''}`;
   const sign = /^0+$/.test(digits) ? 0 : match[1] === '-' ? -1 : 1;
   return { text, sign };
 }

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -3,7 +3,7 @@ import type {
   SubmitAndWaitForTransactionTreeResponse,
 } from '../../../clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree';
 import type { Command, DisclosedContract, ExerciseCommand } from '../../../clients/ledger-json-api/schemas';
-import type { GetAllocationFactoryFromRegistryParams } from '../../../clients/scan-api/operations/v0/registry/allocation-instruction/v1/get-allocation-factory-from-registry';
+import type { GetAllocationFactoryV2FromRegistryParams } from '../../../clients/scan-api/operations/v0/registry/allocation-instruction/v2/get-allocation-factory-v2-from-registry';
 import { CantonError, type ErrorContext } from '../../../core/errors';
 import { isRecord } from '../../../core/utils';
 import { extractEventsFromTransaction } from '../../parsers';
@@ -32,7 +32,9 @@ export class TokenStandardV2AllocationError extends CantonError {
   }
 }
 
-export type TokenStandardV2ChoiceContext = Readonly<Record<string, unknown>>;
+export interface TokenStandardV2ChoiceContext {
+  readonly values: Readonly<Record<string, unknown>>;
+}
 
 export interface TokenStandardV2ExtraArgs {
   readonly context: TokenStandardV2ChoiceContext;
@@ -62,10 +64,8 @@ export interface TokenStandardV2AllocationSpecification {
   readonly authorizer: TokenStandardV2Account;
   readonly transferLegSides: readonly TokenStandardV2TransferLegSide[];
   readonly settlementDeadline: string | null;
-  /** Undefined selects the helper default; null is the Token Standard optional value sent to the ledger. */
   readonly nextIterationFunding?: Readonly<Record<string, string>> | null;
-  /** Token Standard V2 allocation instructions are committed by default. */
-  readonly committed?: boolean;
+  readonly committed: boolean;
   readonly meta?: TokenStandardV2Metadata;
 }
 
@@ -104,12 +104,17 @@ export interface BuildTokenStandardV2AllocationCommandParams extends BuildTokenS
 }
 
 export interface TokenStandardV2AllocationRegistryClient {
-  getAllocationFactoryFromRegistry(params: GetAllocationFactoryFromRegistryParams): Promise<unknown>;
+  getAllocationFactoryV2FromRegistry(params: GetAllocationFactoryV2FromRegistryParams): Promise<unknown>;
 }
 
-export interface PrepareTokenStandardV2AllocationCommandParams extends BuildTokenStandardV2AllocationChoiceArgumentParams {
+export interface PrepareTokenStandardV2AllocationCommandParams extends Omit<
+  BuildTokenStandardV2AllocationChoiceArgumentParams,
+  'extraArgs'
+> {
   readonly registryUrl: string;
   readonly scan: TokenStandardV2AllocationRegistryClient;
+  /** Caller metadata is applied only after the registry returns its choice context. */
+  readonly metadata?: TokenStandardV2Metadata;
   readonly allocationFactoryInterfaceId?: string;
   readonly excludeDebugFields?: boolean;
 }
@@ -132,21 +137,31 @@ export interface SubmitPreparedTokenStandardV2AllocationParams {
   readonly prepared: PreparedTokenStandardV2AllocationCommand;
   readonly actAs: readonly string[];
   readonly readAs?: readonly string[];
-  readonly commandId?: string;
+  /** Stable across retries so Canton command deduplication can protect against duplicate allocations. */
+  readonly commandId: string;
   readonly submissionId?: string;
+  readonly deduplicationPeriod?: SubmitAndWaitForTransactionTreeParams['deduplicationPeriod'];
+  readonly synchronizerId?: string;
+  readonly userId?: string;
+  readonly workflowId?: string;
 }
 
-export interface TokenStandardV2AllocationInstructionCompleted {
+export interface TokenStandardV2AllocationInstructionResultBase {
+  readonly authorizerChangeCids: Readonly<Record<string, readonly string[]>>;
+  readonly meta: TokenStandardV2Metadata;
+}
+
+export interface TokenStandardV2AllocationInstructionCompleted extends TokenStandardV2AllocationInstructionResultBase {
   readonly type: 'Completed';
   readonly allocationCid: string;
 }
 
-export interface TokenStandardV2AllocationInstructionPending {
+export interface TokenStandardV2AllocationInstructionPending extends TokenStandardV2AllocationInstructionResultBase {
   readonly type: 'Pending';
   readonly allocationInstructionCid: string;
 }
 
-export interface TokenStandardV2AllocationInstructionFailed {
+export interface TokenStandardV2AllocationInstructionFailed extends TokenStandardV2AllocationInstructionResultBase {
   readonly type: 'Failed';
 }
 
@@ -161,7 +176,14 @@ export interface SubmitPreparedTokenStandardV2AllocationResult {
   readonly response: SubmitAndWaitForTransactionTreeResponse;
 }
 
-function requireNonEmpty(value: string, fieldName: string): string {
+function requireNonEmpty(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be a string.`,
+      { field: fieldName }
+    );
+  }
   const normalized = value.trim();
   if (normalized.length === 0) {
     throw new TokenStandardV2AllocationError(
@@ -173,6 +195,17 @@ function requireNonEmpty(value: string, fieldName: string): string {
   return normalized;
 }
 
+function requireText(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      `${fieldName} must be text.`,
+      { field: fieldName }
+    );
+  }
+  return value;
+}
+
 function readNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value.trim();
@@ -180,6 +213,13 @@ function readNonEmptyString(value: unknown): string | undefined {
 }
 
 function normalizeStrings(values: readonly string[], fieldName: string, allowEmpty = false): string[] {
+  if (!Array.isArray(values)) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be an array.`,
+      { field: fieldName }
+    );
+  }
   if (!allowEmpty && values.length === 0) {
     throw new TokenStandardV2AllocationError(
       'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
@@ -190,6 +230,161 @@ function normalizeStrings(values: readonly string[], fieldName: string, allowEmp
   return values.map((value, index) => requireNonEmpty(value, `${fieldName}[${index}]`));
 }
 
+function copyStringRecord(value: unknown, fieldName: string): Readonly<Record<string, string>> {
+  if (!isRecord(value)) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be a string map.`,
+      { field: fieldName }
+    );
+  }
+  const result = Object.create(null) as Record<string, string>;
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== 'string') {
+      throw new TokenStandardV2AllocationError(
+        'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+        `${fieldName}.${key} must be a string.`,
+        { field: `${fieldName}.${key}` }
+      );
+    }
+    Object.defineProperty(result, key, {
+      value: entry,
+      enumerable: true,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return result;
+}
+
+function normalizeMetadata(value: unknown, fieldName: string): TokenStandardV2Metadata {
+  if (!isRecord(value)) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be Token Standard metadata.`,
+      { field: fieldName }
+    );
+  }
+  return { values: copyStringRecord(value['values'], `${fieldName}.values`) };
+}
+
+function normalizeChoiceContext(
+  value: unknown,
+  fieldName: string,
+  code: TokenStandardV2AllocationErrorCode = TokenStandardV2AllocationErrorCode.FACTORY_RESPONSE_INVALID
+): TokenStandardV2ChoiceContext {
+  if (!isRecord(value) || !isRecord(value['values'])) {
+    throw new TokenStandardV2AllocationError(code, `${fieldName} must be a Token Standard choice context.`, {
+      field: fieldName,
+    });
+  }
+  const values = Object.create(null) as Record<string, unknown>;
+  for (const [key, entry] of Object.entries(value['values'])) {
+    Object.defineProperty(values, key, {
+      value: entry,
+      enumerable: true,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return { values };
+}
+
+function normalizeAccount(value: unknown, fieldName: string): TokenStandardV2Account {
+  if (!isRecord(value)) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be a Token Standard V2 account.`,
+      { field: fieldName }
+    );
+  }
+  const { id, owner, provider } = value;
+  if (typeof id !== 'string') {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be a Token Standard V2 account.`,
+      { field: fieldName }
+    );
+  }
+  if (owner !== null && typeof owner !== 'string') {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName}.owner must be a party or null.`,
+      { field: `${fieldName}.owner` }
+    );
+  }
+  if (provider !== null && typeof provider !== 'string') {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName}.provider must be a party or null.`,
+      { field: `${fieldName}.provider` }
+    );
+  }
+  return {
+    owner: owner === null ? null : requireNonEmpty(owner, `${fieldName}.owner`),
+    provider: provider === null ? null : requireNonEmpty(provider, `${fieldName}.provider`),
+    // CIP-112 uses the empty string as the default account identifier.
+    id,
+  };
+}
+
+function parseDecimalText(value: unknown, fieldName: string): { readonly text: string; readonly sign: -1 | 0 | 1 } {
+  const text = requireNonEmpty(value, fieldName);
+  const match = /^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))$/.exec(text);
+  if (!match) {
+    throw new TokenStandardV2AllocationError(
+      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      `${fieldName} must be a base-10 decimal string.`,
+      { field: fieldName }
+    );
+  }
+  const digits = `${match[2] ?? ''}${match[3] ?? ''}${match[4] ?? ''}`;
+  const sign = /^0+$/.test(digits) ? 0 : match[1] === '-' ? -1 : 1;
+  return { text, sign };
+}
+
+function normalizePositiveDecimal(value: unknown, fieldName: string): string {
+  const decimal = parseDecimalText(value, fieldName);
+  if (decimal.sign !== 1) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      `${fieldName} must be positive.`,
+      { field: fieldName }
+    );
+  }
+  return decimal.text;
+}
+
+function normalizeNonNegativeDecimal(value: unknown, fieldName: string): string {
+  const decimal = parseDecimalText(value, fieldName);
+  if (decimal.sign === -1) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      `${fieldName} must be non-negative.`,
+      { field: fieldName }
+    );
+  }
+  return decimal.text;
+}
+
+function normalizeFunding(
+  value: Readonly<Record<string, string>> | null | undefined,
+  fieldName: string
+): Readonly<Record<string, string>> | null {
+  if (value === null || value === undefined) return null;
+  const funding = copyStringRecord(value, fieldName);
+  const normalized = Object.create(null) as Record<string, string>;
+  for (const [key, amount] of Object.entries(funding)) {
+    Object.defineProperty(normalized, key, {
+      value: normalizeNonNegativeDecimal(amount, `${fieldName}.${key}`),
+      enumerable: true,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return normalized;
+}
+
 function emptyTokenStandardV2ExtraArgs(): TokenStandardV2ExtraArgs {
   return {
     context: { values: {} },
@@ -198,11 +393,12 @@ function emptyTokenStandardV2ExtraArgs(): TokenStandardV2ExtraArgs {
 }
 
 function withDefaultTokenStandardV2Metadata<T extends { readonly meta?: TokenStandardV2Metadata }>(
-  value: T
+  value: T,
+  fieldName: string
 ): Omit<T, 'meta'> & { readonly meta: TokenStandardV2Metadata } {
   return {
     ...value,
-    meta: value.meta ?? { values: {} },
+    meta: normalizeMetadata(value.meta ?? { values: {} }, `${fieldName}.meta`),
   };
 }
 
@@ -210,22 +406,96 @@ export function buildTokenStandardV2AllocationChoiceArgument(
   params: BuildTokenStandardV2AllocationChoiceArgumentParams
 ): TokenStandardV2AllocationChoiceArgument {
   const extraArgs = params.extraArgs ?? emptyTokenStandardV2ExtraArgs();
+  if (!Array.isArray(params.allocation.transferLegSides)) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'allocation.transferLegSides must be an array.',
+      { field: 'allocation.transferLegSides' }
+    );
+  }
+  if (typeof params.allocation.committed !== 'boolean') {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'allocation.committed must be a boolean.',
+      { field: 'allocation.committed' }
+    );
+  }
+  const settlement = withDefaultTokenStandardV2Metadata(params.settlement, 'settlement');
+  const allocation = withDefaultTokenStandardV2Metadata(params.allocation, 'allocation');
+  const transferLegSides: TokenStandardV2AllocationChoiceArgument['allocation']['transferLegSides'] =
+    params.allocation.transferLegSides.map((transferLegSide, index) => {
+      const fieldName = `allocation.transferLegSides[${index}]`;
+      if (!isRecord(transferLegSide)) {
+        throw new TokenStandardV2AllocationError(
+          TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+          `${fieldName} must be a transfer-leg side.`,
+          { field: fieldName }
+        );
+      }
+      const { amount, instrumentId, otherside, side, transferLegId } = transferLegSide;
+      if (side !== 'SenderSide' && side !== 'ReceiverSide') {
+        throw new TokenStandardV2AllocationError(
+          TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+          `${fieldName}.side must be SenderSide or ReceiverSide.`,
+          { field: `${fieldName}.side` }
+        );
+      }
+      return {
+        ...withDefaultTokenStandardV2Metadata(transferLegSide, fieldName),
+        transferLegId: requireText(transferLegId, `${fieldName}.transferLegId`),
+        side,
+        otherside: normalizeAccount(otherside, `${fieldName}.otherside`),
+        amount: normalizePositiveDecimal(amount, `${fieldName}.amount`),
+        instrumentId: requireText(instrumentId, `${fieldName}.instrumentId`),
+      };
+    });
+  const transferLegSideKeys = transferLegSides.map(({ side, transferLegId }) => JSON.stringify([transferLegId, side]));
+  if (new Set(transferLegSideKeys).size !== transferLegSideKeys.length) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'allocation.transferLegSides must not contain duplicate transfer-leg sides.',
+      { field: 'allocation.transferLegSides' }
+    );
+  }
+  const nextIterationFunding = normalizeFunding(
+    params.allocation.nextIterationFunding,
+    'allocation.nextIterationFunding'
+  );
+  if (transferLegSides.length === 0 && nextIterationFunding === null) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      'allocation.transferLegSides may be empty only when iterated settlement is enabled.',
+      { field: 'allocation.transferLegSides' }
+    );
+  }
   return {
-    settlement: withDefaultTokenStandardV2Metadata(params.settlement),
+    settlement: {
+      ...settlement,
+      executors: normalizeStrings(params.settlement.executors, 'settlement.executors'),
+      id: requireText(params.settlement.id, 'settlement.id'),
+      cid: params.settlement.cid === null ? null : requireNonEmpty(params.settlement.cid, 'settlement.cid'),
+    },
     allocation: {
-      ...withDefaultTokenStandardV2Metadata(params.allocation),
+      ...allocation,
       admin: requireNonEmpty(params.allocation.admin, 'allocation.admin'),
-      transferLegSides: params.allocation.transferLegSides.map((transferLegSide) =>
-        withDefaultTokenStandardV2Metadata(transferLegSide)
-      ),
-      nextIterationFunding: params.allocation.nextIterationFunding ?? null,
-      committed: params.allocation.committed ?? true,
+      authorizer: normalizeAccount(params.allocation.authorizer, 'allocation.authorizer'),
+      transferLegSides,
+      settlementDeadline:
+        params.allocation.settlementDeadline === null
+          ? null
+          : requireNonEmpty(params.allocation.settlementDeadline, 'allocation.settlementDeadline'),
+      nextIterationFunding,
+      committed: params.allocation.committed,
     },
     requestedAt: requireNonEmpty(params.requestedAt, 'requestedAt'),
     inputHoldingCids: normalizeStrings(params.inputHoldingCids, 'inputHoldingCids', true),
     extraArgs: {
-      context: extraArgs.context,
-      meta: extraArgs.meta,
+      context: normalizeChoiceContext(
+        extraArgs.context,
+        'extraArgs.context',
+        TokenStandardV2AllocationErrorCode.INPUT_INVALID
+      ),
+      meta: normalizeMetadata(extraArgs.meta, 'extraArgs.meta'),
     },
     actors: normalizeStrings(params.actors, 'actors'),
   };
@@ -288,12 +558,10 @@ function parseAllocationFactoryResponse(value: unknown): {
 } {
   const response = isRecord(value) ? value : undefined;
   const choiceContext = isRecord(response?.['choiceContext']) ? response['choiceContext'] : undefined;
-  const choiceContextData = isRecord(choiceContext?.['choiceContextData'])
-    ? choiceContext['choiceContextData']
-    : undefined;
+  const choiceContextData = choiceContext?.['choiceContextData'];
   const disclosedContracts = choiceContext?.['disclosedContracts'];
   const factoryId = readNonEmptyString(response?.['factoryId']);
-  if (!factoryId || !choiceContextData || !Array.isArray(disclosedContracts)) {
+  if (!factoryId || !Array.isArray(disclosedContracts)) {
     throw new TokenStandardV2AllocationError(
       'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
       'Token Standard V2 allocation registry returned an invalid factory choice context.',
@@ -302,7 +570,7 @@ function parseAllocationFactoryResponse(value: unknown): {
   }
   return {
     factoryId,
-    choiceContextData,
+    choiceContextData: normalizeChoiceContext(choiceContextData, 'choiceContext.choiceContextData'),
     disclosedContracts: disclosedContracts.map(parseDisclosedContract),
   };
 }
@@ -311,18 +579,21 @@ export async function prepareTokenStandardV2AllocationCommand(
   params: PrepareTokenStandardV2AllocationCommandParams
 ): Promise<PreparedTokenStandardV2AllocationCommand> {
   const registryUrl = requireNonEmpty(params.registryUrl, 'registryUrl');
-  const initialChoiceArgument = buildTokenStandardV2AllocationChoiceArgument(params);
-  const request: GetAllocationFactoryFromRegistryParams = {
+  const registryChoiceArgument = buildTokenStandardV2AllocationChoiceArgument({
+    ...params,
+    extraArgs: emptyTokenStandardV2ExtraArgs(),
+  });
+  const request: GetAllocationFactoryV2FromRegistryParams = {
     registryUrl,
-    choiceArguments: initialChoiceArgument as unknown as GetAllocationFactoryFromRegistryParams['choiceArguments'],
-    ...(params.excludeDebugFields === undefined ? {} : { excludeDebugFields: params.excludeDebugFields }),
+    choiceArguments: registryChoiceArgument as unknown as GetAllocationFactoryV2FromRegistryParams['choiceArguments'],
+    excludeDebugFields: params.excludeDebugFields ?? true,
   };
-  const factory = parseAllocationFactoryResponse(await params.scan.getAllocationFactoryFromRegistry(request));
+  const factory = parseAllocationFactoryResponse(await params.scan.getAllocationFactoryV2FromRegistry(request));
   const choiceArgument: TokenStandardV2AllocationChoiceArgument = {
-    ...initialChoiceArgument,
+    ...registryChoiceArgument,
     extraArgs: {
-      ...initialChoiceArgument.extraArgs,
       context: factory.choiceContextData,
+      meta: normalizeMetadata(params.metadata ?? { values: {} }, 'metadata'),
     },
   };
   return {
@@ -339,6 +610,41 @@ export async function prepareTokenStandardV2AllocationCommand(
   };
 }
 
+function tryReadMetadata(value: unknown): TokenStandardV2Metadata | undefined {
+  if (!isRecord(value) || !isRecord(value['values'])) return undefined;
+  const values = Object.create(null) as Record<string, string>;
+  for (const [key, entry] of Object.entries(value['values'])) {
+    if (typeof entry !== 'string') return undefined;
+    Object.defineProperty(values, key, {
+      value: entry,
+      enumerable: true,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return { values };
+}
+
+function tryReadAuthorizerChangeCids(value: unknown): Readonly<Record<string, readonly string[]>> | undefined {
+  if (!isRecord(value)) return undefined;
+  const result = Object.create(null) as Record<string, readonly string[]>;
+  for (const [key, entry] of Object.entries(value)) {
+    if (
+      !Array.isArray(entry) ||
+      !entry.every((contractId) => typeof contractId === 'string' && contractId.trim().length > 0)
+    ) {
+      return undefined;
+    }
+    Object.defineProperty(result, key, {
+      value: entry.map((contractId) => contractId.trim()),
+      enumerable: true,
+      configurable: true,
+      writable: false,
+    });
+  }
+  return result;
+}
+
 function tryParseTokenStandardV2AllocationInstructionResult(
   value: unknown
 ): TokenStandardV2AllocationInstructionResult | undefined {
@@ -347,17 +653,21 @@ function tryParseTokenStandardV2AllocationInstructionResult(
   const tag = readNonEmptyString(output?.['tag']);
   if (!tag) return undefined;
   const variant = isRecord(output?.['value']) ? output['value'] : undefined;
+  const authorizerChangeCids = tryReadAuthorizerChangeCids(record?.['authorizerChangeCids']);
+  const meta = tryReadMetadata(record?.['meta']);
+  if (!authorizerChangeCids || !meta) return undefined;
+  const common = { authorizerChangeCids, meta };
   switch (tag) {
     case 'AllocationInstructionResult_Completed': {
       const allocationCid = readNonEmptyString(variant?.['allocationCid']);
-      return allocationCid ? { type: 'Completed', allocationCid } : undefined;
+      return allocationCid ? { type: 'Completed', allocationCid, ...common } : undefined;
     }
     case 'AllocationInstructionResult_Pending': {
       const allocationInstructionCid = readNonEmptyString(variant?.['allocationInstructionCid']);
-      return allocationInstructionCid ? { type: 'Pending', allocationInstructionCid } : undefined;
+      return allocationInstructionCid ? { type: 'Pending', allocationInstructionCid, ...common } : undefined;
     }
     case 'AllocationInstructionResult_Failed':
-      return { type: 'Failed' };
+      return { type: 'Failed', ...common };
     default:
       return undefined;
   }
@@ -378,7 +688,8 @@ export function parseTokenStandardV2AllocationInstructionResult(
 }
 
 export function findTokenStandardV2AllocationInstructionResult(
-  input: unknown
+  input: unknown,
+  allocationFactoryContractId?: string
 ): TokenStandardV2AllocationInstructionResult | undefined {
   const direct = tryParseTokenStandardV2AllocationInstructionResult(input);
   if (direct) return direct;
@@ -386,6 +697,7 @@ export function findTokenStandardV2AllocationInstructionResult(
   const { exercised } = extractEventsFromTransaction(input);
   for (const event of exercised) {
     if (event.choice !== TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE) continue;
+    if (allocationFactoryContractId !== undefined && event.contractId !== allocationFactoryContractId) continue;
     const parsed = tryParseTokenStandardV2AllocationInstructionResult(event.exerciseResult);
     if (parsed) return parsed;
   }
@@ -406,13 +718,21 @@ export async function submitPreparedTokenStandardV2Allocation(
   const submitParams: SubmitAndWaitForTransactionTreeParams = {
     commands: [params.prepared.command],
     actAs,
+    commandId: requireNonEmpty(params.commandId, 'commandId'),
     ...(readAs.length > 0 ? { readAs } : {}),
     disclosedContracts: [...params.prepared.disclosedContracts],
-    ...(params.commandId ? { commandId: params.commandId } : {}),
-    ...(params.submissionId ? { submissionId: params.submissionId } : {}),
+    ...(params.submissionId !== undefined
+      ? { submissionId: requireNonEmpty(params.submissionId, 'submissionId') }
+      : {}),
+    ...(params.deduplicationPeriod !== undefined ? { deduplicationPeriod: params.deduplicationPeriod } : {}),
+    ...(params.synchronizerId !== undefined
+      ? { synchronizerId: requireNonEmpty(params.synchronizerId, 'synchronizerId') }
+      : {}),
+    ...(params.userId !== undefined ? { userId: requireNonEmpty(params.userId, 'userId') } : {}),
+    ...(params.workflowId !== undefined ? { workflowId: requireNonEmpty(params.workflowId, 'workflowId') } : {}),
   };
   const response = await params.ledger.submitAndWaitForTransactionTree(submitParams);
-  const result = findTokenStandardV2AllocationInstructionResult(response);
+  const result = findTokenStandardV2AllocationInstructionResult(response, params.prepared.allocationFactoryContractId);
   if (!result) {
     throw new TokenStandardV2AllocationError(
       'TOKEN_STANDARD_V2_ALLOCATION_RESULT_NOT_FOUND',

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -196,6 +196,16 @@ function requireNonEmpty(value: unknown, fieldName: string): string {
   return normalized;
 }
 
+function requireInputRecord(value: unknown, fieldName: string): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new TokenStandardV2AllocationError(
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
+      `${fieldName} must be an object.`,
+      { field: fieldName }
+    );
+  }
+}
+
 function requireText(value: unknown, fieldName: string): string {
   if (typeof value !== 'string') {
     throw new TokenStandardV2AllocationError(
@@ -393,20 +403,29 @@ function emptyTokenStandardV2ExtraArgs(): TokenStandardV2ExtraArgs {
   };
 }
 
+function defaultWhenUndefined<T>(value: T | undefined, fallback: T): T {
+  if (value === undefined) return fallback;
+  return value;
+}
+
 function withDefaultTokenStandardV2Metadata<T extends { readonly meta?: TokenStandardV2Metadata }>(
   value: T,
   fieldName: string
 ): Omit<T, 'meta'> & { readonly meta: TokenStandardV2Metadata } {
   return {
     ...value,
-    meta: normalizeMetadata(value.meta ?? { values: {} }, `${fieldName}.meta`),
+    meta: normalizeMetadata(defaultWhenUndefined(value.meta, { values: {} }), `${fieldName}.meta`),
   };
 }
 
 export function buildTokenStandardV2AllocationChoiceArgument(
   params: BuildTokenStandardV2AllocationChoiceArgumentParams
 ): TokenStandardV2AllocationChoiceArgument {
-  const extraArgs = params.extraArgs ?? emptyTokenStandardV2ExtraArgs();
+  requireInputRecord(params, 'params');
+  requireInputRecord(params.settlement, 'settlement');
+  requireInputRecord(params.allocation, 'allocation');
+  if (params.extraArgs !== undefined) requireInputRecord(params.extraArgs, 'extraArgs');
+  const extraArgs = defaultWhenUndefined(params.extraArgs, emptyTokenStandardV2ExtraArgs());
   if (!Array.isArray(params.allocation.transferLegSides)) {
     throw new TokenStandardV2AllocationError(
       TokenStandardV2AllocationErrorCode.INPUT_INVALID,
@@ -579,6 +598,7 @@ function parseAllocationFactoryResponse(value: unknown): {
 export async function prepareTokenStandardV2AllocationCommand(
   params: PrepareTokenStandardV2AllocationCommandParams
 ): Promise<PreparedTokenStandardV2AllocationCommand> {
+  requireInputRecord(params, 'params');
   const registryUrl = requireNonEmpty(params.registryUrl, 'registryUrl');
   const registryChoiceArgument = buildTokenStandardV2AllocationChoiceArgument({
     ...params,
@@ -594,7 +614,7 @@ export async function prepareTokenStandardV2AllocationCommand(
     ...registryChoiceArgument,
     extraArgs: {
       context: factory.choiceContextData,
-      meta: normalizeMetadata(params.metadata ?? { values: {} }, 'metadata'),
+      meta: normalizeMetadata(defaultWhenUndefined(params.metadata, { values: {} }), 'metadata'),
     },
   };
   return {

--- a/src/utils/token-standard/v2/allocation.ts
+++ b/src/utils/token-standard/v2/allocation.ts
@@ -25,10 +25,11 @@ export type TokenStandardV2AllocationErrorCode =
   (typeof TokenStandardV2AllocationErrorCode)[keyof typeof TokenStandardV2AllocationErrorCode];
 
 export class TokenStandardV2AllocationError extends CantonError {
-  public override readonly name = 'TokenStandardV2AllocationError';
+  public override readonly name: string;
 
   public constructor(code: TokenStandardV2AllocationErrorCode, message: string, context?: ErrorContext) {
     super(message, code, context);
+    this.name = 'TokenStandardV2AllocationError';
   }
 }
 
@@ -179,7 +180,7 @@ export interface SubmitPreparedTokenStandardV2AllocationResult {
 function requireNonEmpty(value: unknown, fieldName: string): string {
   if (typeof value !== 'string') {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be a string.`,
       { field: fieldName }
     );
@@ -187,7 +188,7 @@ function requireNonEmpty(value: unknown, fieldName: string): string {
   const normalized = value.trim();
   if (normalized.length === 0) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be non-empty.`,
       { field: fieldName }
     );
@@ -215,14 +216,14 @@ function readNonEmptyString(value: unknown): string | undefined {
 function normalizeStrings(values: readonly string[], fieldName: string, allowEmpty = false): string[] {
   if (!Array.isArray(values)) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be an array.`,
       { field: fieldName }
     );
   }
   if (!allowEmpty && values.length === 0) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must contain at least one value.`,
       { field: fieldName }
     );
@@ -233,7 +234,7 @@ function normalizeStrings(values: readonly string[], fieldName: string, allowEmp
 function copyStringRecord(value: unknown, fieldName: string): Readonly<Record<string, string>> {
   if (!isRecord(value)) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be a string map.`,
       { field: fieldName }
     );
@@ -242,7 +243,7 @@ function copyStringRecord(value: unknown, fieldName: string): Readonly<Record<st
   for (const [key, entry] of Object.entries(value)) {
     if (typeof entry !== 'string') {
       throw new TokenStandardV2AllocationError(
-        'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+        TokenStandardV2AllocationErrorCode.INPUT_INVALID,
         `${fieldName}.${key} must be a string.`,
         { field: `${fieldName}.${key}` }
       );
@@ -260,7 +261,7 @@ function copyStringRecord(value: unknown, fieldName: string): Readonly<Record<st
 function normalizeMetadata(value: unknown, fieldName: string): TokenStandardV2Metadata {
   if (!isRecord(value)) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be Token Standard metadata.`,
       { field: fieldName }
     );
@@ -293,7 +294,7 @@ function normalizeChoiceContext(
 function normalizeAccount(value: unknown, fieldName: string): TokenStandardV2Account {
   if (!isRecord(value)) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be a Token Standard V2 account.`,
       { field: fieldName }
     );
@@ -301,21 +302,21 @@ function normalizeAccount(value: unknown, fieldName: string): TokenStandardV2Acc
   const { id, owner, provider } = value;
   if (typeof id !== 'string') {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be a Token Standard V2 account.`,
       { field: fieldName }
     );
   }
   if (owner !== null && typeof owner !== 'string') {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName}.owner must be a party or null.`,
       { field: `${fieldName}.owner` }
     );
   }
   if (provider !== null && typeof provider !== 'string') {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName}.provider must be a party or null.`,
       { field: `${fieldName}.provider` }
     );
@@ -333,7 +334,7 @@ function parseDecimalText(value: unknown, fieldName: string): { readonly text: s
   const match = /^([+-]?)(\d{1,28})(?:\.(\d{1,10}))?$/.exec(text);
   if (!match) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      TokenStandardV2AllocationErrorCode.INPUT_INVALID,
       `${fieldName} must be a valid Daml Decimal string.`,
       { field: fieldName }
     );
@@ -538,7 +539,7 @@ function parseDisclosedContract(value: unknown): DisclosedContract {
   const synchronizerId = readNonEmptyString(record?.['synchronizerId']);
   if (!templateId || !contractId || !createdEventBlob || !synchronizerId) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
+      TokenStandardV2AllocationErrorCode.FACTORY_RESPONSE_INVALID,
       'Token Standard V2 allocation registry returned an invalid disclosed contract.',
       { value }
     );
@@ -563,7 +564,7 @@ function parseAllocationFactoryResponse(value: unknown): {
   const factoryId = readNonEmptyString(response?.['factoryId']);
   if (!factoryId || !Array.isArray(disclosedContracts)) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
+      TokenStandardV2AllocationErrorCode.FACTORY_RESPONSE_INVALID,
       'Token Standard V2 allocation registry returned an invalid factory choice context.',
       { value }
     );
@@ -679,7 +680,7 @@ export function parseTokenStandardV2AllocationInstructionResult(
   const parsed = tryParseTokenStandardV2AllocationInstructionResult(value);
   if (!parsed) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_RESULT_INVALID',
+      TokenStandardV2AllocationErrorCode.RESULT_INVALID,
       'Token Standard V2 AllocationInstructionResult is malformed.',
       { value }
     );
@@ -735,7 +736,7 @@ export async function submitPreparedTokenStandardV2Allocation(
   const result = findTokenStandardV2AllocationInstructionResult(response, params.prepared.allocationFactoryContractId);
   if (!result) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_RESULT_NOT_FOUND',
+      TokenStandardV2AllocationErrorCode.RESULT_NOT_FOUND,
       `${TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE} result was not found in the transaction tree.`,
       { updateId: readTransactionTreeUpdateId(response) }
     );
@@ -743,7 +744,7 @@ export async function submitPreparedTokenStandardV2Allocation(
   const updateId = readTransactionTreeUpdateId(response);
   if (!updateId) {
     throw new TokenStandardV2AllocationError(
-      'TOKEN_STANDARD_V2_ALLOCATION_RESULT_INVALID',
+      TokenStandardV2AllocationErrorCode.RESULT_INVALID,
       'Token Standard V2 allocation submission response did not include transactionTree.updateId.',
       { response }
     );

--- a/src/utils/token-standard/v2/index.ts
+++ b/src/utils/token-standard/v2/index.ts
@@ -1,0 +1,2 @@
+export * from './allocation';
+export * from './types';

--- a/src/utils/token-standard/v2/types.ts
+++ b/src/utils/token-standard/v2/types.ts
@@ -1,0 +1,14 @@
+export interface TokenStandardV2Account {
+  readonly owner: string | null;
+  readonly provider: string | null;
+  readonly id: string;
+}
+
+export interface TokenStandardV2InstrumentId {
+  readonly admin: string;
+  readonly id: string;
+}
+
+export interface TokenStandardV2Metadata {
+  readonly values: Readonly<Record<string, string>>;
+}

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -214,6 +214,49 @@ describe('ScanApiClient', () => {
     expect(requestHeaders).not.toHaveProperty('Authorization');
   });
 
+  it('gets a V2 allocation factory from its dedicated registry endpoint without auth', async () => {
+    const { client, mockAxiosInstance } = createClient(
+      { network: 'mainnet' },
+      {
+        scanApiUrls: ['https://scan.example/api/scan'],
+      }
+    );
+    const choiceArguments = {
+      settlement: { id: 'settlement-3' },
+      extraArgs: { context: { values: {} }, meta: { values: {} } },
+    };
+    const response = {
+      factoryId: '#allocation-factory-v2',
+      choiceContext: {
+        choiceContextData: { values: {} },
+        disclosedContracts: [],
+      },
+    };
+    mockAxiosInstance.post.mockResolvedValueOnce({ data: response });
+
+    await expect(
+      client.getAllocationFactoryV2FromRegistry({
+        registryUrl: 'https://cash-token.example/token-registry/',
+        choiceArguments,
+      })
+    ).resolves.toEqual(response);
+
+    expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+      'https://cash-token.example/token-registry/registry/allocation-instruction/v2/allocation-factory',
+      {
+        choiceArguments,
+        excludeDebugFields: false,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    const requestHeaders = mockAxiosInstance.post.mock.calls[0]?.[2]?.headers;
+    expect(requestHeaders).not.toHaveProperty('Authorization');
+  });
+
   it('strips embedded credentials and normalizes trailing slashes from registry URLs', async () => {
     const { client, mockAxiosInstance } = createClient(
       { network: 'mainnet' },

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -211,7 +211,7 @@ describe('Token Standard V2 allocation helpers', () => {
         })
       ).toThrow(TokenStandardV2AllocationError);
     }
-    for (const amount of ['+1.0', '9999999999999999999999999999.1234567890']) {
+    for (const amount of ['1.0', '9999999999999999999999999999.1234567890']) {
       expect(
         buildWithAllocation({
           ...allocationParams.allocation,
@@ -219,7 +219,7 @@ describe('Token Standard V2 allocation helpers', () => {
         }).allocation.transferLegSides[0]?.amount
       ).toBe(amount);
     }
-    for (const amount of ['1.', '10000000000000000000000000000', '1.12345678901']) {
+    for (const amount of ['+1.0', '1.', '10000000000000000000000000000', '1.12345678901']) {
       expect(() =>
         buildWithAllocation({
           ...allocationParams.allocation,

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -262,18 +262,20 @@ describe('Token Standard V2 allocation helpers', () => {
       ).toThrow(TokenStandardV2AllocationError);
     }
 
-    expect(() =>
-      buildWithAllocation({
-        ...allocationParams.allocation,
-        nextIterationFunding: { USD: '-1.0' },
-      })
-    ).toThrow(TokenStandardV2AllocationError);
+    for (const amount of ['-1.0', '0']) {
+      expect(() =>
+        buildWithAllocation({
+          ...allocationParams.allocation,
+          nextIterationFunding: { USD: amount },
+        })
+      ).toThrow(TokenStandardV2AllocationError);
+    }
     expect(
       buildWithAllocation({
         ...allocationParams.allocation,
-        nextIterationFunding: { USD: '0' },
+        nextIterationFunding: { USD: '0.1' },
       }).allocation.nextIterationFunding
-    ).toEqual({ USD: '0' });
+    ).toEqual({ USD: '0.1' });
   });
 
   test('prepares through an arbitrary registry and preserves its context and disclosures', async () => {

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -368,6 +368,29 @@ describe('Token Standard V2 allocation helpers', () => {
     });
   });
 
+  test('rejects malformed scan clients with typed input errors before registry access', async () => {
+    const malformedScans: readonly unknown[] = [
+      null,
+      undefined,
+      {},
+      { getAllocationFactoryV2FromRegistry: null },
+      { getAllocationFactoryV2FromRegistry: 'not-a-function' },
+    ];
+
+    for (const scan of malformedScans) {
+      await expect(
+        prepareTokenStandardV2AllocationCommand({
+          ...allocationParams,
+          registryUrl: 'https://cash.example/token-registry',
+          scan: scan as TokenStandardV2AllocationRegistryClient,
+        })
+      ).rejects.toMatchObject({
+        name: 'TokenStandardV2AllocationError',
+        code: 'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      });
+    }
+  });
+
   test.each([
     [
       'AllocationInstructionResult_Completed',
@@ -546,5 +569,50 @@ describe('Token Standard V2 allocation helpers', () => {
       })
     ).rejects.toThrow(TokenStandardV2AllocationError);
     expect(submitAndWaitForTransactionTree).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects malformed submit inputs with typed errors before ledger submission', async () => {
+    const prepared = await prepareTokenStandardV2AllocationCommand({
+      ...allocationParams,
+      registryUrl: 'https://cash.example',
+      scan: createRegistryClient({
+        factoryId: '#allocation-factory',
+        choiceContext: {
+          choiceContextData: { values: {} },
+          disclosedContracts: [],
+        },
+      }),
+    });
+    const submitAndWaitForTransactionTree = jest.fn();
+    const validParams = {
+      ledger: { submitAndWaitForTransactionTree },
+      prepared,
+      actAs: ['Buyer::alice'],
+      commandId: 'allocation-command',
+    };
+    const malformedParams: readonly unknown[] = [
+      null,
+      undefined,
+      { ...validParams, prepared: null },
+      { ...validParams, prepared: undefined },
+      { ...validParams, prepared: {} },
+      { ...validParams, prepared: { ...prepared, command: null } },
+      { ...validParams, prepared: { ...prepared, disclosedContracts: null } },
+      { ...validParams, prepared: { ...prepared, allocationFactoryContractId: null } },
+      { ...validParams, ledger: null },
+      { ...validParams, ledger: undefined },
+      { ...validParams, ledger: {} },
+      { ...validParams, ledger: { submitAndWaitForTransactionTree: null } },
+    ];
+
+    for (const params of malformedParams) {
+      await expect(
+        submitPreparedTokenStandardV2Allocation(params as Parameters<typeof submitPreparedTokenStandardV2Allocation>[0])
+      ).rejects.toMatchObject({
+        name: 'TokenStandardV2AllocationError',
+        code: 'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      });
+    }
+    expect(submitAndWaitForTransactionTree).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -211,13 +211,21 @@ describe('Token Standard V2 allocation helpers', () => {
         })
       ).toThrow(TokenStandardV2AllocationError);
     }
-    for (const amount of ['+1.0', '1.']) {
+    for (const amount of ['+1.0', '9999999999999999999999999999.1234567890']) {
       expect(
         buildWithAllocation({
           ...allocationParams.allocation,
           transferLegSides: [{ ...transferLegSide, amount }],
         }).allocation.transferLegSides[0]?.amount
       ).toBe(amount);
+    }
+    for (const amount of ['1.', '10000000000000000000000000000', '1.12345678901']) {
+      expect(() =>
+        buildWithAllocation({
+          ...allocationParams.allocation,
+          transferLegSides: [{ ...transferLegSide, amount }],
+        })
+      ).toThrow(TokenStandardV2AllocationError);
     }
 
     expect(() =>

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -1,0 +1,328 @@
+import type { SubmitAndWaitForTransactionTreeResponse } from '../../../../src/clients/ledger-json-api/operations/v2/commands/submit-and-wait-for-transaction-tree';
+import {
+  buildTokenStandardV2AllocationChoiceArgument,
+  buildTokenStandardV2AllocationCommand,
+  parseTokenStandardV2AllocationInstructionResult,
+  prepareTokenStandardV2AllocationCommand,
+  submitPreparedTokenStandardV2Allocation,
+  TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE,
+  TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID,
+  TokenStandardV2AllocationError,
+  type BuildTokenStandardV2AllocationChoiceArgumentParams,
+  type TokenStandardV2AllocationRegistryClient,
+} from '../../../../src/utils/token-standard';
+
+const allocationParams: BuildTokenStandardV2AllocationChoiceArgumentParams = {
+  settlement: {
+    executors: ['Venue::operator'],
+    id: 'settlement-3',
+    cid: null,
+  },
+  allocation: {
+    admin: 'CashAdmin::issuer',
+    authorizer: {
+      owner: 'Buyer::alice',
+      provider: null,
+      id: '',
+    },
+    transferLegSides: [
+      {
+        transferLegId: 'cash-leg',
+        side: 'SenderSide',
+        otherside: {
+          owner: 'Seller::bob',
+          provider: null,
+          id: '',
+        },
+        amount: '25.0',
+        instrumentId: 'USD',
+      },
+    ],
+    settlementDeadline: '2026-07-10T02:00:00.000Z',
+  },
+  requestedAt: '2026-07-10T01:00:00.000Z',
+  inputHoldingCids: ['#cash-holding'],
+  actors: ['Buyer::alice'],
+};
+
+function createRegistryClient(response: unknown): TokenStandardV2AllocationRegistryClient & {
+  readonly getAllocationFactoryFromRegistry: jest.Mock;
+} {
+  return {
+    getAllocationFactoryFromRegistry: jest.fn(async () => response),
+  };
+}
+
+describe('Token Standard V2 allocation helpers', () => {
+  test('builds the exact V2 AllocationFactory_Allocate command and defaults committed to true', () => {
+    expect(
+      buildTokenStandardV2AllocationCommand({
+        ...allocationParams,
+        allocationFactoryContractId: '#allocation-factory',
+      })
+    ).toEqual({
+      ExerciseCommand: {
+        templateId: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID,
+        contractId: '#allocation-factory',
+        choice: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE,
+        choiceArgument: {
+          settlement: {
+            ...allocationParams.settlement,
+            meta: { values: {} },
+          },
+          allocation: {
+            ...allocationParams.allocation,
+            transferLegSides: [
+              {
+                ...allocationParams.allocation.transferLegSides[0],
+                meta: { values: {} },
+              },
+            ],
+            nextIterationFunding: null,
+            committed: true,
+            meta: { values: {} },
+          },
+          requestedAt: allocationParams.requestedAt,
+          inputHoldingCids: allocationParams.inputHoldingCids,
+          extraArgs: {
+            context: { values: {} },
+            meta: { values: {} },
+          },
+          actors: allocationParams.actors,
+        },
+      },
+    });
+  });
+
+  test('preserves explicit committed false and permits a V2 interface ID override', () => {
+    const choiceArgument = buildTokenStandardV2AllocationChoiceArgument({
+      ...allocationParams,
+      allocation: {
+        ...allocationParams.allocation,
+        committed: false,
+      },
+    });
+    expect(choiceArgument.allocation.committed).toBe(false);
+
+    expect(
+      buildTokenStandardV2AllocationCommand({
+        ...allocationParams,
+        allocationFactoryContractId: '#allocation-factory',
+        allocationFactoryInterfaceId: '#custom-v2:Token:AllocationFactory',
+      })
+    ).toMatchObject({
+      ExerciseCommand: {
+        templateId: '#custom-v2:Token:AllocationFactory',
+      },
+    });
+  });
+
+  test('prepares through an arbitrary registry and preserves its context and disclosures', async () => {
+    const choiceContextData = {
+      values: {
+        'cash.example/rules': {
+          tag: 'AV_ContractId',
+          value: '#cash-rules',
+        },
+      },
+    };
+    const scan = createRegistryClient({
+      factoryId: '#allocation-factory',
+      choiceContext: {
+        choiceContextData,
+        disclosedContracts: [
+          {
+            templateId: '#cash:Cash:Rules',
+            contractId: '#cash-rules',
+            createdEventBlob: 'blob',
+            synchronizerId: 'sync::id',
+            debugPackageName: 'cash',
+            debugPayload: { admin: 'CashAdmin::issuer' },
+          },
+        ],
+      },
+    });
+    const prepared = await prepareTokenStandardV2AllocationCommand({
+      ...allocationParams,
+      extraArgs: {
+        context: { values: { ignored: true } },
+        meta: { values: { source: 'test' } },
+      },
+      registryUrl: 'https://cash.example/token-registry',
+      scan,
+      excludeDebugFields: true,
+    });
+
+    expect(scan.getAllocationFactoryFromRegistry).toHaveBeenCalledWith({
+      registryUrl: 'https://cash.example/token-registry',
+      choiceArguments: {
+        ...buildTokenStandardV2AllocationChoiceArgument({
+          ...allocationParams,
+          extraArgs: {
+            context: { values: { ignored: true } },
+            meta: { values: { source: 'test' } },
+          },
+        }),
+      },
+      excludeDebugFields: true,
+    });
+    expect(prepared.choiceArgument.extraArgs.context).toBe(choiceContextData);
+    expect(prepared.choiceArgument.extraArgs.meta).toEqual({ values: { source: 'test' } });
+    expect(prepared.disclosedContracts).toEqual([
+      {
+        templateId: '#cash:Cash:Rules',
+        contractId: '#cash-rules',
+        createdEventBlob: 'blob',
+        synchronizerId: 'sync::id',
+      },
+    ]);
+    expect(prepared.command).toMatchObject({
+      ExerciseCommand: {
+        contractId: '#allocation-factory',
+        choiceArgument: {
+          extraArgs: {
+            context: choiceContextData,
+            meta: { values: { source: 'test' } },
+          },
+        },
+      },
+    });
+  });
+
+  test.each([
+    [
+      'AllocationInstructionResult_Completed',
+      { allocationCid: '#allocation' },
+      { type: 'Completed', allocationCid: '#allocation' },
+    ],
+    [
+      'AllocationInstructionResult_Pending',
+      { allocationInstructionCid: '#instruction' },
+      { type: 'Pending', allocationInstructionCid: '#instruction' },
+    ],
+    ['AllocationInstructionResult_Failed', {}, { type: 'Failed' }],
+  ] as const)('parses the %s result variant', (tag, value, expected) => {
+    expect(parseTokenStandardV2AllocationInstructionResult({ output: { tag, value } })).toEqual(expected);
+  });
+
+  test('rejects malformed registry and result responses with typed errors', async () => {
+    const malformedRegistryResponses = [
+      { factoryId: '' },
+      {
+        factoryId: '#allocation-factory',
+        choiceContext: { choiceContextData: null, disclosedContracts: [] },
+      },
+      {
+        factoryId: '#allocation-factory',
+        choiceContext: {
+          choiceContextData: { values: {} },
+          disclosedContracts: [
+            {
+              templateId: '#cash:Cash:Rules',
+              contractId: '#cash-rules',
+              synchronizerId: 'sync::id',
+            },
+          ],
+        },
+      },
+    ];
+    for (const response of malformedRegistryResponses) {
+      await expect(
+        prepareTokenStandardV2AllocationCommand({
+          ...allocationParams,
+          registryUrl: 'https://cash.example',
+          scan: createRegistryClient(response),
+        })
+      ).rejects.toMatchObject({
+        name: 'TokenStandardV2AllocationError',
+        code: 'TOKEN_STANDARD_V2_ALLOCATION_FACTORY_RESPONSE_INVALID',
+      });
+    }
+
+    expect(() =>
+      parseTokenStandardV2AllocationInstructionResult({
+        output: {
+          tag: 'AllocationInstructionResult_Completed',
+          value: {},
+        },
+      })
+    ).toThrow(TokenStandardV2AllocationError);
+    let unknownTagError: unknown;
+    try {
+      parseTokenStandardV2AllocationInstructionResult({ output: { tag: 'Unknown', value: {} } });
+    } catch (error) {
+      unknownTagError = error;
+    }
+    expect(unknownTagError).toMatchObject({
+      code: 'TOKEN_STANDARD_V2_ALLOCATION_RESULT_INVALID',
+    });
+  });
+
+  test('forwards prepared commands and disclosures to ledger submission and parses the transaction result', async () => {
+    const scan = createRegistryClient({
+      factoryId: '#allocation-factory',
+      choiceContext: {
+        choiceContextData: { values: {} },
+        disclosedContracts: [
+          {
+            templateId: '#cash:Cash:Rules',
+            contractId: '#cash-rules',
+            createdEventBlob: 'blob',
+            synchronizerId: 'sync::id',
+          },
+        ],
+      },
+    });
+    const prepared = await prepareTokenStandardV2AllocationCommand({
+      ...allocationParams,
+      registryUrl: 'https://cash.example',
+      scan,
+    });
+    const response = {
+      transactionTree: {
+        updateId: 'update-3',
+        eventsById: {
+          0: {
+            ExercisedTreeEvent: {
+              value: {
+                contractId: '#allocation-factory',
+                templateId: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID,
+                choice: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE,
+                exerciseResult: {
+                  output: {
+                    tag: 'AllocationInstructionResult_Completed',
+                    value: { allocationCid: '#allocation' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as SubmitAndWaitForTransactionTreeResponse;
+    const submitAndWaitForTransactionTree = jest.fn(async () => response);
+
+    await expect(
+      submitPreparedTokenStandardV2Allocation({
+        ledger: { submitAndWaitForTransactionTree },
+        prepared,
+        actAs: [' Buyer::alice '],
+        readAs: ['Observer::ops'],
+        commandId: 'allocation-command',
+        submissionId: 'allocation-submission',
+      })
+    ).resolves.toEqual({
+      updateId: 'update-3',
+      result: { type: 'Completed', allocationCid: '#allocation' },
+      response,
+    });
+    expect(submitAndWaitForTransactionTree).toHaveBeenCalledWith({
+      commands: [prepared.command],
+      actAs: ['Buyer::alice'],
+      readAs: ['Observer::ops'],
+      disclosedContracts: [...prepared.disclosedContracts],
+      commandId: 'allocation-command',
+      submissionId: 'allocation-submission',
+    });
+  });
+});

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -137,6 +137,40 @@ describe('Token Standard V2 allocation helpers', () => {
     );
   });
 
+  test('rejects malformed runtime objects and null optional metadata with typed errors', () => {
+    const transferLegSide = allocationParams.allocation.transferLegSides[0];
+    if (!transferLegSide) throw new Error('test fixture must include one transfer-leg side');
+    const malformedParams: readonly unknown[] = [
+      null,
+      undefined,
+      { ...allocationParams, settlement: null },
+      { ...allocationParams, allocation: null },
+      { ...allocationParams, extraArgs: null },
+      { ...allocationParams, settlement: { ...allocationParams.settlement, meta: null } },
+      { ...allocationParams, allocation: { ...allocationParams.allocation, meta: null } },
+      {
+        ...allocationParams,
+        allocation: {
+          ...allocationParams.allocation,
+          transferLegSides: [{ ...transferLegSide, meta: null }],
+        },
+      },
+    ];
+
+    for (const value of malformedParams) {
+      let error: unknown;
+      try {
+        buildTokenStandardV2AllocationChoiceArgument(value as BuildTokenStandardV2AllocationChoiceArgumentParams);
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error).toMatchObject({
+        name: 'TokenStandardV2AllocationError',
+        code: 'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
+      });
+    }
+  });
+
   test('preserves settlement text identifiers and normalizes parties and contract ids', () => {
     expect(
       buildTokenStandardV2AllocationChoiceArgument({
@@ -307,6 +341,28 @@ describe('Token Standard V2 allocation helpers', () => {
           },
         },
       },
+    });
+  });
+
+  test('rejects null prepare metadata instead of treating it as absent', async () => {
+    const scan = createRegistryClient({
+      factoryId: '#allocation-factory',
+      choiceContext: {
+        choiceContextData: { values: {} },
+        disclosedContracts: [],
+      },
+    });
+
+    await expect(
+      prepareTokenStandardV2AllocationCommand({
+        ...allocationParams,
+        registryUrl: 'https://cash.example/token-registry',
+        scan,
+        metadata: null as never,
+      })
+    ).rejects.toMatchObject({
+      name: 'TokenStandardV2AllocationError',
+      code: 'TOKEN_STANDARD_V2_ALLOCATION_INPUT_INVALID',
     });
   });
 

--- a/test/unit/token-standard/v2/allocation.test.ts
+++ b/test/unit/token-standard/v2/allocation.test.ts
@@ -39,22 +39,28 @@ const allocationParams: BuildTokenStandardV2AllocationChoiceArgumentParams = {
       },
     ],
     settlementDeadline: '2026-07-10T02:00:00.000Z',
+    committed: true,
   },
   requestedAt: '2026-07-10T01:00:00.000Z',
   inputHoldingCids: ['#cash-holding'],
   actors: ['Buyer::alice'],
 };
 
+const allocationResultCommon = {
+  authorizerChangeCids: { change: ['#change-holding'] },
+  meta: { values: { source: 'registry' } },
+} as const;
+
 function createRegistryClient(response: unknown): TokenStandardV2AllocationRegistryClient & {
-  readonly getAllocationFactoryFromRegistry: jest.Mock;
+  readonly getAllocationFactoryV2FromRegistry: jest.Mock;
 } {
   return {
-    getAllocationFactoryFromRegistry: jest.fn(async () => response),
+    getAllocationFactoryV2FromRegistry: jest.fn(async () => response),
   };
 }
 
 describe('Token Standard V2 allocation helpers', () => {
-  test('builds the exact V2 AllocationFactory_Allocate command and defaults committed to true', () => {
+  test('builds the exact V2 AllocationFactory_Allocate command with explicit commitment', () => {
     expect(
       buildTokenStandardV2AllocationCommand({
         ...allocationParams,
@@ -117,6 +123,117 @@ describe('Token Standard V2 allocation helpers', () => {
     });
   });
 
+  test('requires callers to choose whether the allocation is committed', () => {
+    const missingCommitment = {
+      ...allocationParams,
+      allocation: {
+        ...allocationParams.allocation,
+        committed: undefined,
+      },
+    } as unknown as BuildTokenStandardV2AllocationChoiceArgumentParams;
+
+    expect(() => buildTokenStandardV2AllocationChoiceArgument(missingCommitment)).toThrow(
+      TokenStandardV2AllocationError
+    );
+  });
+
+  test('preserves settlement text identifiers and normalizes parties and contract ids', () => {
+    expect(
+      buildTokenStandardV2AllocationChoiceArgument({
+        ...allocationParams,
+        settlement: {
+          ...allocationParams.settlement,
+          executors: [' Venue::operator '],
+          id: ' settlement-3 ',
+          cid: ' #settlement-context ',
+        },
+      }).settlement
+    ).toMatchObject({
+      executors: ['Venue::operator'],
+      id: ' settlement-3 ',
+      cid: '#settlement-context',
+    });
+    expect(
+      buildTokenStandardV2AllocationChoiceArgument({
+        ...allocationParams,
+        settlement: { ...allocationParams.settlement, id: '', cid: '#settlement-context' },
+      }).settlement.id
+    ).toBe('');
+
+    expect(() =>
+      buildTokenStandardV2AllocationChoiceArgument({
+        ...allocationParams,
+        settlement: { ...allocationParams.settlement, executors: [] },
+      })
+    ).toThrow(TokenStandardV2AllocationError);
+    expect(() =>
+      buildTokenStandardV2AllocationChoiceArgument({
+        ...allocationParams,
+        settlement: { ...allocationParams.settlement, executors: [' '] },
+      })
+    ).toThrow(TokenStandardV2AllocationError);
+  });
+
+  test('enforces the upstream V2 allocation invariants without narrowing valid decimal text', () => {
+    const transferLegSide = allocationParams.allocation.transferLegSides[0];
+    if (!transferLegSide) throw new Error('test fixture must include one transfer-leg side');
+    const buildWithAllocation = (
+      allocation: BuildTokenStandardV2AllocationChoiceArgumentParams['allocation']
+    ): ReturnType<typeof buildTokenStandardV2AllocationChoiceArgument> =>
+      buildTokenStandardV2AllocationChoiceArgument({ ...allocationParams, allocation });
+
+    expect(() =>
+      buildWithAllocation({
+        ...allocationParams.allocation,
+        transferLegSides: [],
+        nextIterationFunding: null,
+      })
+    ).toThrow(TokenStandardV2AllocationError);
+    expect(
+      buildWithAllocation({
+        ...allocationParams.allocation,
+        transferLegSides: [],
+        nextIterationFunding: {},
+      }).allocation.transferLegSides
+    ).toEqual([]);
+    expect(() =>
+      buildWithAllocation({
+        ...allocationParams.allocation,
+        transferLegSides: [transferLegSide, { ...transferLegSide }],
+      })
+    ).toThrow(TokenStandardV2AllocationError);
+
+    for (const amount of ['0', '-1.0']) {
+      expect(() =>
+        buildWithAllocation({
+          ...allocationParams.allocation,
+          transferLegSides: [{ ...transferLegSide, amount }],
+        })
+      ).toThrow(TokenStandardV2AllocationError);
+    }
+    for (const amount of ['+1.0', '1.']) {
+      expect(
+        buildWithAllocation({
+          ...allocationParams.allocation,
+          transferLegSides: [{ ...transferLegSide, amount }],
+        }).allocation.transferLegSides[0]?.amount
+      ).toBe(amount);
+    }
+
+    expect(() =>
+      buildWithAllocation({
+        ...allocationParams.allocation,
+        nextIterationFunding: { USD: '-1.0' },
+      })
+    ).toThrow(TokenStandardV2AllocationError);
+    expect(
+      buildWithAllocation({
+        ...allocationParams.allocation,
+        nextIterationFunding: { USD: '0' },
+      }).allocation.nextIterationFunding
+    ).toEqual({ USD: '0' });
+  });
+
   test('prepares through an arbitrary registry and preserves its context and disclosures', async () => {
     const choiceContextData = {
       values: {
@@ -144,29 +261,25 @@ describe('Token Standard V2 allocation helpers', () => {
     });
     const prepared = await prepareTokenStandardV2AllocationCommand({
       ...allocationParams,
-      extraArgs: {
-        context: { values: { ignored: true } },
-        meta: { values: { source: 'test' } },
-      },
+      metadata: { values: { source: 'test' } },
       registryUrl: 'https://cash.example/token-registry',
       scan,
-      excludeDebugFields: true,
     });
 
-    expect(scan.getAllocationFactoryFromRegistry).toHaveBeenCalledWith({
+    expect(scan.getAllocationFactoryV2FromRegistry).toHaveBeenCalledWith({
       registryUrl: 'https://cash.example/token-registry',
       choiceArguments: {
         ...buildTokenStandardV2AllocationChoiceArgument({
           ...allocationParams,
           extraArgs: {
-            context: { values: { ignored: true } },
-            meta: { values: { source: 'test' } },
+            context: { values: {} },
+            meta: { values: {} },
           },
         }),
       },
       excludeDebugFields: true,
     });
-    expect(prepared.choiceArgument.extraArgs.context).toBe(choiceContextData);
+    expect(prepared.choiceArgument.extraArgs.context).toEqual(choiceContextData);
     expect(prepared.choiceArgument.extraArgs.meta).toEqual({ values: { source: 'test' } });
     expect(prepared.disclosedContracts).toEqual([
       {
@@ -193,16 +306,21 @@ describe('Token Standard V2 allocation helpers', () => {
     [
       'AllocationInstructionResult_Completed',
       { allocationCid: '#allocation' },
-      { type: 'Completed', allocationCid: '#allocation' },
+      { type: 'Completed', allocationCid: '#allocation', ...allocationResultCommon },
     ],
     [
       'AllocationInstructionResult_Pending',
       { allocationInstructionCid: '#instruction' },
-      { type: 'Pending', allocationInstructionCid: '#instruction' },
+      { type: 'Pending', allocationInstructionCid: '#instruction', ...allocationResultCommon },
     ],
-    ['AllocationInstructionResult_Failed', {}, { type: 'Failed' }],
+    ['AllocationInstructionResult_Failed', {}, { type: 'Failed', ...allocationResultCommon }],
   ] as const)('parses the %s result variant', (tag, value, expected) => {
-    expect(parseTokenStandardV2AllocationInstructionResult({ output: { tag, value } })).toEqual(expected);
+    expect(
+      parseTokenStandardV2AllocationInstructionResult({
+        output: { tag, value },
+        ...allocationResultCommon,
+      })
+    ).toEqual(expected);
   });
 
   test('rejects malformed registry and result responses with typed errors', async () => {
@@ -249,7 +367,10 @@ describe('Token Standard V2 allocation helpers', () => {
     ).toThrow(TokenStandardV2AllocationError);
     let unknownTagError: unknown;
     try {
-      parseTokenStandardV2AllocationInstructionResult({ output: { tag: 'Unknown', value: {} } });
+      parseTokenStandardV2AllocationInstructionResult({
+        output: { tag: 'Unknown', value: {} },
+        ...allocationResultCommon,
+      });
     } catch (error) {
       unknownTagError = error;
     }
@@ -285,6 +406,22 @@ describe('Token Standard V2 allocation helpers', () => {
           0: {
             ExercisedTreeEvent: {
               value: {
+                contractId: '#other-allocation-factory',
+                templateId: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID,
+                choice: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE,
+                exerciseResult: {
+                  output: {
+                    tag: 'AllocationInstructionResult_Completed',
+                    value: { allocationCid: '#wrong-allocation' },
+                  },
+                  ...allocationResultCommon,
+                },
+              },
+            },
+          },
+          1: {
+            ExercisedTreeEvent: {
+              value: {
                 contractId: '#allocation-factory',
                 templateId: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_INTERFACE_ID,
                 choice: TOKEN_STANDARD_V2_ALLOCATION_FACTORY_ALLOCATE_CHOICE,
@@ -293,6 +430,7 @@ describe('Token Standard V2 allocation helpers', () => {
                     tag: 'AllocationInstructionResult_Completed',
                     value: { allocationCid: '#allocation' },
                   },
+                  ...allocationResultCommon,
                 },
               },
             },
@@ -310,10 +448,14 @@ describe('Token Standard V2 allocation helpers', () => {
         readAs: ['Observer::ops'],
         commandId: 'allocation-command',
         submissionId: 'allocation-submission',
+        deduplicationPeriod: { DeduplicationDuration: { seconds: 300 } },
+        synchronizerId: 'sync::id',
+        userId: 'worker-user',
+        workflowId: 'scenario-3',
       })
     ).resolves.toEqual({
       updateId: 'update-3',
-      result: { type: 'Completed', allocationCid: '#allocation' },
+      result: { type: 'Completed', allocationCid: '#allocation', ...allocationResultCommon },
       response,
     });
     expect(submitAndWaitForTransactionTree).toHaveBeenCalledWith({
@@ -323,6 +465,20 @@ describe('Token Standard V2 allocation helpers', () => {
       disclosedContracts: [...prepared.disclosedContracts],
       commandId: 'allocation-command',
       submissionId: 'allocation-submission',
+      deduplicationPeriod: { DeduplicationDuration: { seconds: 300 } },
+      synchronizerId: 'sync::id',
+      userId: 'worker-user',
+      workflowId: 'scenario-3',
     });
+
+    await expect(
+      submitPreparedTokenStandardV2Allocation({
+        ledger: { submitAndWaitForTransactionTree },
+        prepared,
+        actAs: ['Buyer::alice'],
+        commandId: ' ',
+      })
+    ).rejects.toThrow(TokenStandardV2AllocationError);
+    expect(submitAndWaitForTransactionTree).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- add generic CIP-112 Token Standard V2 allocation protocol types, builders, and submission helpers
- call the dedicated /registry/allocation-instruction/v2/allocation-factory endpoint without forwarding Scan credentials
- send canonical empty context and metadata during lookup, then combine the returned context with caller metadata and validated disclosures
- require explicit committed intent and stable command IDs, enforce the upstream V2 allocation invariants and Daml Decimal bounds
- parse the full Completed, Pending, or Failed result and correlate transaction-tree results to the prepared factory contract

This moves reusable behavior out of [Fairmint/canton-fairmint-sdk#169](https://github.com/Fairmint/canton-fairmint-sdk/pull/169), where it was at the wrong abstraction layer.

## Validation

- 522 unit tests passed
- 20 focused allocation and Scan client tests passed
- npm run build:lint
- scoped ESLint and Prettier
- generated client methods
- test-cn-quickstart passed in CI
- git diff --check

The node-SDK Quickstart validates this package against the pinned LocalNet. A real V2 allocation using the generic TestTokens package remains downstream integration coverage after the package is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Token Standard v2 allocation utilities for validating, preparing, submitting, and interpreting allocation instructions.
  * Added support for retrieving v2 allocation factories from registry endpoints.
  * Added public Token Standard v2 account, instrument, and metadata types.
  * Added structured allocation status results and typed validation errors.

* **Tests**
  * Added coverage for registry requests, allocation command workflows, validation, submission, and result parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->