### PR TITLE
Isolate WebSocket callback failures

### DIFF
--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -123,11 +123,7 @@ export class GetActiveContracts {
           onMessage: async (parsed): Promise<void> => {
             const decoded = ActiveContractsResponseMessageSchema.safeParse(parsed);
             if (!decoded.success) {
-              if (!settled) {
-                settled = true;
-                reject(new ApiError('Unexpected active-contracts WebSocket message'));
-              }
-              return;
+              throw new ApiError('Unexpected active-contracts WebSocket message');
             }
             const message = decoded.data;
 

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -2,8 +2,17 @@ import { z } from 'zod';
 import { ApiError } from '../../../../../core/errors';
 import { WebSocketClient } from '../../../../../core/ws/WebSocketClient';
 import type { LedgerJsonApiClient } from '../../../LedgerJsonApiClient.generated';
-import { type JsCantonError, type WsCantonError } from '../../../schemas/api/errors';
-import { type JsGetActiveContractsResponse, type JsGetActiveContractsResponseItem } from '../../../schemas/api/state';
+import {
+  JsCantonErrorSchema,
+  WsCantonErrorSchema,
+  type JsCantonError,
+  type WsCantonError,
+} from '../../../schemas/api/errors';
+import {
+  JsGetActiveContractsResponseItemSchema,
+  type JsGetActiveContractsResponse,
+  type JsGetActiveContractsResponseItem,
+} from '../../../schemas/api/state';
 import { buildEventFormat } from '../utils/event-format-builder';
 
 const path = '/v2/state/active-contracts' as const;
@@ -78,8 +87,11 @@ export class GetActiveContracts {
       eventFormat: ReturnType<typeof buildEventFormat>;
     }
 
-    // Response message can be a contract item or an error
-    type ActiveContractsResponseMessage = JsGetActiveContractsResponseItem | JsCantonError | WsCantonError;
+    const ActiveContractsResponseMessageSchema = z.union([
+      JsGetActiveContractsResponseItemSchema,
+      JsCantonErrorSchema,
+      WsCantonErrorSchema,
+    ]);
 
     const requestMessage: ActiveContractsRequestMessage = {
       verbose: false,
@@ -107,18 +119,28 @@ export class GetActiveContracts {
       };
 
       void wsClient
-        .connect<ActiveContractsRequestMessage, ActiveContractsResponseMessage>(path, requestMessage, {
+        .connect<ActiveContractsRequestMessage, unknown>(path, requestMessage, {
           onMessage: async (parsed): Promise<void> => {
+            const decoded = ActiveContractsResponseMessageSchema.safeParse(parsed);
+            if (!decoded.success) {
+              if (!settled) {
+                settled = true;
+                reject(new ApiError('Unexpected active-contracts WebSocket message'));
+              }
+              return;
+            }
+            const message = decoded.data;
+
             // Distinguish item vs error union members
-            if (typeof parsed === 'object' && 'contractEntry' in parsed) {
-              results.push(parsed);
+            if ('contractEntry' in message) {
+              results.push(message);
               if (typeof params.onItem === 'function') {
-                await params.onItem(parsed);
+                await params.onItem(message);
               }
             } else if (!settled) {
               // Treat any non-item as an error message
               settled = true;
-              reject(toError(parsed));
+              reject(toError(message));
             }
           },
           onError: (err) => {

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -32,7 +32,7 @@ const ActiveContractsParamsSchema = z.object({
 
 export type GetActiveContractsParams = z.infer<typeof ActiveContractsParamsSchema> & {
   /** Optional per-item callback to consume results as they arrive. */
-  onItem?: (item: JsGetActiveContractsResponseItem) => void;
+  onItem?: (item: JsGetActiveContractsResponseItem) => void | Promise<void>;
 };
 
 export class GetActiveContracts {
@@ -108,12 +108,12 @@ export class GetActiveContracts {
 
       void wsClient
         .connect<ActiveContractsRequestMessage, ActiveContractsResponseMessage>(path, requestMessage, {
-          onMessage: (parsed) => {
+          onMessage: async (parsed): Promise<void> => {
             // Distinguish item vs error union members
             if (typeof parsed === 'object' && 'contractEntry' in parsed) {
               results.push(parsed);
               if (typeof params.onItem === 'function') {
-                params.onItem(parsed);
+                await params.onItem(parsed);
               }
             } else if (!settled) {
               // Treat any non-item as an error message

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -135,8 +135,10 @@ export class GetActiveContracts {
               }
             } else if (!settled) {
               // Treat any non-item as an error message
+              const error = toError(message);
               settled = true;
-              reject(toError(message));
+              reject(error);
+              throw error;
             }
           },
           onError: (err) => {

--- a/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
+++ b/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
@@ -225,17 +225,15 @@ export class SubscribeToUpdates {
           requestMessage,
           {
             onMessage: async (parsed): Promise<void> => {
+              // Surface Canton error frames immediately; a slow consumer callback must not delay stream failure.
+              if (isErrorMessage(parsed) && !settled) {
+                settled = true;
+                reject(toError(parsed));
+              }
+
               // Call user's onMessage callback if provided
               if (typeof params.onMessage === 'function') {
                 await params.onMessage(parsed);
-              }
-
-              // Check if it's an error
-              if (isErrorMessage(parsed)) {
-                if (!settled) {
-                  settled = true;
-                  reject(toError(parsed));
-                }
               }
             },
             onError: (err) => {

--- a/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
+++ b/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
@@ -2,8 +2,13 @@ import { z } from 'zod';
 import { ApiError } from '../../../../../core/errors';
 import { WebSocketClient, type WebSocketOptions } from '../../../../../core/ws/WebSocketClient';
 import type { LedgerJsonApiClient } from '../../../LedgerJsonApiClient.generated';
-import { type JsCantonError, type WsCantonError } from '../../../schemas/api/errors';
-import { type JsUpdateSchema, type WsUpdateSchema } from '../../../schemas/api/updates';
+import {
+  JsCantonErrorSchema,
+  WsCantonErrorSchema,
+  type JsCantonError,
+  type WsCantonError,
+} from '../../../schemas/api/errors';
+import { JsUpdateSchema, WsUpdateSchema } from '../../../schemas/api/updates';
 import { buildEventFormat } from '../utils/event-format-builder';
 
 const path = '/v2/updates' as const;
@@ -81,11 +86,14 @@ export type SubscribeToUpdatesParams = z.infer<typeof SubscribeToUpdatesParamsSc
   onTokenRefreshNeeded?: WebSocketOptions['onTokenRefreshNeeded'];
 };
 
-export type UpdatesWsMessage =
-  | { update: z.infer<typeof JsUpdateSchema> }
-  | { update: z.infer<typeof WsUpdateSchema> }
-  | JsCantonError
-  | WsCantonError;
+const UpdatesWsMessageSchema = z.union([
+  z.object({ update: JsUpdateSchema }),
+  z.object({ update: WsUpdateSchema }),
+  JsCantonErrorSchema,
+  WsCantonErrorSchema,
+]);
+
+export type UpdatesWsMessage = z.infer<typeof UpdatesWsMessageSchema>;
 
 /**
  * Subscribes to ledger updates via WebSocket connection.
@@ -217,23 +225,33 @@ export class SubscribeToUpdates {
 
       /** Check if a message is a Canton error response */
       const isErrorMessage = (msg: UpdatesWsMessage): msg is JsCantonError | WsCantonError =>
-        typeof msg === 'object' && ('cause' in msg || ('code' in msg && 'message' in msg && !('update' in msg)));
+        'cause' in msg || ('code' in msg && 'message' in msg && !('update' in msg));
 
       void wsClient
-        .connect<typeof requestMessage, UpdatesWsMessage>(
+        .connect<typeof requestMessage, unknown>(
           path,
           requestMessage,
           {
             onMessage: async (parsed): Promise<void> => {
+              const decoded = UpdatesWsMessageSchema.safeParse(parsed);
+              if (!decoded.success) {
+                if (!settled) {
+                  settled = true;
+                  reject(new ApiError('Unexpected ledger updates WebSocket message'));
+                }
+                return;
+              }
+              const message = decoded.data;
+
               // Surface Canton error frames immediately; a slow consumer callback must not delay stream failure.
-              if (isErrorMessage(parsed) && !settled) {
+              if (isErrorMessage(message) && !settled) {
                 settled = true;
-                reject(toError(parsed));
+                reject(toError(message));
               }
 
               // Call user's onMessage callback if provided
               if (typeof params.onMessage === 'function') {
-                await params.onMessage(parsed);
+                await params.onMessage(message);
               }
             },
             onError: (err) => {

--- a/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
+++ b/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
@@ -235,11 +235,7 @@ export class SubscribeToUpdates {
             onMessage: async (parsed): Promise<void> => {
               const decoded = UpdatesWsMessageSchema.safeParse(parsed);
               if (!decoded.success) {
-                if (!settled) {
-                  settled = true;
-                  reject(new ApiError('Unexpected ledger updates WebSocket message'));
-                }
-                return;
+                throw new ApiError('Unexpected ledger updates WebSocket message');
               }
               const message = decoded.data;
 

--- a/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
+++ b/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
@@ -65,7 +65,7 @@ const SubscribeToUpdatesParamsSchema = z.object({
 
 export type SubscribeToUpdatesParams = z.infer<typeof SubscribeToUpdatesParamsSchema> & {
   /** Optional per-message callback to consume updates as they arrive. */
-  onMessage?: (message: UpdatesWsMessage) => void;
+  onMessage?: (message: UpdatesWsMessage) => void | Promise<void>;
 
   /**
    * Called when the token is about to expire and refresh is scheduled. Use this to prepare for reconnection (e.g., save
@@ -224,10 +224,10 @@ export class SubscribeToUpdates {
           path,
           requestMessage,
           {
-            onMessage: (parsed) => {
+            onMessage: async (parsed): Promise<void> => {
               // Call user's onMessage callback if provided
               if (typeof params.onMessage === 'function') {
-                params.onMessage(parsed);
+                await params.onMessage(parsed);
               }
 
               // Check if it's an error

--- a/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
+++ b/src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { ApiError } from '../../../../../core/errors';
-import { WebSocketClient, type WebSocketOptions } from '../../../../../core/ws/WebSocketClient';
+import {
+  WebSocketClient,
+  type WebSocketOptions,
+  type WebSocketSubscription,
+} from '../../../../../core/ws/WebSocketClient';
 import type { LedgerJsonApiClient } from '../../../LedgerJsonApiClient.generated';
 import {
   JsCantonErrorSchema,
@@ -211,6 +215,15 @@ export class SubscribeToUpdates {
 
     return new Promise<void>((resolve, reject) => {
       let settled = false;
+      let subscription: WebSocketSubscription | undefined;
+      let closeWhenConnected = false;
+      const closeSubscription = (): void => {
+        if (subscription) {
+          subscription.close();
+        } else {
+          closeWhenConnected = true;
+        }
+      };
 
       /** Convert a Canton error response to a proper Error object */
       const toError = (errorResponse: JsCantonError | WsCantonError): Error => {
@@ -240,9 +253,18 @@ export class SubscribeToUpdates {
               const message = decoded.data;
 
               // Surface Canton error frames immediately; a slow consumer callback must not delay stream failure.
-              if (isErrorMessage(message) && !settled) {
-                settled = true;
-                reject(toError(message));
+              if (isErrorMessage(message)) {
+                const error = toError(message);
+                if (!settled) {
+                  settled = true;
+                  reject(error);
+                }
+                closeSubscription();
+
+                if (typeof params.onMessage === 'function') {
+                  await params.onMessage(message);
+                }
+                throw error;
               }
 
               // Call user's onMessage callback if provided
@@ -265,6 +287,12 @@ export class SubscribeToUpdates {
           },
           wsOptions
         )
+        .then((connected) => {
+          subscription = connected;
+          if (closeWhenConnected) {
+            connected.close();
+          }
+        })
         .catch((err: unknown) => {
           if (!settled) {
             settled = true;

--- a/src/core/operations/WebSocketOperationFactory.ts
+++ b/src/core/operations/WebSocketOperationFactory.ts
@@ -63,9 +63,7 @@ export function createWebSocketOperation<Params, RequestMessage, InboundMessage>
       const wrappedHandlers: WebSocketHandlers<InboundMessage> = transformInbound
         ? {
             ...handlers,
-            onMessage: (msg) => {
-              handlers.onMessage(transformInbound(msg));
-            },
+            onMessage: (msg): void | Promise<void> => handlers.onMessage(transformInbound(msg)),
           }
         : handlers;
 

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -151,7 +151,24 @@ export class WebSocketClient {
         }
       );
     };
-    let pendingMessageCallbacks = Promise.resolve();
+    let inFlightMessageCallbacks = 0;
+    let resolveMessageCallbacksDrained: (() => void) | undefined;
+    let messageCallbacksDrained = Promise.resolve();
+    const beginMessageCallback = (): void => {
+      if (inFlightMessageCallbacks === 0) {
+        messageCallbacksDrained = new Promise<void>((resolve) => {
+          resolveMessageCallbacksDrained = resolve;
+        });
+      }
+      inFlightMessageCallbacks += 1;
+    };
+    const completeMessageCallback = (): void => {
+      inFlightMessageCallbacks -= 1;
+      if (inFlightMessageCallbacks === 0) {
+        resolveMessageCallbacksDrained?.();
+        resolveMessageCallbacksDrained = undefined;
+      }
+    };
 
     log('connect', { headers: token ? { Authorization: '[REDACTED]' } : undefined, protocols });
 
@@ -256,11 +273,7 @@ export class WebSocketClient {
         return;
       }
 
-      let markMessageCallbackComplete: (() => void) | undefined;
-      const messageCallbackComplete = new Promise<void>((resolve) => {
-        markMessageCallbackComplete = resolve;
-      });
-      pendingMessageCallbacks = Promise.all([pendingMessageCallbacks, messageCallbackComplete]).then(() => undefined);
+      beginMessageCallback();
 
       void runCallback(
         (): void | Promise<void> => handlers.onMessage(parsed as InboundMessage),
@@ -276,7 +289,7 @@ export class WebSocketClient {
             error: toError(err).message,
           });
         })
-        .finally(() => markMessageCallbackComplete?.());
+        .finally(completeMessageCallback);
     });
 
     socket.on('error', (err: Error) => {
@@ -294,7 +307,7 @@ export class WebSocketClient {
       log('close', { code, reason: closeReason });
       const { onClose } = handlers;
       if (onClose) {
-        void pendingMessageCallbacks.then(() => {
+        void messageCallbacksDrained.then(() => {
           observeCallback(
             (): void | Promise<void> => onClose(code, closeReason),
             (error) => {

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -188,13 +188,10 @@ export class WebSocketClient {
         tokenRefreshTimer = null;
         void (async () => {
           if (options.onTokenExpiring) {
-            try {
-              await options.onTokenExpiring();
-            } catch (err) {
-              const error = toError(err);
+            observeCallback(options.onTokenExpiring, (error) => {
               notifyError(error);
               log('token_expiring_handler_error', { error: error.message });
-            }
+            });
           }
 
           log('token_refresh_triggered', { reason: 'proactive_refresh' });

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -88,24 +88,33 @@ export class WebSocketClient {
     let tokenRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
     const logger = this.client.getLogger();
-    const log = async (event: string, payload: unknown): Promise<void> => {
-      if (logger) {
-        await logger.logRequestResponse(wsUrl, { event, requestMessage }, payload);
+    const reportAuxiliaryFailure = (message: string, context: Record<string, unknown>): void => {
+      try {
+        logger?.error?.(message, context);
+      } catch {
+        // A failing logger cannot report its own failure.
       }
     };
-    const logMessageEvent = async (event: string, payload: unknown): Promise<void> => {
+    const log = async (event: string, payload: unknown): Promise<void> => {
+      if (!logger) return;
       try {
-        await log(event, payload);
+        await logger.logRequestResponse(wsUrl, { event, requestMessage }, payload);
       } catch (err) {
         // Request/response logging is auxiliary and must not change WebSocket delivery semantics.
-        try {
-          logger?.error?.('WebSocket request/response logging failed', {
-            event,
-            error: toError(err).message,
-          });
-        } catch {
-          // A failing logger cannot report its own failure.
-        }
+        reportAuxiliaryFailure('WebSocket request/response logging failed', {
+          event,
+          error: toError(err).message,
+        });
+      }
+    };
+    const notifyError = (error: Error): void => {
+      try {
+        handlers.onError?.(error);
+      } catch (err) {
+        reportAuxiliaryFailure('WebSocket onError handler failed', {
+          error: toError(err).message,
+          originalError: error.message,
+        });
       }
     };
 
@@ -154,7 +163,7 @@ export class WebSocketClient {
         } catch (err) {
           const error = toError(err);
           await log('send_error', { message: error.message });
-          if (handlers.onError) handlers.onError(error);
+          notifyError(error);
           socket.close();
         }
       })();
@@ -176,9 +185,9 @@ export class WebSocketClient {
           parsed = WebSocketErrorUtils.safeJsonParse(dataString, 'WebSocket message');
         } catch (err) {
           const error = toError(err);
-          if (handlers.onError) handlers.onError(error);
+          notifyError(error);
           socket.close(1003, 'Invalid JSON received');
-          await logMessageEvent('parse_error', { raw: dataString, error: error.message });
+          await log('parse_error', { raw: dataString, error: error.message });
           return;
         }
 
@@ -186,22 +195,22 @@ export class WebSocketClient {
           handlers.onMessage(parsed as InboundMessage);
         } catch (err) {
           const error = toError(err);
-          if (handlers.onError) handlers.onError(error);
+          notifyError(error);
           socket.close(1011, 'Message handler failed');
-          await logMessageEvent('message_handler_error', { error: error.message });
+          await log('message_handler_error', { error: error.message });
           return;
         }
 
         // Servers may close immediately after their final frame. Dispatch it before async logging so close handlers
         // cannot observe an incomplete stream.
-        await logMessageEvent('message', parsed);
+        await log('message', parsed);
       })();
     });
 
     socket.on('error', (err: Error) => {
       void (async () => {
         await log('socket_error', { message: err.message });
-        if (handlers.onError) handlers.onError(err);
+        notifyError(err);
       })();
     });
 

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -93,6 +93,21 @@ export class WebSocketClient {
         await logger.logRequestResponse(wsUrl, { event, requestMessage }, payload);
       }
     };
+    const logMessageEvent = async (event: string, payload: unknown): Promise<void> => {
+      try {
+        await log(event, payload);
+      } catch (err) {
+        // Request/response logging is auxiliary and must not change WebSocket delivery semantics.
+        try {
+          logger?.error?.('WebSocket request/response logging failed', {
+            event,
+            error: toError(err).message,
+          });
+        } catch {
+          // A failing logger cannot report its own failure.
+        }
+      }
+    };
 
     await log('connect', { headers: token ? { Authorization: '[REDACTED]' } : undefined, protocols });
 
@@ -156,19 +171,30 @@ export class WebSocketClient {
         dataString = new TextDecoder().decode(rawData);
       }
       void (async () => {
+        let parsed: unknown;
         try {
-          const parsed = WebSocketErrorUtils.safeJsonParse(dataString, 'WebSocket message');
-          // Servers may close immediately after their final frame. Dispatch it before async logging so close handlers
-          // cannot observe an incomplete stream.
-          handlers.onMessage(parsed as InboundMessage);
-          await log('message', parsed);
+          parsed = WebSocketErrorUtils.safeJsonParse(dataString, 'WebSocket message');
         } catch (err) {
           const error = toError(err);
-          await log('parse_error', { raw: dataString, error: error.message });
-          // Close connection on JSON parse failure to prevent inconsistent state
-          socket.close(1003, 'Invalid JSON received');
           if (handlers.onError) handlers.onError(error);
+          socket.close(1003, 'Invalid JSON received');
+          await logMessageEvent('parse_error', { raw: dataString, error: error.message });
+          return;
         }
+
+        try {
+          handlers.onMessage(parsed as InboundMessage);
+        } catch (err) {
+          const error = toError(err);
+          if (handlers.onError) handlers.onError(error);
+          socket.close(1011, 'Message handler failed');
+          await logMessageEvent('message_handler_error', { error: error.message });
+          return;
+        }
+
+        // Servers may close immediately after their final frame. Dispatch it before async logging so close handlers
+        // cannot observe an incomplete stream.
+        await logMessageEvent('message', parsed);
       })();
     });
 

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -159,12 +159,21 @@ export class WebSocketClient {
         try {
           socket.send(JSON.stringify(requestMessage));
           await log('send', requestMessage);
-          if (handlers.onOpen) handlers.onOpen();
         } catch (err) {
           const error = toError(err);
           await log('send_error', { message: error.message });
           notifyError(error);
           socket.close();
+          return;
+        }
+
+        try {
+          handlers.onOpen?.();
+        } catch (err) {
+          const error = toError(err);
+          notifyError(error);
+          socket.close(1011, 'Open handler failed');
+          await log('open_handler_error', { error: error.message });
         }
       })();
     });

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -15,10 +15,10 @@ export interface WebSocketSubscription {
 
 /** Callbacks for WebSocket lifecycle events. Only `onMessage` is required. */
 export interface WebSocketHandlers<Message> {
-  readonly onOpen?: () => void;
-  readonly onMessage: (msg: Message) => void;
-  readonly onError?: (err: Error) => void;
-  readonly onClose?: (code: number, reason: string) => void;
+  readonly onOpen?: () => void | Promise<void>;
+  readonly onMessage: (msg: Message) => void | Promise<void>;
+  readonly onError?: (err: Error) => void | Promise<void>;
+  readonly onClose?: (code: number, reason: string) => void | Promise<void>;
 }
 
 /** Converts an unknown error to an Error instance */
@@ -35,13 +35,16 @@ export interface WebSocketOptions {
    * Called when the token is about to expire and refresh is scheduled. Use this to prepare for reconnection (e.g.,
    * track current offset for resumption).
    */
-  readonly onTokenExpiring?: () => void;
+  readonly onTokenExpiring?: () => void | Promise<void>;
 
   /**
    * Called when token refresh timer fires. The WebSocket will close after this callback returns, and the caller should
    * initiate a new connection with a fresh token. Returns the close code and reason.
    */
-  readonly onTokenRefreshNeeded?: () => { code?: number; reason?: string } | void;
+  readonly onTokenRefreshNeeded?: () =>
+    | { code?: number; reason?: string }
+    | void
+    | Promise<{ code?: number; reason?: string } | void>;
 }
 
 // calculateTokenRefreshTime is imported from @hardlydifficult/websocket
@@ -95,10 +98,17 @@ export class WebSocketClient {
         // A failing logger cannot report its own failure.
       }
     };
-    const log = async (event: string, payload: unknown): Promise<void> => {
+    const log = (event: string, payload: unknown): void => {
       if (!logger) return;
       try {
-        await logger.logRequestResponse(wsUrl, { event, requestMessage }, payload);
+        void Promise.resolve(logger.logRequestResponse(wsUrl, { event, requestMessage }, payload)).catch(
+          (err: unknown) => {
+            reportAuxiliaryFailure('WebSocket request/response logging failed', {
+              event,
+              error: toError(err).message,
+            });
+          }
+        );
       } catch (err) {
         // Request/response logging is auxiliary and must not change WebSocket delivery semantics.
         reportAuxiliaryFailure('WebSocket request/response logging failed', {
@@ -107,75 +117,122 @@ export class WebSocketClient {
         });
       }
     };
-    const notifyError = (error: Error): void => {
+    const runCallback = async (
+      callback: () => void | Promise<void>,
+      onFailure: (error: Error) => void,
+      onSuccess?: () => void
+    ): Promise<void> => {
       try {
-        handlers.onError?.(error);
+        await callback();
+        onSuccess?.();
       } catch (err) {
-        reportAuxiliaryFailure('WebSocket onError handler failed', {
-          error: toError(err).message,
-          originalError: error.message,
-        });
+        onFailure(toError(err));
       }
     };
+    const observeCallback = (
+      callback: () => void | Promise<void>,
+      onFailure: (error: Error) => void,
+      onSuccess?: () => void
+    ): void => {
+      void runCallback(callback, onFailure, onSuccess).catch((err: unknown) => {
+        reportAuxiliaryFailure('WebSocket callback failure handling failed', { error: toError(err).message });
+      });
+    };
+    const notifyError = (error: Error): void => {
+      const { onError } = handlers;
+      if (!onError) return;
+      observeCallback(
+        (): void | Promise<void> => onError(error),
+        (err) => {
+          reportAuxiliaryFailure('WebSocket onError handler failed', {
+            error: err.message,
+            originalError: error.message,
+          });
+        }
+      );
+    };
+    let pendingMessageCallbacks = Promise.resolve();
 
-    await log('connect', { headers: token ? { Authorization: '[REDACTED]' } : undefined, protocols });
+    log('connect', { headers: token ? { Authorization: '[REDACTED]' } : undefined, protocols });
 
     // Schedule proactive token refresh if we have token timing and callbacks
     if (tokenIssuedAt !== null && tokenExpiresAt !== null && options?.onTokenRefreshNeeded) {
       const refreshTime = calculateTokenRefreshTime(tokenIssuedAt, tokenExpiresAt);
       const delayMs = Math.max(0, refreshTime - Date.now());
 
-      if (delayMs > 0) {
-        await log('token_refresh_scheduled', {
-          tokenIssuedAt: new Date(tokenIssuedAt).toISOString(),
-          tokenExpiresAt: new Date(tokenExpiresAt).toISOString(),
-          refreshAt: new Date(refreshTime).toISOString(),
-          delayMs,
-        });
+      log('token_refresh_scheduled', {
+        tokenIssuedAt: new Date(tokenIssuedAt).toISOString(),
+        tokenExpiresAt: new Date(tokenExpiresAt).toISOString(),
+        refreshAt: new Date(refreshTime).toISOString(),
+        delayMs,
+      });
 
-        tokenRefreshTimer = setTimeout(() => {
-          void (async () => {
-            // Notify that token is expiring
-            if (options.onTokenExpiring) {
-              options.onTokenExpiring();
+      tokenRefreshTimer = setTimeout(() => {
+        tokenRefreshTimer = null;
+        void (async () => {
+          if (options.onTokenExpiring) {
+            try {
+              await options.onTokenExpiring();
+            } catch (err) {
+              const error = toError(err);
+              notifyError(error);
+              log('token_expiring_handler_error', { error: error.message });
             }
+          }
 
-            await log('token_refresh_triggered', { reason: 'proactive_refresh' });
+          log('token_refresh_triggered', { reason: 'proactive_refresh' });
 
-            // Get close params from callback
-            const closeParams = options.onTokenRefreshNeeded?.();
-            const closeCode = closeParams?.code ?? 4000;
-            const closeReason = closeParams?.reason ?? 'Token refresh required';
+          let closeCode = 4000;
+          let closeReason = 'Token refresh required';
+          try {
+            const closeParams = await options.onTokenRefreshNeeded?.();
+            closeCode = closeParams?.code ?? closeCode;
+            closeReason = closeParams?.reason ?? closeReason;
+          } catch (err) {
+            const error = toError(err);
+            notifyError(error);
+            log('token_refresh_handler_error', { error: error.message });
+          }
 
-            // Close the socket to trigger reconnection from the caller
+          try {
             socket.close(closeCode, closeReason);
-          })();
-        }, delayMs);
-      }
+          } catch (err) {
+            const error = toError(err);
+            notifyError(error);
+            log('token_refresh_close_error', { error: error.message });
+          }
+        })().catch((err: unknown) => {
+          const error = toError(err);
+          notifyError(error);
+          log('token_refresh_error', { error: error.message });
+          try {
+            socket.close(4000, 'Token refresh required');
+          } catch {
+            // The original refresh failure was already reported.
+          }
+        });
+      }, delayMs);
     }
 
     socket.on('open', () => {
-      void (async () => {
-        try {
-          socket.send(JSON.stringify(requestMessage));
-          await log('send', requestMessage);
-        } catch (err) {
-          const error = toError(err);
-          await log('send_error', { message: error.message });
-          notifyError(error);
-          socket.close();
-          return;
-        }
+      try {
+        socket.send(JSON.stringify(requestMessage));
+        log('send', requestMessage);
+      } catch (err) {
+        const error = toError(err);
+        log('send_error', { message: error.message });
+        notifyError(error);
+        socket.close();
+        return;
+      }
 
-        try {
-          handlers.onOpen?.();
-        } catch (err) {
-          const error = toError(err);
+      if (handlers.onOpen) {
+        observeCallback(handlers.onOpen, (error) => {
           notifyError(error);
           socket.close(1011, 'Open handler failed');
-          await log('open_handler_error', { error: error.message });
-        }
-      })();
+          log('open_handler_error', { error: error.message });
+        });
+      }
     });
 
     socket.on('message', (rawData: RawData) => {
@@ -188,57 +245,70 @@ export class WebSocketClient {
       } else {
         dataString = new TextDecoder().decode(rawData);
       }
-      void (async () => {
-        let parsed: unknown;
-        try {
-          parsed = WebSocketErrorUtils.safeJsonParse(dataString, 'WebSocket message');
-        } catch (err) {
-          const error = toError(err);
-          notifyError(error);
-          socket.close(1003, 'Invalid JSON received');
-          await log('parse_error', { raw: dataString, error: error.message });
-          return;
-        }
+      let parsed: unknown;
+      try {
+        parsed = WebSocketErrorUtils.safeJsonParse(dataString, 'WebSocket message');
+      } catch (err) {
+        const error = toError(err);
+        notifyError(error);
+        socket.close(1003, 'Invalid JSON received');
+        log('parse_error', { raw: dataString, error: error.message });
+        return;
+      }
 
-        try {
-          handlers.onMessage(parsed as InboundMessage);
-        } catch (err) {
-          const error = toError(err);
+      let markMessageCallbackComplete: (() => void) | undefined;
+      const messageCallbackComplete = new Promise<void>((resolve) => {
+        markMessageCallbackComplete = resolve;
+      });
+      pendingMessageCallbacks = Promise.all([pendingMessageCallbacks, messageCallbackComplete]).then(() => undefined);
+
+      void runCallback(
+        (): void | Promise<void> => handlers.onMessage(parsed as InboundMessage),
+        (error) => {
           notifyError(error);
           socket.close(1011, 'Message handler failed');
-          await log('message_handler_error', { error: error.message });
-          return;
-        }
-
-        // Servers may close immediately after their final frame. Dispatch it before async logging so close handlers
-        // cannot observe an incomplete stream.
-        await log('message', parsed);
-      })();
+          log('message_handler_error', { error: error.message });
+        },
+        () => log('message', parsed)
+      )
+        .catch((err: unknown) => {
+          reportAuxiliaryFailure('WebSocket message callback failure handling failed', {
+            error: toError(err).message,
+          });
+        })
+        .finally(() => markMessageCallbackComplete?.());
     });
 
     socket.on('error', (err: Error) => {
-      void (async () => {
-        await log('socket_error', { message: err.message });
-        notifyError(err);
-      })();
+      log('socket_error', { message: err.message });
+      notifyError(err);
     });
 
     socket.on('close', (code: number, reason: Buffer) => {
-      void (async () => {
-        // Clear token refresh timer on close
-        if (tokenRefreshTimer) {
-          clearTimeout(tokenRefreshTimer);
-          tokenRefreshTimer = null;
-        }
-        await log('close', { code, reason: reason.toString() });
-        if (handlers.onClose) handlers.onClose(code, reason.toString());
-      })();
+      // Clear token refresh timer on close
+      if (tokenRefreshTimer !== null) {
+        clearTimeout(tokenRefreshTimer);
+        tokenRefreshTimer = null;
+      }
+      const closeReason = reason.toString();
+      log('close', { code, reason: closeReason });
+      const { onClose } = handlers;
+      if (onClose) {
+        void pendingMessageCallbacks.then(() => {
+          observeCallback(
+            (): void | Promise<void> => onClose(code, closeReason),
+            (error) => {
+              reportAuxiliaryFailure('WebSocket onClose handler failed', { error: error.message });
+            }
+          );
+        });
+      }
     });
 
     return {
       close: () => {
         // Clear token refresh timer
-        if (tokenRefreshTimer) {
+        if (tokenRefreshTimer !== null) {
           clearTimeout(tokenRefreshTimer);
           tokenRefreshTimer = null;
         }

--- a/test/unit/clients/completion-stream.test.ts
+++ b/test/unit/clients/completion-stream.test.ts
@@ -63,8 +63,8 @@ describe('waitForCompletionWithMetadata', () => {
     if (!firstHandlers) {
       throw new Error('Expected first completion subscription');
     }
-    firstHandlers.onClose?.(1000, 'stream complete');
-    firstHandlers.onClose?.(1000, 'duplicate close');
+    await firstHandlers.onClose?.(1000, 'stream complete');
+    await firstHandlers.onClose?.(1000, 'duplicate close');
     jest.advanceTimersByTime(250);
     await Promise.resolve();
 
@@ -79,7 +79,7 @@ describe('waitForCompletionWithMetadata', () => {
     if (!secondHandlers) {
       throw new Error('Expected second completion subscription');
     }
-    secondHandlers.onMessage(completionMessage('submission-123'));
+    await secondHandlers.onMessage(completionMessage('submission-123'));
 
     await expect(resultPromise).resolves.toEqual({
       updateId: 'update-123',
@@ -125,7 +125,7 @@ describe('waitForCompletionWithMetadata', () => {
       throw new Error('Expected first completion subscription');
     }
 
-    firstHandlers.onClose?.(1000, 'stream complete');
+    await firstHandlers.onClose?.(1000, 'stream complete');
     jest.advanceTimersByTime(250);
     await Promise.resolve();
 
@@ -144,7 +144,7 @@ describe('waitForCompletionWithMetadata', () => {
     if (!secondHandlers) {
       throw new Error('Expected second completion subscription');
     }
-    secondHandlers.onMessage(completionMessage('submission-123'));
+    await secondHandlers.onMessage(completionMessage('submission-123'));
 
     await expect(resultPromise).resolves.toEqual({
       updateId: 'update-123',

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -299,6 +299,46 @@ describe('WebSocketClient', () => {
     expect(onError.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0] ?? 0);
   });
 
+  it('waits for every in-flight message callback before delivering close', async () => {
+    const firstMessage = deferred();
+    const secondMessage = deferred();
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const onMessage = jest
+      .fn<Promise<void>, [unknown]>()
+      .mockImplementationOnce(async () => firstMessage.promise)
+      .mockImplementationOnce(async () => secondMessage.promise);
+    const onClose = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage, onClose }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { id: 1 } })));
+    socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { id: 2 } })));
+    socket.emit('close', 1000, Buffer.from('snapshot complete'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onClose).not.toHaveBeenCalled();
+    firstMessage.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onClose).not.toHaveBeenCalled();
+
+    secondMessage.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onClose).toHaveBeenCalledWith(1000, 'snapshot complete');
+  });
+
   it('still closes for token refresh when async refresh callbacks reject', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-07-10T04:00:00.000Z'));

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -49,6 +49,10 @@ describe('WebSocketClient', () => {
     mockSockets.length = 0;
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('dispatches the final message before a close while message logging is pending', async () => {
     const messageLog = deferred();
     const logRequestResponse = jest.fn(async (_url: string, request: { event?: string }): Promise<void> => {
@@ -123,6 +127,44 @@ describe('WebSocketClient', () => {
     }
   });
 
+  it('does not let a never-settling logger block connection or lifecycle callbacks', async () => {
+    const logRequestResponse = jest.fn(async (): Promise<void> => {
+      await new Promise<void>(() => undefined);
+    });
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const onOpen = jest.fn();
+    const onMessage = jest.fn();
+    const onClose = jest.fn();
+    let subscription: Awaited<ReturnType<WebSocketClient['connect']>> | undefined;
+
+    void new WebSocketClient(client)
+      .connect('/v2/state/active-contracts', { activeAtOffset: 42 }, { onOpen, onMessage, onClose })
+      .then((result) => {
+        subscription = result;
+      });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(subscription).toBeDefined();
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('open');
+    socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { JsActiveContract: {} } })));
+    socket.emit('close', 1000, Buffer.from('snapshot complete'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(socket.close).not.toHaveBeenCalled();
+  });
+
   it('reports an open handler failure without labeling it a send failure', async () => {
     const logRequestResponse = jest.fn().mockResolvedValue(undefined);
     const client = {
@@ -133,7 +175,8 @@ describe('WebSocketClient', () => {
       getLogger: () => ({ logRequestResponse }),
     } as unknown as BaseClient;
     const handlerError = new Error('open callback failed');
-    const onOpen = jest.fn(() => {
+    const onOpen = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
       throw handlerError;
     });
     const onError = jest.fn();
@@ -174,7 +217,8 @@ describe('WebSocketClient', () => {
       getTokenExpiryTime: () => null,
       getLogger: () => ({ logRequestResponse, error: loggerError }),
     } as unknown as BaseClient;
-    const onError = jest.fn(() => {
+    const onError = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
       throw new Error('error callback failed');
     });
 
@@ -213,22 +257,26 @@ describe('WebSocketClient', () => {
       getLogger: () => ({ logRequestResponse, error: loggerError }),
     } as unknown as BaseClient;
     const handlerError = new Error('consumer failed');
-    const onMessage = jest.fn(() => {
+    const onMessage = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
       throw handlerError;
     });
-    const onError = jest.fn(() => {
+    const onError = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
       throw new Error('error callback failed');
     });
+    const onClose = jest.fn();
 
     await new WebSocketClient(client).connect(
       '/v2/state/active-contracts',
       { activeAtOffset: 42 },
-      { onMessage, onError }
+      { onMessage, onError, onClose }
     );
     const socket = mockSockets[0];
     if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
 
     socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { JsActiveContract: {} } })));
+    socket.emit('close', 1000, Buffer.from('server closed'));
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(onError).toHaveBeenCalledWith(handlerError);
@@ -246,6 +294,93 @@ describe('WebSocketClient', () => {
     expect(loggerError).toHaveBeenCalledWith('WebSocket onError handler failed', {
       error: 'error callback failed',
       originalError: 'consumer failed',
+    });
+    expect(onClose).toHaveBeenCalledWith(1000, 'server closed');
+    expect(onError.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0] ?? 0);
+  });
+
+  it('still closes for token refresh when async refresh callbacks reject', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-10T04:00:00.000Z'));
+    const now = Date.now();
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => now - 120_000,
+      getTokenExpiryTime: () => now - 60_000,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const expiringError = new Error('expiring callback failed');
+    const refreshError = new Error('refresh callback failed');
+    const onTokenExpiring = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
+      throw expiringError;
+    });
+    const onTokenRefreshNeeded = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
+      throw refreshError;
+    });
+    const onError = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn(), onError },
+      { onTokenExpiring, onTokenRefreshNeeded }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(onTokenExpiring).toHaveBeenCalledTimes(1);
+    expect(onTokenRefreshNeeded).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenNthCalledWith(1, expiringError);
+    expect(onError).toHaveBeenNthCalledWith(2, refreshError);
+    expect(socket.close).toHaveBeenCalledWith(4000, 'Token refresh required');
+    expect(logRequestResponse).toHaveBeenCalledWith(
+      'wss://ledger.example/v2/state/active-contracts',
+      expect.objectContaining({ event: 'token_expiring_handler_error' }),
+      { error: 'expiring callback failed' }
+    );
+    expect(logRequestResponse).toHaveBeenCalledWith(
+      'wss://ledger.example/v2/state/active-contracts',
+      expect.objectContaining({ event: 'token_refresh_handler_error' }),
+      { error: 'refresh callback failed' }
+    );
+  });
+
+  it('isolates a rejected close callback after delivering the close event', async () => {
+    const loggerError = jest.fn();
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse, error: loggerError }),
+    } as unknown as BaseClient;
+    const closeError = new Error('close callback failed');
+    const onClose = jest.fn(async (): Promise<void> => {
+      await Promise.resolve();
+      throw closeError;
+    });
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn(), onClose }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('close', 1000, Buffer.from('snapshot complete'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onClose).toHaveBeenCalledWith(1000, 'snapshot complete');
+    expect(loggerError).toHaveBeenCalledWith('WebSocket onClose handler failed', {
+      error: closeError.message,
     });
   });
 });

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -376,8 +376,8 @@ describe('WebSocketClient', () => {
 
     expect(onTokenExpiring).toHaveBeenCalledTimes(1);
     expect(onTokenRefreshNeeded).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenNthCalledWith(1, expiringError);
-    expect(onError).toHaveBeenNthCalledWith(2, refreshError);
+    expect(onError).toHaveBeenCalledWith(expiringError);
+    expect(onError).toHaveBeenCalledWith(refreshError);
     expect(socket.close).toHaveBeenCalledWith(4000, 'Token refresh required');
     expect(logRequestResponse).toHaveBeenCalledWith(
       'wss://ledger.example/v2/state/active-contracts',
@@ -389,6 +389,37 @@ describe('WebSocketClient', () => {
       expect.objectContaining({ event: 'token_refresh_handler_error' }),
       { error: 'refresh callback failed' }
     );
+  });
+
+  it('does not let a pending token-expiring callback block refresh close', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-10T04:00:00.000Z'));
+    const now = Date.now();
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => now - 120_000,
+      getTokenExpiryTime: () => now - 60_000,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const onTokenExpiring = jest.fn(async (): Promise<void> => new Promise<void>(() => undefined));
+    const onTokenRefreshNeeded = jest.fn().mockResolvedValue(undefined);
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn() },
+      { onTokenExpiring, onTokenRefreshNeeded }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(onTokenExpiring).toHaveBeenCalledTimes(1);
+    expect(onTokenRefreshNeeded).toHaveBeenCalledTimes(1);
+    expect(socket.close).toHaveBeenCalledWith(4000, 'Token refresh required');
   });
 
   it('isolates a rejected close callback after delivering the close event', async () => {

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -85,13 +85,9 @@ describe('WebSocketClient', () => {
     messageLog.resolve();
   });
 
-  it('does not turn a message logging failure into a stream failure', async () => {
+  it('does not let logging failures interrupt the stream lifecycle', async () => {
     const loggerError = jest.fn();
-    const logRequestResponse = jest.fn(async (_url: string, request: { event?: string }): Promise<void> => {
-      if (request.event === 'message') {
-        throw new Error('logger unavailable');
-      }
-    });
+    const logRequestResponse = jest.fn().mockRejectedValue(new Error('logger unavailable'));
     const client = {
       getApiUrl: () => 'https://ledger.example',
       authenticate: jest.fn().mockResolvedValue('token'),
@@ -119,26 +115,69 @@ describe('WebSocketClient', () => {
     expect(onError).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(socket.close).not.toHaveBeenCalled();
-    expect(loggerError).toHaveBeenCalledWith('WebSocket request/response logging failed', {
-      event: 'message',
-      error: 'logger unavailable',
-    });
+    for (const event of ['connect', 'message', 'close']) {
+      expect(loggerError).toHaveBeenCalledWith('WebSocket request/response logging failed', {
+        event,
+        error: 'logger unavailable',
+      });
+    }
   });
 
-  it('reports a message handler failure without labeling it invalid JSON', async () => {
+  it('closes after invalid JSON even when the error handler throws', async () => {
     const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const loggerError = jest.fn();
     const client = {
       getApiUrl: () => 'https://ledger.example',
       authenticate: jest.fn().mockResolvedValue('token'),
       getTokenIssuedAt: () => null,
       getTokenExpiryTime: () => null,
-      getLogger: () => ({ logRequestResponse }),
+      getLogger: () => ({ logRequestResponse, error: loggerError }),
+    } as unknown as BaseClient;
+    const onError = jest.fn(() => {
+      throw new Error('error callback failed');
+    });
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn(), onError }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('message', Buffer.from('{invalid json'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(socket.close).toHaveBeenCalledWith(1003, 'Invalid JSON received');
+    expect(logRequestResponse).toHaveBeenCalledWith(
+      'wss://ledger.example/v2/state/active-contracts',
+      expect.objectContaining({ event: 'parse_error' }),
+      expect.objectContaining({ raw: '{invalid json' })
+    );
+    expect(loggerError).toHaveBeenCalledWith('WebSocket onError handler failed', {
+      error: 'error callback failed',
+      originalError: expect.any(String),
+    });
+  });
+
+  it('reports a message handler failure without labeling it invalid JSON', async () => {
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const loggerError = jest.fn();
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse, error: loggerError }),
     } as unknown as BaseClient;
     const handlerError = new Error('consumer failed');
     const onMessage = jest.fn(() => {
       throw handlerError;
     });
-    const onError = jest.fn();
+    const onError = jest.fn(() => {
+      throw new Error('error callback failed');
+    });
 
     await new WebSocketClient(client).connect(
       '/v2/state/active-contracts',
@@ -163,5 +202,9 @@ describe('WebSocketClient', () => {
       expect.objectContaining({ event: 'parse_error' }),
       expect.anything()
     );
+    expect(loggerError).toHaveBeenCalledWith('WebSocket onError handler failed', {
+      error: 'error callback failed',
+      originalError: 'consumer failed',
+    });
   });
 });

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -84,4 +84,84 @@ describe('WebSocketClient', () => {
 
     messageLog.resolve();
   });
+
+  it('does not turn a message logging failure into a stream failure', async () => {
+    const loggerError = jest.fn();
+    const logRequestResponse = jest.fn(async (_url: string, request: { event?: string }): Promise<void> => {
+      if (request.event === 'message') {
+        throw new Error('logger unavailable');
+      }
+    });
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse, error: loggerError }),
+    } as unknown as BaseClient;
+    const onMessage = jest.fn();
+    const onError = jest.fn();
+    const onClose = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage, onError, onClose }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { JsActiveContract: {} } })));
+    socket.emit('close', 1000, Buffer.from('snapshot complete'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(loggerError).toHaveBeenCalledWith('WebSocket request/response logging failed', {
+      event: 'message',
+      error: 'logger unavailable',
+    });
+  });
+
+  it('reports a message handler failure without labeling it invalid JSON', async () => {
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const handlerError = new Error('consumer failed');
+    const onMessage = jest.fn(() => {
+      throw handlerError;
+    });
+    const onError = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage, onError }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { JsActiveContract: {} } })));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onError).toHaveBeenCalledWith(handlerError);
+    expect(socket.close).toHaveBeenCalledWith(1011, 'Message handler failed');
+    expect(logRequestResponse).toHaveBeenCalledWith(
+      'wss://ledger.example/v2/state/active-contracts',
+      expect.objectContaining({ event: 'message_handler_error' }),
+      { error: 'consumer failed' }
+    );
+    expect(logRequestResponse).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ event: 'parse_error' }),
+      expect.anything()
+    );
+  });
 });

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -123,6 +123,47 @@ describe('WebSocketClient', () => {
     }
   });
 
+  it('reports an open handler failure without labeling it a send failure', async () => {
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const handlerError = new Error('open callback failed');
+    const onOpen = jest.fn(() => {
+      throw handlerError;
+    });
+    const onError = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onOpen, onMessage: jest.fn(), onError }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('open');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ activeAtOffset: 42 }));
+    expect(onError).toHaveBeenCalledWith(handlerError);
+    expect(socket.close).toHaveBeenCalledWith(1011, 'Open handler failed');
+    expect(logRequestResponse).toHaveBeenCalledWith(
+      'wss://ledger.example/v2/state/active-contracts',
+      expect.objectContaining({ event: 'open_handler_error' }),
+      { error: 'open callback failed' }
+    );
+    expect(logRequestResponse).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ event: 'send_error' }),
+      expect.anything()
+    );
+  });
+
   it('closes after invalid JSON even when the error handler throws', async () => {
     const logRequestResponse = jest.fn().mockResolvedValue(undefined);
     const loggerError = jest.fn();

--- a/test/unit/operations/get-active-contracts.test.ts
+++ b/test/unit/operations/get-active-contracts.test.ts
@@ -67,4 +67,25 @@ describe('GetActiveContracts', () => {
       expect.any(Object)
     );
   });
+
+  it('rejects a null frame without treating it as a contract or Canton error', async () => {
+    mockConnect.mockImplementation(
+      async (
+        _path: string,
+        _request: unknown,
+        handlers: { onMessage: (message: unknown) => Promise<void> }
+      ): Promise<unknown> => {
+        await handlers.onMessage(null);
+        return {
+          close: jest.fn(),
+          isConnected: () => false,
+          getConnectionState: () => 3,
+        };
+      }
+    );
+
+    await expect(
+      new GetActiveContracts({} as never).execute({ parties: ['Alice'], activeAtOffset: 42 })
+    ).rejects.toThrow('Unexpected active-contracts WebSocket message');
+  });
 });

--- a/test/unit/operations/subscribe-to-updates.test.ts
+++ b/test/unit/operations/subscribe-to-updates.test.ts
@@ -51,4 +51,35 @@ describe('SubscribeToUpdates', (): void => {
     ).rejects.toThrow('WebSocket error [INTERNAL]: stream failed');
     expect(onMessage).toHaveBeenCalledTimes(1);
   });
+
+  it('rejects a null frame without invoking the typed consumer callback', async (): Promise<void> => {
+    const onMessage = jest.fn().mockResolvedValue(undefined);
+    mockConnect.mockImplementation(
+      async (
+        _path: string,
+        _request: unknown,
+        handlers: {
+          onMessage: (message: unknown) => Promise<void>;
+          onClose?: (code: number, reason: string) => void;
+        }
+      ): Promise<unknown> => {
+        await handlers.onMessage(null);
+        handlers.onClose?.(1000, 'stream complete');
+        return {
+          close: jest.fn(),
+          isConnected: (): boolean => false,
+          getConnectionState: (): number => 3,
+        };
+      }
+    );
+    const client = {
+      buildPartyList: (): string[] => ['Alice'],
+      getLedgerEnd: jest.fn().mockResolvedValue({ offset: 42 }),
+    };
+
+    await expect(new SubscribeToUpdates(client as never).connect({ beginExclusive: 42, onMessage })).rejects.toThrow(
+      'Unexpected ledger updates WebSocket message'
+    );
+    expect(onMessage).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/operations/subscribe-to-updates.test.ts
+++ b/test/unit/operations/subscribe-to-updates.test.ts
@@ -1,0 +1,54 @@
+import { SubscribeToUpdates } from '../../../src/clients/ledger-json-api/operations/v2/updates/subscribe-to-updates';
+
+const mockConnect = jest.fn();
+
+jest.mock('../../../src/core/ws/WebSocketClient', () => ({
+  WebSocketClient: class {
+    public connect(...args: unknown[]): unknown {
+      return mockConnect(...args);
+    }
+  },
+}));
+
+describe('SubscribeToUpdates', (): void => {
+  beforeEach((): void => {
+    mockConnect.mockReset();
+  });
+
+  it('rejects an error frame without waiting for a never-settling consumer callback', async (): Promise<void> => {
+    const neverSettles = new Promise<void>(() => undefined);
+    const onMessage = jest.fn(async (): Promise<void> => {
+      await neverSettles;
+    });
+    mockConnect.mockImplementation(
+      async (
+        _path: string,
+        _request: unknown,
+        handlers: { onMessage: (message: unknown) => Promise<void> }
+      ): Promise<unknown> => {
+        void handlers.onMessage({
+          code: 'INTERNAL',
+          cause: 'stream failed',
+          errorCategory: 1,
+        });
+        return {
+          close: jest.fn(),
+          isConnected: (): boolean => true,
+          getConnectionState: (): number => 1,
+        };
+      }
+    );
+    const client = {
+      buildPartyList: (): string[] => ['Alice'],
+      getLedgerEnd: jest.fn().mockResolvedValue({ offset: 42 }),
+    };
+
+    await expect(
+      new SubscribeToUpdates(client as never).connect({
+        beginExclusive: 42,
+        onMessage,
+      })
+    ).rejects.toThrow('WebSocket error [INTERNAL]: stream failed');
+    expect(onMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/operations/subscribe-to-updates.test.ts
+++ b/test/unit/operations/subscribe-to-updates.test.ts
@@ -17,6 +17,7 @@ describe('SubscribeToUpdates', (): void => {
 
   it('rejects an error frame without waiting for a never-settling consumer callback', async (): Promise<void> => {
     const neverSettles = new Promise<void>(() => undefined);
+    const close = jest.fn();
     const onMessage = jest.fn(async (): Promise<void> => {
       await neverSettles;
     });
@@ -32,7 +33,7 @@ describe('SubscribeToUpdates', (): void => {
           errorCategory: 1,
         });
         return {
-          close: jest.fn(),
+          close,
           isConnected: (): boolean => true,
           getConnectionState: (): number => 1,
         };
@@ -50,6 +51,8 @@ describe('SubscribeToUpdates', (): void => {
       })
     ).rejects.toThrow('WebSocket error [INTERNAL]: stream failed');
     expect(onMessage).toHaveBeenCalledTimes(1);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a null frame without invoking the typed consumer callback', async (): Promise<void> => {


### PR DESCRIPTION
## Summary

- separate malformed JSON, transport failures, and consumer callback failures in WebSocket lifecycle handling
- make request/response logging fully fire-and-forget so rejected or never-settling loggers cannot block delivery, close handling, or connection setup
- support both synchronous and asynchronous WebSocket callbacks, preserving `1011` close semantics for `onOpen` and `onMessage` failures
- wait for in-flight message callbacks before delivering `onClose`, so an async final-frame failure cannot be overtaken by server close
- isolate rejected `onError`, `onClose`, token-expiring, and token-refresh callbacks; an already-due refresh still closes with safe defaults
- propagate promise-returning callbacks through the operation factory, active-contract item callback, and updates subscription
- reject Canton update-stream error frames before awaiting consumer callbacks, while continuing to observe callback failures
- validate active-contract and update-stream frames from `unknown` against their runtime Zod wire unions before delivering typed callbacks

## Context

Follow-up to #375 and its matching Copilot/Cursor findings. #375 fixed final-frame delivery ordering; this PR ensures logging and consumer callbacks cannot reclassify valid frames as malformed JSON, leave a failed stream open, or surface unhandled rejections.

## Validation

- exact head `3dac450`: `npm run build`
- exact head `3dac450`: `npx jest test/unit --runInBand` (54 suites, 523 tests)
- exact head `3dac450`: focused WebSocket and frame-validation suites (3 suites, 14 tests)
- targeted ESLint and Prettier on all changed implementation/test files
- `git diff --check`
- `npm run check:package-artifacts` (4.92 MB unpacked, 1,197 files)
- exact-head package, pinned-dependency, security, CodeQL, and CN Quickstart checks all green
- current-head Copilot and Cursor reviews found no new issues; CodeRabbit incremental review completed; zero unresolved threads

Repository-wide ESLint and Prettier still report pre-existing findings outside this PR's implementation scope; the modified files are ESLint-clean and the newly formatted files pass Prettier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebSocket delivery ordering and error semantics used by ledger streaming; behavior changes are intentional but could affect consumers relying on prior timing or untyped frames.
> 
> **Overview**
> Hardens **WebSocket** lifecycle handling so logging and consumer callbacks cannot block delivery, mislabel failures, or leave failed streams open.
> 
> **`WebSocketClient`** now treats request/response logging as fire-and-forget, allows **sync and async** lifecycle callbacks, closes with **1011** when `onOpen`/`onMessage` fail (distinct from invalid JSON), waits for **in-flight message handlers** before `onClose`, and isolates failures in `onError`, `onClose`, and token-refresh hooks while still closing on refresh when callbacks reject or hang.
> 
> **Active contracts** and **subscribe-to-updates** parse inbound frames from `unknown` with **Zod** wire unions before typed delivery; updates **reject Canton error frames immediately** (close subscription, reject promise) without waiting on a slow `onMessage`, then still invoke the consumer when appropriate.
> 
> **`onItem` / `onMessage`** and the WebSocket operation factory propagate **promise-returning** callbacks. Unit tests cover logging, ordering, token refresh, frame validation, and error-frame behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dac450bb5c48909b55969ae3d4d1be3bec618ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

