### PR TITLE
Bound external-party allocation submissions

### DIFF
--- a/src/utils/external-signing/allocate-external-party.ts
+++ b/src/utils/external-signing/allocate-external-party.ts
@@ -10,16 +10,24 @@ export interface AllocateExternalPartyOptions {
   readonly identityProviderId: string;
   readonly onboardingTransactions: AllocateExternalPartyParams['onboardingTransactions'];
   readonly multiHashSignatures?: AllocateExternalPartyParams['multiHashSignatures'];
+  /**
+   * Cancels the HTTP request. Because allocation is a mutation, cancellation after dispatch has an ambiguous outcome
+   * and callers must reconcile the exact party ID before deciding whether to retry.
+   */
+  readonly signal?: AbortSignal;
 }
 
 /** Helper that submits the signed external party topology to the ledger. */
 export async function allocateExternalParty(
   options: AllocateExternalPartyOptions
 ): Promise<AllocateExternalPartyResponse> {
-  return options.ledgerClient.allocateExternalParty({
+  const params: AllocateExternalPartyParams = {
     synchronizer: options.synchronizerId,
     identityProviderId: options.identityProviderId,
     onboardingTransactions: options.onboardingTransactions,
     multiHashSignatures: options.multiHashSignatures,
-  });
+  };
+  return options.signal === undefined
+    ? options.ledgerClient.allocateExternalParty(params)
+    : options.ledgerClient.allocateExternalParty(params, { signal: options.signal });
 }

--- a/src/utils/external-signing/external-party-lifecycle.ts
+++ b/src/utils/external-signing/external-party-lifecycle.ts
@@ -7,6 +7,7 @@ import {
   ValidationError,
   type NormalizedCantonErrorDetails,
 } from '../../core/errors';
+import { isAbortError } from '../../core/http/abort';
 import { runWithAbortSignal } from '../../core/utils/abort';
 import { checkPartySynchronizerReadiness, type PartySynchronizerReadiness } from '../party-readiness';
 import { assertCantonPartyMatchesPublicKey } from './canton-protocol';
