### PR TITLE
Fix WebSocket message close ordering

### DIFF
--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -158,9 +158,10 @@ export class WebSocketClient {
       void (async () => {
         try {
           const parsed = WebSocketErrorUtils.safeJsonParse(dataString, 'WebSocket message');
-          await log('message', parsed);
-
+          // Servers may close immediately after their final frame. Dispatch it before async logging so close handlers
+          // cannot observe an incomplete stream.
           handlers.onMessage(parsed as InboundMessage);
+          await log('message', parsed);
         } catch (err) {
           const error = toError(err);
           await log('parse_error', { raw: dataString, error: error.message });

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -1,0 +1,87 @@
+import type { EventEmitter } from 'node:events';
+import { type BaseClient } from '../../../src/core/BaseClient';
+import { WebSocketClient } from '../../../src/core/ws/WebSocketClient';
+
+jest.mock('ws', () => {
+  const { EventEmitter: MockEventEmitter } = jest.requireActual<typeof import('node:events')>('node:events');
+  const mockSockets: unknown[] = [];
+
+  class MockWebSocket extends MockEventEmitter {
+    public static readonly OPEN = 1;
+    public readonly close = jest.fn();
+    public readonly send = jest.fn();
+    public readyState = MockWebSocket.OPEN;
+
+    public constructor(..._args: unknown[]) {
+      super();
+      mockSockets.push(this);
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: MockWebSocket,
+    mockSockets,
+  };
+});
+
+type MockSocket = EventEmitter & {
+  readonly close: jest.Mock;
+  readonly send: jest.Mock;
+  readyState: number;
+};
+
+const { mockSockets } = jest.requireMock<{ mockSockets: MockSocket[] }>('ws');
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return {
+    promise,
+    resolve: () => resolve?.(),
+  };
+}
+
+describe('WebSocketClient', () => {
+  beforeEach(() => {
+    mockSockets.length = 0;
+  });
+
+  it('dispatches the final message before a close while message logging is pending', async () => {
+    const messageLog = deferred();
+    const logRequestResponse = jest.fn(async (_url: string, request: { event?: string }): Promise<void> => {
+      if (request.event === 'message') {
+        await messageLog.promise;
+      }
+    });
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const onMessage = jest.fn();
+    const onClose = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage, onClose }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { JsActiveContract: {} } })));
+    socket.emit('close', 1000, Buffer.from('snapshot complete'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0] ?? 0);
+
+    messageLog.resolve();
+  });
+});


### PR DESCRIPTION
## Summary

- dispatch parsed WebSocket messages before awaiting asynchronous request/response logging
- add a regression test for a final message immediately followed by socket close while message logging is pending

## Root cause

The Ledger active-contract snapshot endpoint closes its WebSocket immediately after the final frame. `WebSocketClient` awaited logging before invoking `onMessage`, while close handling could complete independently. If close logging completed first, callers resolved an incomplete snapshot or even treated a Canton error frame as an empty success.

This surfaced in Scenario 1 settlement preparation as intermittent false `EquityRegistry` / `EquityHolding` missing errors even though canton-ops showed both contracts active.

## Impact

The change preserves frame arrival order at the consumer boundary. Logging still runs, but it can no longer delay the final frame past `onClose`.

## Validation

- `npm run build`
- `npm test -- --runInBand test/unit` (53 suites, 511 tests)
- focused WebSocket and active-contract tests (2 suites, 2 tests)
- targeted ESLint and Prettier
- `npm run check:package-artifacts`
- read-only DevNet probe before fix: production settlement resolver failed 3/8 iterations and invalid filters sometimes returned empty success
- same probe through the built fix: resolver passed 8/8 iterations; registry and holding reads passed 8/8; all 16 invalid filters surfaced `INVALID_FIELD`

The repository-wide Jest command also includes LocalNet integration tests; that run was not applicable without the LocalNet auth service at `localhost:8082`. No ledger submissions were made by the DevNet probe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering for all WebSocket consumers (including active-contract snapshots that resolve on close); behavior fix is targeted but affects core streaming infrastructure.
> 
> **Overview**
> **Fixes a race where `onClose` could run before the last `onMessage` when request/response logging is slow.**
> 
> In `WebSocketClient`, parsed frames are now passed to `handlers.onMessage` **before** `await log('message', …)`. Async logging no longer blocks delivery of the final frame when the server closes the socket immediately afterward (e.g. active-contract snapshots).
> 
> Adds a unit test with a mocked `ws` socket and a deferred message log: a `message` followed by `close` must invoke `onMessage` before `onClose` while message logging is still pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03b501292dcfd25e3fdbe6215e8ebd99299fd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->