### PR TITLE
docs: add Cursor Cloud LocalNet setup + gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# canton-node-sdk
+
+See [CLAUDE.md](CLAUDE.md), [README.md](README.md), and
+`.cursor/skills/localnet-testing/SKILL.md`. `package.json` (`localnet:*` scripts) and
+`bin/canton-localnet` are the source of truth for LocalNet commands.
+
+## Cursor Cloud specific instructions
+
+Repo checks (`npm install`, `npm run fix`, `npm test`, `npm run build`) need no dashboard secrets.
+`npm install` does not require `NPM_TOKEN` here (dependencies are public).
+
+### Canton LocalNet on a cloud VM
+
+LocalNet runs Canton Network Quickstart in Docker. `npm run localnet:start` (=
+`bin/canton-localnet start`, infra-only + OAuth2 by default) is self-provisioning on the cloud image:
+it `apt`-installs Docker, starts a `dockerd` (vfs storage driver, iptables-legacy) via passwordless
+`sudo`, adds `scan.localhost`/`sv.localhost`/`wallet.localhost` to `/etc/hosts`, runs cn-quickstart
+`make setup`, brings up the compose stack, and waits for the Validator, Scan, and Ledger JSON APIs.
+
+Prerequisites (on demand — heavy, not in the dashboard update script):
+
+```bash
+git submodule update --init --recursive --depth 1 libs/cn-quickstart
+git submodule update --init --depth 1 libs/splice
+npm install
+npm run localnet:start   # first run ~10-15 min: image pulls + Splice DSO bootstrap
+npm run localnet:smoke   # Keycloak/Validator/Scan/Ledger reachability
+npm run localnet:stop
+```
+
+Verified ready endpoints: Ledger JSON API `http://localhost:3975/v2/version` (returned `3.5.4`),
+Scan `http://scan.localhost:4000/api/scan/v0/dso-party-id` (returns the DSO party id), Validator
+`http://localhost:3903/...` (200/401).
+
+Known gotchas hit in this cloud/multi-repo setup:
+
+- **Port 3000 conflict.** LocalNet's `nginx` binds host `127.0.0.1:3000`, which collides with the
+  `apiv2` dev gateway (also `:3000`). Free `:3000` (stop the apiv2 dev server) before starting
+  LocalNet, or `nginx` fails with `failed to bind host port 127.0.0.1:3000: address already in use`.
+- **`nginx` left network-less after a failed start.** If `nginx`'s first start fails (e.g. the port
+  clash above), the container is created but never attached to the `quickstart` Docker network, then
+  crash-loops with `host not found in upstream "splice"`. Fix: `sudo docker rm -f nginx` and re-run
+  `npm run localnet:start` so it is recreated and attached.
+- **Splice force-recreate can stall Scan readiness.** The SDK patches the Splice config
+  (`enable-forced-acs-snapshots`) and force-recreates the running Splice, which disrupts `nginx`'s
+  static upstream resolution and can make the Scan API miss its readiness window. Once the config is
+  applied, set `CANTON_NODE_SDK_SPLICE_CONFIG_PENDING=false` in
+  `libs/cn-quickstart/quickstart/.env.local` to skip the recreate on the next start.
+
+Do not commit the `libs/cn-quickstart` / `libs/splice` submodule pointer changes produced by
+`submodule update`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting how to bring up Canton LocalNet on a Cursor Cloud VM, verified end to end during environment setup. Captures three non-obvious failure modes hit during bring-up.

## Verified flow

```bash
git submodule update --init --recursive --depth 1 libs/cn-quickstart
git submodule update --init --depth 1 libs/splice
npm install
npm run localnet:start   # auto-installs Docker, starts dockerd (vfs), configures cn-quickstart, waits for APIs
npm run localnet:smoke   # passed
```

Ready endpoints observed: Ledger JSON API `:3975/v2/version` → `3.5.4`; Scan `scan.localhost:4000/api/scan/v0/dso-party-id` → DSO party id; Validator `:3903` → 200/401.

## Documented gotchas

1. **Port 3000 conflict** — LocalNet's `nginx` binds host `127.0.0.1:3000`, colliding with the `apiv2` dev gateway (also `:3000`). Free `:3000` before starting.
2. **`nginx` left network-less after a failed start** — if the first `nginx` start fails (e.g. the port clash), the container isn't attached to the `quickstart` network and crash-loops with `host not found in upstream "splice"`. Fix: `docker rm -f nginx` then re-run start.
3. **Splice force-recreate can stall Scan readiness** — the SDK patches Splice config and force-recreates it, disrupting `nginx` upstream resolution. Once applied, set `CANTON_NODE_SDK_SPLICE_CONFIG_PENDING=false` in `libs/cn-quickstart/quickstart/.env.local` to skip the recreate.

Docs-only change; no code touched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ace82b-c673-41ce-8ebe-c7db05ae4cd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ace82b-c673-41ce-8ebe-c7db05ae4cd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup and troubleshooting guidance for Canton LocalNet and cloud checks.
  * Documented prerequisites, verification steps, common Docker/nginx/Splice issues, and remediation actions.
  * Added guidance to avoid committing unintended submodule pointer changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->