@@ -243,6 +244,14 @@ export interface ExternalPartyAllocationFailure {
 /** Classifies allocation failures from structured SDK/Canton fields, never from localized error messages. */
 export function classifyExternalPartyAllocationFailure(error: unknown): ExternalPartyAllocationFailure {
   const details = normalizeStatusFailure(error);
+  if (isAbortError(error)) {
+    return {
+      kind: 'definite-rejection',
+      definite: true,
+      shouldReconcile: false,
+      details,
+    };
+  }
   const alreadyExists = details.status === 409 && details.code === 'ALREADY_EXISTS';
   if (alreadyExists) {
     return {

--- a/src/utils/external-signing/external-party-lifecycle.ts
+++ b/src/utils/external-signing/external-party-lifecycle.ts
@@ -113,7 +113,8 @@ export async function reconcileExternalPartyOnboarding(
   };
 
   let partyDetails: Record<string, unknown>;
-  const createPartyDetailsAbortError = (): ValidationError => reconciliationAborted(options, 'party-details');
+  const partyDetailsAbortError = reconciliationAborted(options, 'party-details');
+  const createPartyDetailsAbortError = (): ValidationError => partyDetailsAbortError;
   try {
     const raw = await runWithAbortSignal(
       options.signal,
@@ -142,7 +143,7 @@ export async function reconcileExternalPartyOnboarding(
     }
     partyDetails = matched;
   } catch (error) {
-    if (options.signal?.aborted) throw createPartyDetailsAbortError();
+    if (error === partyDetailsAbortError) throw error;
     if (readErrorStatus(error) === 404) {
       return {
         ...base,
@@ -162,7 +163,8 @@ export async function reconcileExternalPartyOnboarding(
     };
   }
 
-  const createReadinessAbortError = (): ValidationError => reconciliationAborted(options, 'readiness');
+  const readinessAbortError = reconciliationAborted(options, 'readiness');
+  const createReadinessAbortError = (): ValidationError => readinessAbortError;
   try {
     const readiness = await runWithAbortSignal(
       options.signal,
@@ -206,7 +208,7 @@ export async function reconcileExternalPartyOnboarding(
       readiness,
     };
   } catch (error) {
-    if (options.signal?.aborted) throw createReadinessAbortError();
+    if (error === readinessAbortError) throw error;
     return {
       ...base,
       state: 'unknown',

--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -99,7 +99,10 @@ export type ExternalPartyHashSigner = (
 export interface CreateExternalPartyWithSignerOptions extends PrepareExternalPartyOnboardingOptions {
   readonly signMultiHash: ExternalPartyHashSigner;
   readonly identityProviderId?: string;
-  /** Cancels signing and allocation. It cannot undo an allocation already accepted by Canton. */
+  /**
+   * Cancels allocation transport. It does not cancel topology preparation or the caller-provided signer callback, and
+   * it cannot undo an allocation already accepted by Canton.
+   */
   readonly signal?: AbortSignal;
   /**
    * Treat a 409 allocation conflict as success when the party already exists and the party details endpoint confirms

--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -414,8 +414,8 @@ async function readExistingExternalPartyAfterAllocationConflict(
   signal?: AbortSignal
 ): Promise<Record<string, unknown> | null> {
   if (!isConflict(error)) return null;
-  const createAbortError = (): ValidationError =>
-    new ValidationError('Canton external-party conflict reconciliation was aborted', { partyId });
+  const abortError = new ValidationError('Canton external-party conflict reconciliation was aborted', { partyId });
+  const createAbortError = (): ValidationError => abortError;
   try {
     const partyDetailsResponse = await runWithAbortSignal(signal, createAbortError, () =>
       signal === undefined
@@ -439,7 +439,7 @@ async function readExistingExternalPartyAfterAllocationConflict(
       allocationError: readErrorDetails(error),
     };
   } catch (cause) {
-    if (signal?.aborted) {
+    if (cause === abortError) {
       throw new ExternalPartyConflictReconciliationError({
         partyId,
         allocationError: error,

--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -1,6 +1,7 @@
 import { type LedgerJsonApiClient } from '../../clients/ledger-json-api';
 import { ApiError, OperationError, OperationErrorCode, ValidationError } from '../../core/errors';
 import { isRecord } from '../../core/utils';
+import { runWithAbortSignal } from '../../core/utils/abort';
 import { objectOrEmpty, readRequiredString } from '../canton-response-utils';
 import { allocateExternalParty } from './allocate-external-party';
 import { type CantonEd25519Signature, normalizeCantonEd25519Signature } from './canton-ed25519-signer';
@@ -291,7 +292,8 @@ export async function submitExternalPartyOnboarding(
       options.ledgerClient,
       options.partyId,
       options.identityProviderId ?? DEFAULT_CANTON_IDENTITY_PROVIDER_ID,
-      error
+      error,
+      options.signal
     );
     if (!existing) {
       throw error;
@@ -393,14 +395,27 @@ async function readExistingExternalPartyAfterAllocationConflict(
   ledgerClient: LedgerJsonApiClient,
   partyId: string,
   identityProviderId: string,
-  error: unknown
+  error: unknown,
+  signal?: AbortSignal
 ): Promise<Record<string, unknown> | null> {
   if (!isConflict(error)) return null;
+  const createAbortError = (): ValidationError =>
+    new ValidationError('Canton external-party conflict reconciliation was aborted', { partyId });
   try {
-    const partyDetailsResponse = await ledgerClient.getPartyDetails({
-      party: partyId,
-      identityProviderId,
-    });
+    const partyDetailsResponse = await runWithAbortSignal(signal, createAbortError, () =>
+      signal === undefined
+        ? ledgerClient.getPartyDetails({
+            party: partyId,
+            identityProviderId,
+          })
+        : ledgerClient.getPartyDetails(
+            {
+              party: partyId,
+              identityProviderId,
+            },
+            { signal }
+          )
+    );
     const partyDetails = readMatchingExternalPartyDetails(partyDetailsResponse, partyId);
     if (!partyDetails) return null;
     return {
@@ -408,7 +423,8 @@ async function readExistingExternalPartyAfterAllocationConflict(
       partyDetails,
       allocationError: readErrorDetails(error),
     };
-  } catch {
+  } catch (cause) {
+    if (signal?.aborted) throw createAbortError();
     return null;
   }
 }

--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -78,6 +78,21 @@ export interface SubmittedExternalPartyOnboarding {
   readonly alreadyExisted: boolean;
 }
 
+/** Preserves an allocation conflict when its bounded existence confirmation is canceled. */
+export class ExternalPartyConflictReconciliationError extends Error {
+  readonly partyId: string;
+  readonly allocationError: unknown;
+  declare readonly cause: unknown;
+
+  constructor(options: { readonly partyId: string; readonly allocationError: unknown; readonly cause: unknown }) {
+    super('Canton external-party conflict reconciliation was aborted');
+    this.name = 'ExternalPartyConflictReconciliationError';
+    this.partyId = options.partyId;
+    this.allocationError = options.allocationError;
+    this.cause = options.cause;
+  }
+}
+
 export interface ExternalPartyHashSigningRequest {
   readonly partyHint: string;
   readonly partyId: string;
@@ -424,7 +439,13 @@ async function readExistingExternalPartyAfterAllocationConflict(
       allocationError: readErrorDetails(error),
     };
   } catch (cause) {
-    if (signal?.aborted) throw createAbortError();
+    if (signal?.aborted) {
+      throw new ExternalPartyConflictReconciliationError({
+        partyId,
+        allocationError: error,
+        cause,
+      });
+    }
     return null;
   }
 }

--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -60,6 +60,11 @@ export interface SubmitExternalPartyOnboardingOptions {
   readonly publicKeyFingerprint?: string | null;
   readonly identityProviderId?: string;
   /**
+   * Cancels the allocation request. Cancellation after dispatch has an ambiguous outcome; reconcile `partyId` before
+   * deciding whether to submit another allocation.
+   */
+  readonly signal?: AbortSignal;
+  /**
    * Treat a 409 allocation conflict as success when the party already exists and the party details endpoint confirms
    * it.
    */
@@ -94,6 +99,8 @@ export type ExternalPartyHashSigner = (
 export interface CreateExternalPartyWithSignerOptions extends PrepareExternalPartyOnboardingOptions {
   readonly signMultiHash: ExternalPartyHashSigner;
   readonly identityProviderId?: string;
+  /** Cancels signing and allocation. It cannot undo an allocation already accepted by Canton. */
+  readonly signal?: AbortSignal;
   /**
    * Treat a 409 allocation conflict as success when the party already exists and the party details endpoint confirms
    * it.
@@ -213,6 +220,7 @@ export async function createExternalPartyWithSigner(
     multiHashSignatureBase64: normalizeExternalPartyHashSignature(signature),
     ...(options.identityProviderId !== undefined ? { identityProviderId: options.identityProviderId } : {}),
     ...(options.allowAlreadyExists !== undefined ? { allowAlreadyExists: options.allowAlreadyExists } : {}),
+    ...(options.signal !== undefined ? { signal: options.signal } : {}),
   });
 
   return {
@@ -257,6 +265,7 @@ export async function submitExternalPartyOnboarding(
           signingAlgorithmSpec: CANTON_ED25519_SIGNATURE_ALGORITHM,
         },
       ],
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
     });
     const partyId = readAllocatedExternalPartyId(raw);
     if (partyId !== options.partyId) {

--- a/src/utils/external-signing/external-party-wallet.ts
+++ b/src/utils/external-signing/external-party-wallet.ts
@@ -287,15 +287,18 @@ export interface ExternalPartyWalletBridge {
     readonly partyName: string;
     readonly publicKeyBase64: string;
   }) => Promise<PreparedExternalPartyWalletOnboarding>;
-  readonly submitExternalPartySignature: (input: {
-    readonly partyId: string;
-    readonly publicKeyBase64: string;
-    readonly multiHashHex: string;
-    readonly synchronizerId: string;
-    readonly topologyTransactions: readonly string[];
-    readonly multiHashSignatureBase64: string;
-    readonly publicKeyFingerprint?: string | null;
-  }) => Promise<SubmittedExternalPartyWalletOnboarding>;
+  readonly submitExternalPartySignature: (
+    input: {
+      readonly partyId: string;
+      readonly publicKeyBase64: string;
+      readonly multiHashHex: string;
+      readonly synchronizerId: string;
+      readonly topologyTransactions: readonly string[];
+      readonly multiHashSignatureBase64: string;
+      readonly publicKeyFingerprint?: string | null;
+    },
+    options?: ExternalPartyWalletSubmissionOptions
+  ) => Promise<SubmittedExternalPartyWalletOnboarding>;
   readonly prepareCcTransfer: (
     input: PrepareExternalPartyWalletCcTransferInput
   ) => Promise<PreparedExternalPartyWalletCcTransfer>;
@@ -322,6 +325,14 @@ export interface ExternalPartyWalletBridge {
     input: ListExternalPartyWalletActiveContractsInput
   ) => Promise<ExternalPartyWalletActiveContracts>;
   readonly getExternalPartyBalance: (input: { readonly partyId: string }) => Promise<ExternalPartyWalletBalance>;
+}
+
+export interface ExternalPartyWalletSubmissionOptions {
+  /**
+   * Cancels the request. Cancellation after allocation dispatch has an ambiguous outcome; reconcile the exact party ID
+   * before deciding whether to submit another allocation.
+   */
+  readonly signal?: AbortSignal;
 }
 
 interface ProviderTransferOfferForAcceptance {
@@ -398,17 +409,24 @@ export function createExternalPartyWalletBridge(options: ExternalPartyWalletOpti
       };
     },
 
-    async submitExternalPartySignature(input: {
-      readonly partyId: string;
-      readonly publicKeyBase64: string;
-      readonly multiHashHex: string;
-      readonly synchronizerId: string;
-      readonly topologyTransactions: readonly string[];
-      readonly multiHashSignatureBase64: string;
-      readonly publicKeyFingerprint?: string | null;
-    }): Promise<SubmittedExternalPartyWalletOnboarding> {
+    async submitExternalPartySignature(
+      input: {
+        readonly partyId: string;
+        readonly publicKeyBase64: string;
+        readonly multiHashHex: string;
+        readonly synchronizerId: string;
+        readonly topologyTransactions: readonly string[];
+        readonly multiHashSignatureBase64: string;
+        readonly publicKeyFingerprint?: string | null;
+      },
+      submissionOptions: ExternalPartyWalletSubmissionOptions = {}
+    ): Promise<SubmittedExternalPartyWalletOnboarding> {
       assertCantonSha256MultihashHex(input.multiHashHex);
-      const synchronizerId = await readRequiredConnectedSynchronizerId(options.ledgerClient, options.providerPartyId);
+      const synchronizerId = await readRequiredConnectedSynchronizerId(
+        options.ledgerClient,
+        options.providerPartyId,
+        submissionOptions.signal
+      );
       if (synchronizerId !== input.synchronizerId) {
         throw new ValidationError(
           "Prepared Canton synchronizer no longer matches the provider's connected synchronizer",
@@ -428,6 +446,7 @@ export function createExternalPartyWalletBridge(options: ExternalPartyWalletOpti
         multiHashSignatureBase64: input.multiHashSignatureBase64,
         ...(input.publicKeyFingerprint !== undefined ? { publicKeyFingerprint: input.publicKeyFingerprint } : {}),
         allowAlreadyExists: true,
+        ...(submissionOptions.signal !== undefined ? { signal: submissionOptions.signal } : {}),
       });
       return {
         partyId: submitted.partyId,
@@ -1052,9 +1071,13 @@ function validateExistingOfferContractId(offerContractId: string): string {
 
 async function readConnectedSynchronizers(
   ledgerClient: LedgerJsonApiClient,
-  providerPartyId: string
+  providerPartyId: string,
+  signal?: AbortSignal
 ): Promise<ExternalPartyWalletConnectedSynchronizers> {
-  const raw = await ledgerClient.getConnectedSynchronizers({ party: providerPartyId });
+  const raw =
+    signal === undefined
+      ? await ledgerClient.getConnectedSynchronizers({ party: providerPartyId })
+      : await ledgerClient.getConnectedSynchronizers({ party: providerPartyId }, { signal });
   return {
     synchronizerId: parseExternalPartyWalletConnectedSynchronizerId(raw),
     raw,
@@ -1063,9 +1086,10 @@ async function readConnectedSynchronizers(
 
 async function readRequiredConnectedSynchronizerId(
   ledgerClient: LedgerJsonApiClient,
-  providerPartyId: string
+  providerPartyId: string,
+  signal?: AbortSignal
 ): Promise<string> {
-  const { synchronizerId } = await readConnectedSynchronizers(ledgerClient, providerPartyId);
+  const { synchronizerId } = await readConnectedSynchronizers(ledgerClient, providerPartyId, signal);
   if (synchronizerId) return synchronizerId;
   throw new OperationError(
     'Canton provider did not report a connected synchronizer',

--- a/src/utils/external-signing/external-signing-client.ts
+++ b/src/utils/external-signing/external-signing-client.ts
@@ -189,11 +189,13 @@ export async function createExternalPartyWithEd25519Signer(
     try {
       reconciliation = await reconcileExternalPartyAllocationFailure(reconcileOptions);
     } catch (reconciliationCause) {
-      if (!options.signal?.aborted) throw reconciliationCause;
       const failedAt =
-        reconciliationCause instanceof ValidationError && reconciliationCause.context?.['step'] === 'readiness'
-          ? 'readiness'
-          : 'party-details';
+        reconciliationCause instanceof ValidationError &&
+        (reconciliationCause.context?.['step'] === 'party-details' ||
+          reconciliationCause.context?.['step'] === 'readiness')
+          ? reconciliationCause.context['step']
+          : undefined;
+      if (failedAt === undefined) throw reconciliationCause;
       reconciliation = {
         failure: classifyExternalPartyAllocationFailure(allocationCause),
         status: {

--- a/src/utils/external-signing/external-signing-client.ts
+++ b/src/utils/external-signing/external-signing-client.ts
@@ -4,6 +4,7 @@ import {
   OperationError,
   OperationErrorCode,
   readCantonDefiniteAnswer,
+  ValidationError,
 } from '../../core/errors';
 import { readRequiredString } from '../canton-response-utils';
 import { waitForPartyCanSubmit, type WaitForPartyCanSubmitOptions } from '../party-readiness';
@@ -37,6 +38,7 @@ import {
   CANTON_ED25519_SIGNATURE_ALGORITHM,
   CANTON_RAW_SIGNATURE_FORMAT,
   createExternalPartyWithSigner,
+  ExternalPartyConflictReconciliationError,
   type CreatedExternalPartyWithSigner,
   type PrepareExternalPartyOnboardingOptions,
 } from './external-party-onboarding';
@@ -167,12 +169,13 @@ export async function createExternalPartyWithEd25519Signer(
   } catch (cause) {
     const signed = signedPayloads[0];
     if (!signed) throw cause;
+    const allocationCause = cause instanceof ExternalPartyConflictReconciliationError ? cause.allocationError : cause;
     const reconcileOptions = {
       ledgerClient: options.ledgerClient,
       partyId: signed.request.partyId,
       publicKeyBase64,
       synchronizerId: signed.request.synchronizerId,
-      error: cause,
+      error: allocationCause,
       expectSubmitReady: options.localParticipantObservationOnly !== true,
       ...(options.identityProviderId !== undefined ? { identityProviderId: options.identityProviderId } : {}),
       ...(options.participantId !== undefined ? { participantId: options.participantId } : {}),
@@ -183,16 +186,20 @@ export async function createExternalPartyWithEd25519Signer(
       reconciliation = await reconcileExternalPartyAllocationFailure(reconcileOptions);
     } catch (reconciliationCause) {
       if (!options.signal?.aborted) throw reconciliationCause;
+      const failedAt =
+        reconciliationCause instanceof ValidationError && reconciliationCause.context?.['step'] === 'readiness'
+          ? 'readiness'
+          : 'party-details';
       reconciliation = {
-        failure: classifyExternalPartyAllocationFailure(cause),
+        failure: classifyExternalPartyAllocationFailure(allocationCause),
         status: {
           state: 'unknown',
           partyId: signed.request.partyId,
           publicKeyFingerprint: signed.request.publicKeyFingerprint,
           synchronizerId: signed.request.synchronizerId,
-          exists: null,
+          exists: failedAt === 'readiness' ? true : null,
           ready: false,
-          failedAt: 'party-details',
+          failedAt,
           failure: {
             name: reconciliationCause instanceof Error ? reconciliationCause.name : 'AbortError',
             message:

--- a/src/utils/external-signing/external-signing-client.ts
+++ b/src/utils/external-signing/external-signing-client.ts
@@ -6,6 +6,7 @@ import {
   readCantonDefiniteAnswer,
   ValidationError,
 } from '../../core/errors';
+import { isAbortError } from '../../core/http/abort';
 import { readRequiredString } from '../canton-response-utils';
 import { waitForPartyCanSubmit, type WaitForPartyCanSubmitOptions } from '../party-readiness';
 import {
@@ -169,6 +170,9 @@ export async function createExternalPartyWithEd25519Signer(
   } catch (cause) {
     const signed = signedPayloads[0];
     if (!signed) throw cause;
+    // A plain AbortError is emitted only before mutation dispatch. Post-dispatch cancellation is wrapped as
+    // UnknownMutationOutcomeError and must continue through exact-party reconciliation.
+    if (isAbortError(cause)) throw cause;
     const allocationCause = cause instanceof ExternalPartyConflictReconciliationError ? cause.allocationError : cause;
     const reconcileOptions = {
       ledgerClient: options.ledgerClient,

--- a/src/utils/external-signing/external-signing-client.ts
+++ b/src/utils/external-signing/external-signing-client.ts
@@ -27,6 +27,7 @@ import {
   type InteractiveSubmissionHashingSchemeVersion,
 } from './execute-external-transaction';
 import {
+  classifyExternalPartyAllocationFailure,
   reconcileExternalPartyAllocationFailure,
   reconcileExternalPartyOnboarding,
   type ExternalPartyAllocationReconciliation,
@@ -166,7 +167,7 @@ export async function createExternalPartyWithEd25519Signer(
   } catch (cause) {
     const signed = signedPayloads[0];
     if (!signed) throw cause;
-    const reconciliation = await reconcileExternalPartyAllocationFailure({
+    const reconcileOptions = {
       ledgerClient: options.ledgerClient,
       partyId: signed.request.partyId,
       publicKeyBase64,
@@ -175,7 +176,33 @@ export async function createExternalPartyWithEd25519Signer(
       expectSubmitReady: options.localParticipantObservationOnly !== true,
       ...(options.identityProviderId !== undefined ? { identityProviderId: options.identityProviderId } : {}),
       ...(options.participantId !== undefined ? { participantId: options.participantId } : {}),
-    });
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
+    };
+    let reconciliation: ExternalPartyAllocationReconciliation;
+    try {
+      reconciliation = await reconcileExternalPartyAllocationFailure(reconcileOptions);
+    } catch (reconciliationCause) {
+      if (!options.signal?.aborted) throw reconciliationCause;
+      reconciliation = {
+        failure: classifyExternalPartyAllocationFailure(cause),
+        status: {
+          state: 'unknown',
+          partyId: signed.request.partyId,
+          publicKeyFingerprint: signed.request.publicKeyFingerprint,
+          synchronizerId: signed.request.synchronizerId,
+          exists: null,
+          ready: false,
+          failedAt: 'party-details',
+          failure: {
+            name: reconciliationCause instanceof Error ? reconciliationCause.name : 'AbortError',
+            message:
+              reconciliationCause instanceof Error
+                ? reconciliationCause.message
+                : 'Canton external-party reconciliation was aborted',
+          },
+        },
+      };
+    }
     throw new ExternalPartyOnboardingError({
       cause,
       reconciliation,

--- a/src/utils/external-signing/external-signing-client.ts
+++ b/src/utils/external-signing/external-signing-client.ts
@@ -61,7 +61,10 @@ export interface CreateExternalPartyWithEd25519SignerOptions extends Omit<
   readonly signingContext?: CantonEd25519SigningContext;
   readonly requestTtlMs?: number;
   readonly now?: () => number;
-  /** Cancels signing and post-allocation readiness reads; it cannot undo an allocation already submitted to Canton. */
+  /**
+   * Cancels signing, allocation transport, and post-allocation readiness reads. It cannot undo an allocation already
+   * accepted by Canton.
+   */
   readonly signal?: AbortSignal;
 }
 
@@ -142,6 +145,7 @@ export async function createExternalPartyWithEd25519Signer(
       ...(options.observingParticipantUids !== undefined
         ? { observingParticipantUids: options.observingParticipantUids }
         : {}),
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
       async signMultiHash(request) {
         const signed = await signAndVerifyCantonEd25519Payload({
           signer: options.signer,

--- a/test/unit/external-signing/external-party-lifecycle.test.ts
+++ b/test/unit/external-signing/external-party-lifecycle.test.ts
@@ -221,6 +221,13 @@ describe('external-party allocation failure classification', (): void => {
   });
 
   it('separates definite local/API rejection from ambiguous transport outcomes', (): void => {
+    const preDispatchAbort = new Error('allocation canceled before dispatch');
+    preDispatchAbort.name = 'AbortError';
+    expect(classifyExternalPartyAllocationFailure(preDispatchAbort)).toMatchObject({
+      kind: 'definite-rejection',
+      definite: true,
+      shouldReconcile: false,
+    });
     expect(classifyExternalPartyAllocationFailure(new ValidationError('invalid signature'))).toMatchObject({
       kind: 'definite-rejection',
       definite: true,

--- a/test/unit/external-signing/external-party-lifecycle.test.ts
+++ b/test/unit/external-signing/external-party-lifecycle.test.ts
@@ -1,6 +1,13 @@
 import { generateKeyPairSync } from 'node:crypto';
 import type { LedgerJsonApiClient } from '../../../src/clients/ledger-json-api';
-import { ApiError, NetworkError, OperationError, OperationErrorCode, ValidationError } from '../../../src/core/errors';
+import {
+  ApiError,
+  NetworkError,
+  OperationError,
+  OperationErrorCode,
+  UnknownMutationOutcomeError,
+  ValidationError,
+} from '../../../src/core/errors';
 import {
   buildExternalPartyId,
   deriveCantonEd25519PublicKeyFingerprint,
@@ -227,6 +234,18 @@ describe('external-party allocation failure classification', (): void => {
       kind: 'definite-rejection',
       definite: true,
       shouldReconcile: false,
+    });
+    expect(
+      classifyExternalPartyAllocationFailure(
+        new UnknownMutationOutcomeError(
+          { method: 'POST', endpoint: 'https://ledger.example.test/v2/parties/external', attempts: 1 },
+          preDispatchAbort
+        )
+      )
+    ).toMatchObject({
+      kind: 'ambiguous',
+      definite: false,
+      shouldReconcile: true,
     });
     expect(classifyExternalPartyAllocationFailure(new ValidationError('invalid signature'))).toMatchObject({
       kind: 'definite-rejection',

--- a/test/unit/external-signing/external-party-lifecycle.test.ts
+++ b/test/unit/external-signing/external-party-lifecycle.test.ts
@@ -182,6 +182,44 @@ describe('external-party lifecycle reconciliation', (): void => {
     expect(ledgerClient.getConnectedSynchronizers).not.toHaveBeenCalled();
   });
 
+  it('preserves a party-details failure that settles before a later abort', async (): Promise<void> => {
+    const fixture = createPartyFixture();
+    const ledgerClient = createMockLedgerClient(fixture.partyId);
+    const controller = new AbortController();
+    const partyDetailsError = new NetworkError('ledger unavailable');
+    let rejectPartyDetails: ((reason: unknown) => void) | undefined;
+    let markPartyDetailsStarted: (() => void) | undefined;
+    const partyDetailsStarted = new Promise<void>((resolve) => {
+      markPartyDetailsStarted = resolve;
+    });
+    ledgerClient.getPartyDetails.mockImplementationOnce(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectPartyDetails = reject;
+          markPartyDetailsStarted?.();
+        })
+    );
+    const reconciliation = reconcileExternalPartyOnboarding({
+      ledgerClient,
+      partyId: fixture.partyId,
+      publicKeyBase64: fixture.publicKeyBase64,
+      synchronizerId: SYNCHRONIZER_ID,
+      signal: controller.signal,
+    });
+
+    await partyDetailsStarted;
+    rejectPartyDetails?.(partyDetailsError);
+    controller.abort();
+
+    await expect(reconciliation).resolves.toMatchObject({
+      state: 'unknown',
+      exists: null,
+      ready: false,
+      failedAt: 'party-details',
+      failure: { name: 'NetworkError', message: 'ledger unavailable' },
+    });
+  });
+
   it('cancels an unresolved readiness read during reconciliation', async (): Promise<void> => {
     const fixture = createPartyFixture();
     const ledgerClient = createMockLedgerClient(fixture.partyId);

--- a/test/unit/external-signing/external-party-onboarding.test.ts
+++ b/test/unit/external-signing/external-party-onboarding.test.ts
@@ -12,6 +12,7 @@ import {
   CANTON_ED25519_SIGNATURE_ALGORITHM,
   CANTON_RAW_SIGNATURE_FORMAT,
   createExternalPartyWithSigner,
+  ExternalPartyConflictReconciliationError,
   getExternalPartyIdForHintAndPublicKey,
   listExternalPartyIdsForPublicKey,
   prepareExternalPartyOnboarding,
@@ -359,7 +360,12 @@ describe('external-party onboarding helpers', () => {
     await confirmationStarted;
     controller.abort();
 
-    await expect(submitted).rejects.toThrow('Canton external-party conflict reconciliation was aborted');
+    await expect(submitted).rejects.toMatchObject({
+      name: 'ExternalPartyConflictReconciliationError',
+      partyId: fixture.partyId,
+      allocationError: { status: 409 },
+      cause: { message: 'Canton external-party conflict reconciliation was aborted' },
+    } satisfies Partial<ExternalPartyConflictReconciliationError>);
   });
 
   it('lists and checks existing external parties by public-key fingerprint', async () => {

--- a/test/unit/external-signing/external-party-onboarding.test.ts
+++ b/test/unit/external-signing/external-party-onboarding.test.ts
@@ -159,6 +159,32 @@ describe('external-party onboarding helpers', () => {
     });
   });
 
+  it('forwards allocation cancellation without changing the submitted topology', async () => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+
+    await submitExternalPartyOnboarding({
+      ledgerClient,
+      synchronizerId: 'global-domain::sync',
+      partyId: fixture.partyId,
+      publicKeyBase64: fixture.publicKeyBase64,
+      publicKeyFingerprint: fixture.publicKeyFingerprint,
+      multiHashHex: MULTI_HASH_HEX,
+      topologyTransactions: ['topology-tx-1'],
+      multiHashSignatureBase64: fixture.signMultiHash(),
+      signal: controller.signal,
+    });
+
+    expect(ledgerClient.allocateExternalParty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        synchronizer: 'global-domain::sync',
+        onboardingTransactions: [{ transaction: 'topology-tx-1' }],
+      }),
+      { signal: controller.signal }
+    );
+  });
+
   it('creates an external party with an external signer callback returning hex', async () => {
     const fixture = createSigningFixture();
     const ledgerClient = createMockLedgerClient(fixture);

--- a/test/unit/external-signing/external-party-onboarding.test.ts
+++ b/test/unit/external-signing/external-party-onboarding.test.ts
@@ -368,6 +368,45 @@ describe('external-party onboarding helpers', () => {
     } satisfies Partial<ExternalPartyConflictReconciliationError>);
   });
 
+  it('preserves a confirmation failure that settles before a later abort', async () => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+    const allocationError = new ApiError('already exists', 409);
+    const confirmationError = new ApiError('party details unavailable', 503);
+    let rejectConfirmation: ((reason: unknown) => void) | undefined;
+    let markConfirmationStarted: (() => void) | undefined;
+    const confirmationStarted = new Promise<void>((resolve) => {
+      markConfirmationStarted = resolve;
+    });
+    ledgerClient.allocateExternalParty.mockRejectedValueOnce(allocationError);
+    ledgerClient.getPartyDetails.mockImplementationOnce(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectConfirmation = reject;
+          markConfirmationStarted?.();
+        })
+    );
+
+    const submitted = submitExternalPartyOnboarding({
+      ledgerClient,
+      synchronizerId: 'global-domain::sync',
+      partyId: fixture.partyId,
+      publicKeyBase64: fixture.publicKeyBase64,
+      multiHashHex: MULTI_HASH_HEX,
+      topologyTransactions: ['topology-tx-1'],
+      multiHashSignatureBase64: fixture.signMultiHash(),
+      allowAlreadyExists: true,
+      signal: controller.signal,
+    });
+
+    await confirmationStarted;
+    rejectConfirmation?.(confirmationError);
+    controller.abort();
+
+    await expect(submitted).rejects.toBe(allocationError);
+  });
+
   it('lists and checks existing external parties by public-key fingerprint', async () => {
     const fixture = createSigningFixture();
     const ledgerClient = createMockLedgerClient(fixture);

--- a/test/unit/external-signing/external-party-onboarding.test.ts
+++ b/test/unit/external-signing/external-party-onboarding.test.ts
@@ -301,6 +301,7 @@ describe('external-party onboarding helpers', () => {
   it('can treat allocation conflict as success after confirming the party exists', async () => {
     const fixture = createSigningFixture();
     const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
     ledgerClient.allocateExternalParty.mockRejectedValueOnce(new ApiError('already exists', 409));
 
     const submitted = await submitExternalPartyOnboarding({
@@ -313,14 +314,52 @@ describe('external-party onboarding helpers', () => {
       multiHashSignatureBase64: fixture.signMultiHash(),
       identityProviderId: 'custom-idp',
       allowAlreadyExists: true,
+      signal: controller.signal,
     });
 
-    expect(ledgerClient.getPartyDetails).toHaveBeenCalledWith({
-      party: fixture.partyId,
-      identityProviderId: 'custom-idp',
-    });
+    expect(ledgerClient.getPartyDetails).toHaveBeenCalledWith(
+      {
+        party: fixture.partyId,
+        identityProviderId: 'custom-idp',
+      },
+      { signal: controller.signal }
+    );
     expect(submitted.alreadyExisted).toBe(true);
     expect(submitted.partyId).toBe(fixture.partyId);
+  });
+
+  it('aborts a pending allocation-conflict confirmation read', async () => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+    let markConfirmationStarted: (() => void) | undefined;
+    const confirmationStarted = new Promise<void>((resolve) => {
+      markConfirmationStarted = resolve;
+    });
+    ledgerClient.allocateExternalParty.mockRejectedValueOnce(new ApiError('already exists', 409));
+    ledgerClient.getPartyDetails.mockImplementationOnce(
+      async () =>
+        new Promise<never>(() => {
+          markConfirmationStarted?.();
+        })
+    );
+
+    const submitted = submitExternalPartyOnboarding({
+      ledgerClient,
+      synchronizerId: 'global-domain::sync',
+      partyId: fixture.partyId,
+      publicKeyBase64: fixture.publicKeyBase64,
+      multiHashHex: MULTI_HASH_HEX,
+      topologyTransactions: ['topology-tx-1'],
+      multiHashSignatureBase64: fixture.signMultiHash(),
+      allowAlreadyExists: true,
+      signal: controller.signal,
+    });
+
+    await confirmationStarted;
+    controller.abort();
+
+    await expect(submitted).rejects.toThrow('Canton external-party conflict reconciliation was aborted');
   });
 
   it('lists and checks existing external parties by public-key fingerprint', async () => {

--- a/test/unit/external-signing/external-party-wallet.test.ts
+++ b/test/unit/external-signing/external-party-wallet.test.ts
@@ -16,6 +16,7 @@ import {
 
 const PREPARED_TRANSACTION_HASH_HEX = `1220${'22'.repeat(32)}`;
 const PREPARED_TRANSACTION_HASH_BASE64 = Buffer.from(PREPARED_TRANSACTION_HASH_HEX, 'hex').toString('base64');
+const MULTI_HASH_HEX = `1220${'11'.repeat(32)}`;
 const OFFER_CONTRACT_ID = '00offer-contract-id';
 const SYNCHRONIZER_ID = 'global-domain::sync';
 
@@ -45,6 +46,7 @@ const createSigningFixture = (): {
   readonly publicKeyFingerprint: string;
   readonly partyId: string;
   readonly signPreparedHash: () => string;
+  readonly signMultiHash: () => string;
 } => {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519');
   const publicKeyBase64 = Buffer.from(publicKey.export({ format: 'der', type: 'spki' }))
@@ -57,6 +59,7 @@ const createSigningFixture = (): {
     partyId: buildExternalPartyId('privy-test', publicKeyFingerprint),
     signPreparedHash: (): string =>
       sign(null, Buffer.from(PREPARED_TRANSACTION_HASH_HEX, 'hex'), privateKey).toString('base64'),
+    signMultiHash: (): string => sign(null, Buffer.from(MULTI_HASH_HEX, 'hex'), privateKey).toString('base64'),
   };
 };
 
@@ -77,6 +80,7 @@ const createMockLedgerClient = (): jest.Mocked<LedgerJsonApiClient> =>
     }),
     listParties: jest.fn().mockResolvedValue({ partyDetails: [] }),
     getPartyDetails: jest.fn().mockResolvedValue({ partyDetails: [] }),
+    allocateExternalParty: jest.fn(),
   }) as unknown as jest.Mocked<LedgerJsonApiClient>;
 
 const createMockValidatorClient = (): jest.Mocked<ValidatorApiClient> =>
@@ -156,6 +160,44 @@ const createBridge = (
 describe('external-party wallet bridge', (): void => {
   beforeEach((): void => {
     jest.clearAllMocks();
+  });
+
+  it('uses one cancellation signal for synchronizer lookup and external-party allocation', async (): Promise<void> => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient();
+    ledgerClient.allocateExternalParty.mockResolvedValueOnce({ partyId: fixture.partyId });
+    const bridge = createBridge({ ledgerClient });
+    const controller = new AbortController();
+
+    const submitted = await bridge.submitExternalPartySignature(
+      {
+        partyId: fixture.partyId,
+        publicKeyBase64: fixture.publicKeyBase64,
+        publicKeyFingerprint: fixture.publicKeyFingerprint,
+        multiHashHex: MULTI_HASH_HEX,
+        synchronizerId: SYNCHRONIZER_ID,
+        topologyTransactions: ['topology-tx'],
+        multiHashSignatureBase64: fixture.signMultiHash(),
+      },
+      { signal: controller.signal }
+    );
+
+    expect(ledgerClient.getConnectedSynchronizers).toHaveBeenCalledWith(
+      { party: 'provider::fingerprint' },
+      { signal: controller.signal }
+    );
+    expect(ledgerClient.allocateExternalParty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        synchronizer: SYNCHRONIZER_ID,
+        onboardingTransactions: [{ transaction: 'topology-tx' }],
+      }),
+      { signal: controller.signal }
+    );
+    expect(submitted).toEqual({
+      partyId: fixture.partyId,
+      raw: { partyId: fixture.partyId },
+      alreadyExisted: false,
+    });
   });
 
   it('prepares and submits an externally signed CC transfer with a token-bound payload', async (): Promise<void> => {

--- a/test/unit/external-signing/external-signing-client.test.ts
+++ b/test/unit/external-signing/external-signing-client.test.ts
@@ -396,6 +396,88 @@ describe('Canton Ed25519 external signing orchestration', (): void => {
     });
   });
 
+  it('preserves an allocation conflict when its existence confirmation is aborted', async (): Promise<void> => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+    let markConfirmationStarted: (() => void) | undefined;
+    const confirmationStarted = new Promise<void>((resolve) => {
+      markConfirmationStarted = resolve;
+    });
+    ledgerClient.allocateExternalParty.mockRejectedValueOnce(
+      new ApiError('already exists', 409, 'Conflict', { code: 'ALREADY_EXISTS' })
+    );
+    ledgerClient.getPartyDetails.mockImplementationOnce(
+      async () =>
+        new Promise<never>(() => {
+          markConfirmationStarted?.();
+        })
+    );
+
+    const onboarding = createExternalPartyWithEd25519Signer({
+      ledgerClient,
+      synchronizerId: SYNCHRONIZER_ID,
+      partyHint: 'external-test',
+      signer: fixture.signer,
+      signal: controller.signal,
+    });
+
+    await confirmationStarted;
+    controller.abort();
+
+    await expect(onboarding).rejects.toMatchObject({
+      name: 'ExternalPartyOnboardingError',
+      reconciliation: {
+        failure: { kind: 'already-exists', definite: true, shouldReconcile: true, status: 409 },
+        status: { state: 'unknown', exists: null, ready: false, failedAt: 'party-details' },
+      },
+      signingRequest: { partyId: fixture.partyId },
+    });
+  });
+
+  it('retains known party existence when allocation reconciliation aborts during readiness', async (): Promise<void> => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+    let markReadinessStarted: (() => void) | undefined;
+    const readinessStarted = new Promise<void>((resolve) => {
+      markReadinessStarted = resolve;
+    });
+    ledgerClient.allocateExternalParty.mockRejectedValueOnce(new NetworkError('connection reset after upload'));
+    ledgerClient.getConnectedSynchronizers.mockImplementationOnce(
+      async () =>
+        new Promise<never>(() => {
+          markReadinessStarted?.();
+        })
+    );
+
+    const onboarding = createExternalPartyWithEd25519Signer({
+      ledgerClient,
+      synchronizerId: SYNCHRONIZER_ID,
+      partyHint: 'external-test',
+      signer: fixture.signer,
+      signal: controller.signal,
+    });
+
+    await readinessStarted;
+    controller.abort();
+
+    await expect(onboarding).rejects.toMatchObject({
+      name: 'ExternalPartyOnboardingError',
+      reconciliation: {
+        failure: { kind: 'ambiguous', shouldReconcile: true },
+        status: {
+          state: 'unknown',
+          exists: true,
+          ready: false,
+          failedAt: 'readiness',
+          failure: { message: 'Canton external-party reconciliation was aborted' },
+        },
+      },
+      signingRequest: { partyId: fixture.partyId },
+    });
+  });
+
   it('aborts readiness after allocation without returning a successful onboarding result', async (): Promise<void> => {
     const fixture = createSigningFixture();
     const ledgerClient = createMockLedgerClient(fixture);

--- a/test/unit/external-signing/external-signing-client.test.ts
+++ b/test/unit/external-signing/external-signing-client.test.ts
@@ -340,6 +340,10 @@ describe('Canton Ed25519 external signing orchestration', (): void => {
         signatureBase64: expect.any(String) as string,
       });
     }
+    expect(ledgerClient.allocateExternalParty).toHaveBeenCalledWith(
+      expect.objectContaining({ synchronizer: SYNCHRONIZER_ID }),
+      { signal: controller.signal }
+    );
   });
 
   it('aborts readiness after allocation without returning a successful onboarding result', async (): Promise<void> => {

--- a/test/unit/external-signing/external-signing-client.test.ts
+++ b/test/unit/external-signing/external-signing-client.test.ts
@@ -353,6 +353,29 @@ describe('Canton Ed25519 external signing orchestration', (): void => {
     expect(ledgerClient.getPartyDetails).not.toHaveBeenCalled();
   });
 
+  it('surfaces a pre-dispatch allocation cancellation without reconciliation', async (): Promise<void> => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+    const abortError = new Error('allocation canceled before dispatch');
+    abortError.name = 'AbortError';
+    ledgerClient.allocateExternalParty.mockImplementationOnce(async () => {
+      controller.abort();
+      throw abortError;
+    });
+
+    await expect(
+      createExternalPartyWithEd25519Signer({
+        ledgerClient,
+        synchronizerId: SYNCHRONIZER_ID,
+        partyHint: 'external-test',
+        signer: fixture.signer,
+        signal: controller.signal,
+      })
+    ).rejects.toBe(abortError);
+    expect(ledgerClient.getPartyDetails).not.toHaveBeenCalled();
+  });
+
   it('aborts a pending reconciliation read after an ambiguous allocation failure', async (): Promise<void> => {
     const fixture = createSigningFixture();
     const ledgerClient = createMockLedgerClient(fixture);

--- a/test/unit/external-signing/external-signing-client.test.ts
+++ b/test/unit/external-signing/external-signing-client.test.ts
@@ -311,7 +311,7 @@ describe('Canton Ed25519 external signing orchestration', (): void => {
     expect(Object.getOwnPropertyDescriptor(normalizedContext ?? {}, '__proto__')).toMatchObject({ value: null });
   });
 
-  it('returns structured reconciliation after an ambiguous allocation outcome', async (): Promise<void> => {
+  it('returns a bounded unknown reconciliation after an ambiguous allocation abort', async (): Promise<void> => {
     const fixture = createSigningFixture();
     const ledgerClient = createMockLedgerClient(fixture);
     const controller = new AbortController();
@@ -334,7 +334,13 @@ describe('Canton Ed25519 external signing orchestration', (): void => {
       expect(error).toMatchObject({
         reconciliation: {
           failure: { kind: 'ambiguous', shouldReconcile: true },
-          status: { state: 'ready', exists: true, ready: true },
+          status: {
+            state: 'unknown',
+            exists: null,
+            ready: false,
+            failedAt: 'party-details',
+            failure: { message: 'Canton external-party reconciliation was aborted' },
+          },
         },
         signingRequest: { partyId: fixture.partyId },
         signatureBase64: expect.any(String) as string,
@@ -344,6 +350,50 @@ describe('Canton Ed25519 external signing orchestration', (): void => {
       expect.objectContaining({ synchronizer: SYNCHRONIZER_ID }),
       { signal: controller.signal }
     );
+    expect(ledgerClient.getPartyDetails).not.toHaveBeenCalled();
+  });
+
+  it('aborts a pending reconciliation read after an ambiguous allocation failure', async (): Promise<void> => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient(fixture);
+    const controller = new AbortController();
+    let markReconciliationStarted: (() => void) | undefined;
+    const reconciliationStarted = new Promise<void>((resolve) => {
+      markReconciliationStarted = resolve;
+    });
+    ledgerClient.allocateExternalParty.mockRejectedValueOnce(new NetworkError('connection reset after upload'));
+    ledgerClient.getPartyDetails.mockImplementationOnce(
+      async () =>
+        new Promise<never>(() => {
+          markReconciliationStarted?.();
+        })
+    );
+
+    const onboarding = createExternalPartyWithEd25519Signer({
+      ledgerClient,
+      synchronizerId: SYNCHRONIZER_ID,
+      partyHint: 'external-test',
+      signer: fixture.signer,
+      signal: controller.signal,
+    });
+
+    await reconciliationStarted;
+    controller.abort();
+
+    await expect(onboarding).rejects.toMatchObject({
+      name: 'ExternalPartyOnboardingError',
+      reconciliation: {
+        failure: { kind: 'ambiguous', shouldReconcile: true },
+        status: {
+          state: 'unknown',
+          exists: null,
+          ready: false,
+          failedAt: 'party-details',
+          failure: { message: 'Canton external-party reconciliation was aborted' },
+        },
+      },
+      signingRequest: { partyId: fixture.partyId },
+    });
   });
 
   it('aborts readiness after allocation without returning a successful onboarding result', async (): Promise<void> => {


### PR DESCRIPTION
## Summary

- expose an optional `AbortSignal` on external-party onboarding and wallet-bridge submission
- carry one signal through the provider synchronizer lookup and the Ledger `/v2/parties/external/allocate` mutation
- preserve the SDK’s mutation-safe behavior: an abort after dispatch is an ambiguous outcome and callers must reconcile the exact prepared party ID before retrying

## Why

[apiv2 PR #816](https://github.com/Fairmint/apiv2/pull/816) reached `POST /wallet/external-party-submit`, then remained blocked inside `submitExternalPartySignature` for more than 280 seconds because canton-node-sdk 0.0.237 had no bounded allocation transport. The prepared buyer party remained absent in repeated exact Ledger party lookups, while a raw bridge probe completed in 1.7 seconds, isolating the defect to the unbounded application submission path rather than credentials or endpoint availability.

The consumer can now call:

```ts
bridge.submitExternalPartySignature(input, {
  signal: AbortSignal.timeout(allocationTimeoutMs),
});
```

If cancellation happens after dispatch, the consumer must check the exact `partyId` before deciding whether a fresh allocation is safe.

## Validation

- `npm test -- --runInBand test/unit/external-signing/external-party-onboarding.test.ts test/unit/external-signing/external-party-wallet.test.ts` (34 tests)
- `npm run build:core`
- Prettier check on all five changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Canton party onboarding mutation and idempotent 409 handling; incorrect abort/retry semantics could duplicate allocation attempts if callers skip party-ID reconciliation.
> 
> **Overview**
> Adds optional **`AbortSignal`** support across external-party allocation so callers can cap how long synchronizer lookup, ledger allocation, and follow-up reads may run (e.g. `AbortSignal.timeout` on wallet submit).
> 
> The same signal is threaded from **`submitExternalPartySignature`** through provider **`getConnectedSynchronizers`** and **`allocateExternalParty`**, and through onboarding helpers including post-409 party-details confirmation. Docs stress that **canceling after the allocation mutation is dispatched is ambiguous**—callers must reconcile the exact **`partyId`** before retrying.
> 
> **Cancellation semantics** are tightened: reconciliation aborts are detected by **error identity** (not only `signal.aborted`), real failures that settle before a later abort are preserved, and **`classifyExternalPartyAllocationFailure`** treats plain pre-dispatch **`AbortError`** as definite rejection (while **`UnknownMutationOutcomeError`** + abort stays ambiguous). **`ExternalPartyConflictReconciliationError`** is new when 409 existence confirmation is aborted; **`createExternalPartyWithEd25519Signer`** maps reconciliation aborts into bounded **`ExternalPartyOnboardingError`** status instead of implying success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0169592b93f95e5c047dc8a76e592d8210e4073e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->