### PR TITLE
Bound external party recovery lookups

### DIFF
--- a/src/utils/external-signing/external-party-onboarding.ts
+++ b/src/utils/external-signing/external-party-onboarding.ts
@@ -335,14 +335,16 @@ function normalizeExternalPartyHashSignature(signature: ExternalPartyHashSignatu
 /** Lists party ids whose suffix matches the supplied Ed25519 public key fingerprint. */
 export async function listExternalPartyIdsForPublicKey(
   ledgerClient: LedgerJsonApiClient,
-  publicKeyBase64: string
+  publicKeyBase64: string,
+  signal?: AbortSignal
 ): Promise<{
   readonly publicKeyFingerprint: string;
   readonly parties: readonly string[];
   readonly raw: unknown;
 }> {
   const publicKeyFingerprint = deriveCantonEd25519PublicKeyFingerprint(publicKeyBase64);
-  const raw = await ledgerClient.listParties({});
+  const raw =
+    signal === undefined ? await ledgerClient.listParties({}) : await ledgerClient.listParties({}, { signal });
   return {
     publicKeyFingerprint,
     parties: readPartyIdsByFingerprint(raw, publicKeyFingerprint),
@@ -355,7 +357,8 @@ export async function getExternalPartyIdForHintAndPublicKey(
   ledgerClient: LedgerJsonApiClient,
   partyHint: string,
   publicKeyBase64: string,
-  identityProviderId = DEFAULT_CANTON_IDENTITY_PROVIDER_ID
+  identityProviderId = DEFAULT_CANTON_IDENTITY_PROVIDER_ID,
+  signal?: AbortSignal
 ): Promise<{
   readonly publicKeyFingerprint: string;
   readonly partyId: string;
@@ -365,7 +368,11 @@ export async function getExternalPartyIdForHintAndPublicKey(
   const publicKeyFingerprint = deriveCantonEd25519PublicKeyFingerprint(publicKeyBase64);
   const partyId = buildExternalPartyId(partyHint, publicKeyFingerprint);
   try {
-    const raw = await ledgerClient.getPartyDetails({ party: partyId, identityProviderId });
+    const params = { party: partyId, identityProviderId };
+    const raw =
+      signal === undefined
+        ? await ledgerClient.getPartyDetails(params)
+        : await ledgerClient.getPartyDetails(params, { signal });
     return {
       publicKeyFingerprint,
       partyId,

--- a/src/utils/external-signing/external-party-wallet.ts
+++ b/src/utils/external-signing/external-party-wallet.ts
@@ -279,10 +279,13 @@ export interface ExternalPartyWalletBalance {
 export interface ExternalPartyWalletBridge {
   readonly getConnectedSynchronizers: () => Promise<ExternalPartyWalletConnectedSynchronizers>;
   readonly getProviderSourceBalance: () => Promise<ExternalPartyWalletProviderBalance>;
-  readonly listExternalPartiesForPublicKey: (input: {
-    readonly publicKeyBase64: string;
-    readonly partyName?: string;
-  }) => Promise<ExternalPartyWalletParties>;
+  readonly listExternalPartiesForPublicKey: (
+    input: {
+      readonly publicKeyBase64: string;
+      readonly partyName?: string;
+    },
+    options?: ExternalPartyWalletLookupOptions
+  ) => Promise<ExternalPartyWalletParties>;
   readonly prepareExternalParty: (input: {
     readonly partyName: string;
     readonly publicKeyBase64: string;
@@ -335,6 +338,11 @@ export interface ExternalPartyWalletSubmissionOptions {
   readonly signal?: AbortSignal;
 }
 
+export interface ExternalPartyWalletLookupOptions {
+  /** Cancels the exact-party or public-key lookup request. */
+  readonly signal?: AbortSignal;
+}
+
 interface ProviderTransferOfferForAcceptance {
   readonly offer: unknown;
   readonly offerContractId: string;
@@ -368,15 +376,20 @@ export function createExternalPartyWalletBridge(options: ExternalPartyWalletOpti
       };
     },
 
-    async listExternalPartiesForPublicKey(input: {
-      readonly publicKeyBase64: string;
-      readonly partyName?: string;
-    }): Promise<ExternalPartyWalletParties> {
+    async listExternalPartiesForPublicKey(
+      input: {
+        readonly publicKeyBase64: string;
+        readonly partyName?: string;
+      },
+      lookupOptions: ExternalPartyWalletLookupOptions = {}
+    ): Promise<ExternalPartyWalletParties> {
       if (input.partyName) {
         const result = await getExternalPartyIdForHintAndPublicKey(
           options.ledgerClient,
           input.partyName,
-          input.publicKeyBase64
+          input.publicKeyBase64,
+          undefined,
+          lookupOptions.signal
         );
         return {
           publicKeyFingerprint: result.publicKeyFingerprint,
@@ -384,7 +397,7 @@ export function createExternalPartyWalletBridge(options: ExternalPartyWalletOpti
           raw: result.raw,
         };
       }
-      return listExternalPartyIdsForPublicKey(options.ledgerClient, input.publicKeyBase64);
+      return listExternalPartyIdsForPublicKey(options.ledgerClient, input.publicKeyBase64, lookupOptions.signal);
     },
 
     async prepareExternalParty(input: {

--- a/test/unit/external-signing/external-party-wallet.test.ts
+++ b/test/unit/external-signing/external-party-wallet.test.ts
@@ -200,6 +200,29 @@ describe('external-party wallet bridge', (): void => {
     });
   });
 
+  it('forwards cancellation to exact external-party recovery lookups', async (): Promise<void> => {
+    const fixture = createSigningFixture();
+    const ledgerClient = createMockLedgerClient();
+    const bridge = createBridge({ ledgerClient });
+    const controller = new AbortController();
+
+    await bridge.listExternalPartiesForPublicKey(
+      {
+        partyName: 'privy-test',
+        publicKeyBase64: fixture.publicKeyBase64,
+      },
+      { signal: controller.signal }
+    );
+
+    expect(ledgerClient.getPartyDetails).toHaveBeenCalledWith(
+      {
+        party: fixture.partyId,
+        identityProviderId: '',
+      },
+      { signal: controller.signal }
+    );
+  });
+
   it('prepares and submits an externally signed CC transfer with a token-bound payload', async (): Promise<void> => {
     const fixture = createSigningFixture();
     const validatorClient = createMockValidatorClient();


### PR DESCRIPTION
## Summary

- expose cancellation for external-party public-key and exact-party lookup helpers
- forward the same signal through the wallet bridge recovery lookup
- cover exact-party signal forwarding with a focused regression test

This closes the post-allocation recovery gap found while exercising the API v2 trading playground. The allocation itself is bounded by #391; consumers can now bound the exact-party reconciliation lookup without an untracked background request.

## Validation

- `npm test -- --runInBand test/unit/external-signing/external-party-wallet.test.ts test/unit/external-signing/external-party-onboarding.test.ts` (37 tests)
- TypeScript 7 compile
- Prettier check
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API with no change to default behavior; limited to lookup/cancellation plumbing and a focused regression test.
> 
> **Overview**
> Adds optional **`AbortSignal`** support to external-party **recovery lookups** so callers can cancel in-flight ledger requests during post-allocation reconciliation.
> 
> **Onboarding helpers** (`listExternalPartyIdsForPublicKey`, `getExternalPartyIdForHintAndPublicKey`) now accept an optional signal and pass it through to `listParties` / `getPartyDetails` when present.
> 
> The **wallet bridge** exposes `ExternalPartyWalletLookupOptions` and threads the same signal through `listExternalPartiesForPublicKey` for both public-key listing and exact hint+key lookups. A unit test asserts exact-party recovery forwards the signal to `getPartyDetails`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7606de25f5350cfe2ce965494bdc312a99e704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->