### PR TITLE
Bound HTTP and active-contracts requests with timeouts

### DIFF
--- a/src/Canton.ts
+++ b/src/Canton.ts
@@ -65,6 +65,11 @@ export interface CantonConfig {
   readonly managedParties?: readonly string[];
   /** OAuth2 auth URL (if different from default). */
   readonly authUrl?: string;
+  /**
+   * Socket-inactivity timeout in milliseconds for every HTTP request. Defaults to `DEFAULT_HTTP_TIMEOUT_MS`; a
+   * per-service `apis[...].timeoutMs` takes precedence.
+   */
+  readonly timeoutMs?: number;
   /** Override API endpoints or timeouts per service (`ledgerJsonApi`, `validatorApi`, `scanApi`). */
   readonly apis?: ClientConfig['apis'];
 }
@@ -246,6 +251,7 @@ function buildClientConfig(config: CantonConfig): ClientConfig {
   if (config.userId !== undefined) clientConfig.userId = config.userId;
   if (config.managedParties !== undefined) clientConfig.managedParties = [...config.managedParties];
   if (config.authUrl !== undefined) clientConfig.authUrl = config.authUrl;
+  if (config.timeoutMs !== undefined) clientConfig.timeoutMs = config.timeoutMs;
   if (config.apis !== undefined) clientConfig.apis = { ...config.apis };
 
   return clientConfig;

--- a/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
+++ b/src/clients/ledger-json-api/operations/v2/state/get-active-contracts.ts
@@ -18,6 +18,14 @@ import { buildEventFormat } from '../utils/event-format-builder';
 const path = '/v2/state/active-contracts' as const;
 
 /**
+ * Idle timeout for the active-contracts snapshot stream.
+ *
+ * The snapshot is a bounded stream that the server closes on its own, so silence this long means the connection is hung
+ * rather than slow. Callers that expect longer gaps can raise it or pass `0` to wait indefinitely.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 600_000;
+
+/**
  * We intentionally do not expose the JSON/REST version of this endpoint. The REST variant is too limited, while the
  * WebSocket variant returns the same snapshot and automatically closes the connection once the current state is sent.
  * Wrapping the WebSocket call behind a simple awaitable method gives a better DX and keeps the door open for optional
@@ -37,6 +45,8 @@ const ActiveContractsParamsSchema = z.object({
   includeCreatedEventBlob: z.boolean().optional(),
   /** Allow caller to omit activeAtOffset; we'll default to ledger end */
   activeAtOffset: z.number().optional(),
+  /** Fail the snapshot when no message arrives for this many milliseconds. `0` waits indefinitely. */
+  idleTimeoutMs: z.number().min(0).optional(),
 });
 
 export type GetActiveContractsParams = z.infer<typeof ActiveContractsParamsSchema> & {
@@ -119,41 +129,46 @@ export class GetActiveContracts {
       };
 
       void wsClient
-        .connect<ActiveContractsRequestMessage, unknown>(path, requestMessage, {
-          onMessage: async (parsed): Promise<void> => {
-            const decoded = ActiveContractsResponseMessageSchema.safeParse(parsed);
-            if (!decoded.success) {
-              throw new ApiError('Unexpected active-contracts WebSocket message');
-            }
-            const message = decoded.data;
-
-            // Distinguish item vs error union members
-            if ('contractEntry' in message) {
-              results.push(message);
-              if (typeof params.onItem === 'function') {
-                await params.onItem(message);
+        .connect<ActiveContractsRequestMessage, unknown>(
+          path,
+          requestMessage,
+          {
+            onMessage: async (parsed): Promise<void> => {
+              const decoded = ActiveContractsResponseMessageSchema.safeParse(parsed);
+              if (!decoded.success) {
+                throw new ApiError('Unexpected active-contracts WebSocket message');
               }
-            } else if (!settled) {
-              // Treat any non-item as an error message
-              const error = toError(message);
-              settled = true;
-              reject(error);
-              throw error;
-            }
+              const message = decoded.data;
+
+              // Distinguish item vs error union members
+              if ('contractEntry' in message) {
+                results.push(message);
+                if (typeof params.onItem === 'function') {
+                  await params.onItem(message);
+                }
+              } else if (!settled) {
+                // Treat any non-item as an error message
+                const error = toError(message);
+                settled = true;
+                reject(error);
+                throw error;
+              }
+            },
+            onError: (err) => {
+              if (!settled) {
+                settled = true;
+                reject(err instanceof Error ? err : new Error(String(err)));
+              }
+            },
+            onClose: () => {
+              if (!settled) {
+                settled = true;
+                resolve(results);
+              }
+            },
           },
-          onError: (err) => {
-            if (!settled) {
-              settled = true;
-              reject(err instanceof Error ? err : new Error(String(err)));
-            }
-          },
-          onClose: () => {
-            if (!settled) {
-              settled = true;
-              resolve(results);
-            }
-          },
-        })
+          { idleTimeoutMs: validated.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS }
+        )
         .catch((err: unknown) => {
           if (!settled) {
             settled = true;

--- a/src/core/BaseClient.ts
+++ b/src/core/BaseClient.ts
@@ -47,8 +47,11 @@ export abstract class BaseClient {
       throw new ConfigurationError(`API configuration not found for ${this.apiType}`);
     }
 
-    this.httpClient = new HttpClient(this.clientConfig.logger, async () =>
-      this.runtime.getAuthenticationManager(this.config.authUrl, apiConfig.auth).authenticate()
+    const timeoutMs = apiConfig.timeoutMs ?? this.clientConfig.timeoutMs;
+    this.httpClient = new HttpClient(
+      this.clientConfig.logger,
+      async () => this.runtime.getAuthenticationManager(this.config.authUrl, apiConfig.auth).authenticate(),
+      timeoutMs === undefined ? {} : { timeoutMs }
     );
   }
 

--- a/src/core/http/HttpClient.ts
+++ b/src/core/http/HttpClient.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import axios, { type AxiosError, type AxiosInstance, type AxiosRequestConfig } from 'axios';
 import {
   ApiError,
   AuthenticationError,
@@ -35,6 +35,34 @@ export interface HttpClientRetryConfig {
   readonly delayMs: number;
 }
 
+/**
+ * Socket-inactivity timeout applied to every request unless a caller overrides it.
+ *
+ * Axios disables the socket timer entirely when no timeout is set, so a Canton endpoint that accepts the TCP connection
+ * and then stops responding suspends the awaiting caller forever. This value is a hang detector, not a latency budget:
+ * the timer resets on every received byte, and it is deliberately larger than any documented Canton blocking wait.
+ *
+ * The longest legitimate silence comes from the Ledger API command service, which holds a `submit-and-wait` response
+ * open until the command completes or its tracking timeout fires (`CommandServiceConfig.DefaultDefaultTrackingTimeout`,
+ * 5 minutes). Every other observed Canton/Splice server bound is shorter: the JSON API's own request timeout defaults
+ * to 20 seconds, Splice apps run a 38-second pekko request timeout, and Canton's console request timeout is 40 seconds.
+ * Ten minutes therefore leaves 2x headroom over the slowest legitimate operation.
+ *
+ * Use {@link RequestConfig.timeoutMs} for a different per-request floor, or an `AbortSignal` (for example
+ * `AbortSignal.timeout(ms)`) when a total deadline rather than an inactivity timer is needed.
+ */
+export const DEFAULT_HTTP_TIMEOUT_MS = 600_000;
+
+/** Construction-time transport options for {@link HttpClient}. */
+export interface HttpClientOptions {
+  /**
+   * Socket-inactivity timeout in milliseconds applied to every request from this client. Defaults to
+   * {@link DEFAULT_HTTP_TIMEOUT_MS}. `0` disables the timer and restores the unbounded-wait behavior; never use it for
+   * production workloads.
+   */
+  readonly timeoutMs?: number;
+}
+
 type HttpMethod = 'GET' | MutationHttpMethod;
 
 interface AttemptFailure<Body> {
@@ -48,6 +76,7 @@ export class HttpClient {
   private readonly axiosInstance: AxiosInstance;
   private readonly bearerTokenProvider: (() => Promise<string>) | undefined;
   private readonly logger: Logger | undefined;
+  private readonly defaultTimeoutMs: number;
   private retryConfig: HttpClientRetryConfig = { maxRetries: 3, delayMs: 6000 };
 
   // Error message formatting constants
@@ -57,10 +86,16 @@ export class HttpClient {
   private static readonly MAX_CONTEXT_KEYS = 3;
   private static readonly MAX_ATTEMPT_IDENTIFIER_LENGTH = 200;
 
-  constructor(logger?: Logger, bearerTokenProvider?: () => Promise<string>) {
-    this.axiosInstance = axios.create();
+  constructor(logger?: Logger, bearerTokenProvider?: () => Promise<string>, options: HttpClientOptions = {}) {
+    this.defaultTimeoutMs = HttpClient.validateTimeoutMs(options.timeoutMs, 'HTTP client') ?? DEFAULT_HTTP_TIMEOUT_MS;
+    this.axiosInstance = axios.create({ timeout: this.defaultTimeoutMs });
     this.bearerTokenProvider = bearerTokenProvider;
     this.logger = logger;
+  }
+
+  /** Socket-inactivity timeout in milliseconds applied to requests that do not override it. */
+  public getDefaultTimeoutMs(): number {
+    return this.defaultTimeoutMs;
   }
 
   /** Configure the default retry policy used only by requests classified as semantic reads. */
@@ -119,6 +154,7 @@ export class HttpClient {
     // options signal or retry object while a token/hook is pending change the in-flight request contract.
     const requestOptions = snapshotHttpRequestOptions(options);
     const requestConfig: RequestConfig = Object.freeze({ ...config });
+    const timeoutMs = HttpClient.validateTimeoutMs(requestConfig.timeoutMs, 'HTTP request') ?? this.defaultTimeoutMs;
     const {
       signal,
       retry: requestedRetry,
@@ -205,13 +241,20 @@ export class HttpClient {
       let dispatched = false;
       try {
         const headers = await awaitWithAbort(async (): Promise<Record<string, string>> => {
-          const builtHeaders = await this.buildHeaders(requestConfig);
+          const builtHeaders = await this.buildHeaders(requestConfig, timeoutMs);
           return builtHeaders;
         }, signal);
         throwIfAborted(signal);
         const requestBody = this.cloneBody(currentBody);
         dispatched = true;
-        const response = await this.dispatchRequest<T, Body>(method, attemptUrl, requestBody, headers, signal);
+        const response = await this.dispatchRequest<T, Body>(
+          method,
+          attemptUrl,
+          requestBody,
+          headers,
+          signal,
+          timeoutMs
+        );
 
         this.observeLog(
           attemptUrl,
@@ -427,10 +470,12 @@ export class HttpClient {
     url: string,
     body: Body,
     headers: Record<string, string>,
-    signal: AbortSignal | undefined
+    signal: AbortSignal | undefined,
+    timeoutMs: number
   ): Promise<T> {
     const axiosConfig: AxiosRequestConfig = {
       headers,
+      timeout: timeoutMs,
       ...(signal !== undefined ? { signal } : {}),
     };
 
@@ -446,7 +491,7 @@ export class HttpClient {
     }
   }
 
-  private async buildHeaders(config: RequestConfig): Promise<Record<string, string>> {
+  private async buildHeaders(config: RequestConfig, timeoutMs: number): Promise<Record<string, string>> {
     const headers: Record<string, string> = {};
 
     if (config.contentType) {
@@ -460,13 +505,32 @@ export class HttpClient {
         throw new AuthenticationError('Bearer token requested but no token provider is configured');
       }
 
-      const token = await this.bearerTokenProvider();
+      const token = await this.fetchBearerToken(this.bearerTokenProvider, timeoutMs);
       if (token) {
         headers['Authorization'] = `Bearer ${token}`;
       }
     }
 
     return headers;
+  }
+
+  /** Bound the token fetch too: a silent auth endpoint would otherwise suspend the request before it is dispatched. */
+  private async fetchBearerToken(provider: () => Promise<string>, timeoutMs: number): Promise<string> {
+    const tokenPromise = provider();
+    if (timeoutMs === 0) return tokenPromise;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new NetworkError(`Bearer token request timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([tokenPromise, timeoutPromise]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /** Invoke logging as a detached observer. Logger behavior can never affect request control flow. */
@@ -573,8 +637,24 @@ export class HttpClient {
     );
   }
 
+  /** Reject non-numeric or negative timeouts up front rather than letting axios silently disable the socket timer. */
+  private static validateTimeoutMs(timeoutMs: number | undefined, label: string): number | undefined {
+    if (timeoutMs === undefined) return undefined;
+    if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+      throw new ConfigurationError(`${label} timeoutMs must be a non-negative finite number`);
+    }
+    return timeoutMs;
+  }
+
   private handleRequestError(error: unknown): Error {
     if (error instanceof CantonError) return error;
+    if (this.isTimeoutError(error)) {
+      const method = error.config?.method?.toUpperCase() ?? 'GET';
+      return new NetworkError(
+        `Request timed out after ${error.config?.timeout ?? 'unknown'}ms without response data ` +
+          `[request: ${method} ${error.config?.url ?? 'unknown'}]`
+      );
+    }
     if (axios.isAxiosError(error)) {
       const status = error.response?.status;
       const { data, responseBody } = this.normalizeErrorResponseData(error.response?.data);
@@ -801,6 +881,12 @@ export class HttpClient {
 
   private isCanceledError(error: unknown): boolean {
     return axios.isCancel(error) || (axios.isAxiosError(error) && error.code === 'ERR_CANCELED');
+  }
+
+  /** A socket-inactivity timeout never reaches the server response, so it must not be reported as an API error. */
+  private isTimeoutError(error: unknown): error is AxiosError {
+    if (!axios.isAxiosError(error) || error.response !== undefined) return false;
+    return error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT';
   }
 
   private async abortableSleep(ms: number, signal: AbortSignal | undefined): Promise<void> {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -68,6 +68,11 @@ export interface ApiConfig {
   readonly auth: AuthConfig;
   partyId?: string;
   userId?: string;
+  /**
+   * Socket-inactivity timeout in milliseconds for every request to this API. Overrides {@link ClientConfig.timeoutMs}
+   * and defaults to `DEFAULT_HTTP_TIMEOUT_MS`.
+   */
+  timeoutMs?: number;
 }
 
 /** Full provider configuration with all API types required. */
@@ -88,6 +93,12 @@ export interface PartialProviderConfig {
 export interface RequestConfig {
   readonly contentType?: 'application/json' | 'application/octet-stream';
   readonly includeBearerToken?: boolean;
+  /**
+   * Socket-inactivity timeout in milliseconds for this request, overriding the client default. The timer resets on
+   * every received byte, so it bounds silence rather than total duration; pass an `AbortSignal` (for example
+   * `AbortSignal.timeout(ms)`) for a hard deadline. `0` disables the timer.
+   */
+  readonly timeoutMs?: number;
 }
 
 /**
@@ -108,6 +119,11 @@ export interface ClientConfig {
   debug?: boolean;
 
   authUrl?: string;
+  /**
+   * Socket-inactivity timeout in milliseconds applied to every HTTP request made by clients created from this config.
+   * Defaults to `DEFAULT_HTTP_TIMEOUT_MS`; a per-API {@link ApiConfig.timeoutMs} takes precedence.
+   */
+  timeoutMs?: number;
   /** Party ID. Mutable so it can be set at runtime after client initialization (e.g., LocalNet discovery). */
   partyId?: string;
   userId?: string;

--- a/src/core/ws/WebSocketClient.ts
+++ b/src/core/ws/WebSocketClient.ts
@@ -1,6 +1,7 @@
 import { calculateTokenRefreshTime } from '@hardlydifficult/websocket';
 import WebSocket, { type RawData } from 'ws';
 import { type BaseClient } from '../BaseClient';
+import { ConfigurationError } from '../errors';
 import { WebSocketErrorUtils } from './WebSocketErrorUtils';
 
 /** Handle returned from a WebSocket connection, used to check status and disconnect. */
@@ -31,6 +32,13 @@ function toError(value: unknown): Error {
 
 /** Options for WebSocket token refresh lifecycle. */
 export interface WebSocketOptions {
+  /**
+   * Close the socket when no message arrives for this many milliseconds. The timer starts when the socket opens and
+   * resets on every inbound message, so it detects a peer that completed the handshake and then went silent. Omit it,
+   * or pass `0`, to wait indefinitely (the default for long-lived subscriptions).
+   */
+  readonly idleTimeoutMs?: number;
+
   /**
    * Called when the token is about to expire and refresh is scheduled. Use this to prepare for reconnection (e.g.,
    * track current offset for resumption).
@@ -68,6 +76,10 @@ export class WebSocketClient {
     handlers: WebSocketHandlers<InboundMessage>,
     options?: WebSocketOptions
   ): Promise<WebSocketSubscription> {
+    const idleTimeoutMs = options?.idleTimeoutMs ?? 0;
+    if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs < 0) {
+      throw new ConfigurationError('WebSocket idleTimeoutMs must be a non-negative finite number');
+    }
     const baseUrl = this.client.getApiUrl();
     const wsUrl = this.buildWsUrl(baseUrl, path);
 
@@ -170,6 +182,31 @@ export class WebSocketClient {
       }
     };
 
+    // Idle watchdog for a peer that completes the handshake and then stops sending. Without it, a caller awaiting a
+    // terminal message (such as the active-contracts snapshot) waits forever.
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearIdleTimer = (): void => {
+      if (idleTimer !== null) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+    };
+    const restartIdleTimer = (): void => {
+      if (idleTimeoutMs === 0) return;
+      clearIdleTimer();
+      idleTimer = setTimeout(() => {
+        idleTimer = null;
+        const error = new Error(`WebSocket idle timeout: no message received for ${idleTimeoutMs}ms`);
+        log('idle_timeout', { idleTimeoutMs });
+        notifyError(error);
+        try {
+          socket.close(4008, 'WebSocket idle timeout');
+        } catch (err) {
+          reportAuxiliaryFailure('WebSocket idle timeout close failed', { error: toError(err).message });
+        }
+      }, idleTimeoutMs);
+    };
+
     log('connect', { headers: token ? { Authorization: '[REDACTED]' } : undefined, protocols });
 
     // Schedule proactive token refresh if we have token timing and callbacks
@@ -229,6 +266,7 @@ export class WebSocketClient {
     }
 
     socket.on('open', () => {
+      restartIdleTimer();
       try {
         socket.send(JSON.stringify(requestMessage));
         log('send', requestMessage);
@@ -250,6 +288,7 @@ export class WebSocketClient {
     });
 
     socket.on('message', (rawData: RawData) => {
+      restartIdleTimer();
       // Convert RawData to string safely
       let dataString: string;
       if (Buffer.isBuffer(rawData)) {
@@ -295,6 +334,7 @@ export class WebSocketClient {
     });
 
     socket.on('close', (code: number, reason: Buffer) => {
+      clearIdleTimer();
       // Clear token refresh timer on close
       if (tokenRefreshTimer !== null) {
         clearTimeout(tokenRefreshTimer);
@@ -317,6 +357,7 @@ export class WebSocketClient {
 
     return {
       close: () => {
+        clearIdleTimer();
         // Clear token refresh timer
         if (tokenRefreshTimer !== null) {
           clearTimeout(tokenRefreshTimer);

--- a/test/unit/clients/scan-api.test.ts
+++ b/test/unit/clients/scan-api.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   ApiError,
   CantonRuntime,
+  DEFAULT_HTTP_TIMEOUT_MS,
   NetworkError,
   UnknownMutationOutcomeError,
   type ClientConfig,
@@ -833,6 +834,7 @@ describe('ScanApiClient', () => {
         headers: {
           'Content-Type': 'application/json',
         },
+        timeout: DEFAULT_HTTP_TIMEOUT_MS,
       }
     );
     const requestHeaders = mockAxiosInstance.post.mock.calls[0]?.[2]?.headers;
@@ -876,6 +878,7 @@ describe('ScanApiClient', () => {
         headers: {
           'Content-Type': 'application/json',
         },
+        timeout: DEFAULT_HTTP_TIMEOUT_MS,
       }
     );
     const requestHeaders = mockAxiosInstance.post.mock.calls[0]?.[2]?.headers;
@@ -927,6 +930,7 @@ describe('ScanApiClient', () => {
         headers: {
           'Content-Type': 'application/json',
         },
+        timeout: DEFAULT_HTTP_TIMEOUT_MS,
       }
     );
     const requestHeaders = mockAxiosInstance.post.mock.calls[0]?.[2]?.headers;

--- a/test/unit/clients/validator-api-health.test.ts
+++ b/test/unit/clients/validator-api-health.test.ts
@@ -16,7 +16,7 @@ jest.mock('axios', () => {
 });
 
 import { ValidatorApiClient } from '../../../src';
-import { CantonRuntime, type ClientConfig } from '../../../src/core';
+import { CantonRuntime, DEFAULT_HTTP_TIMEOUT_MS, type ClientConfig } from '../../../src/core';
 
 interface MockAxiosInstance {
   get: jest.Mock<Promise<{ data: undefined }>, [string, Record<string, unknown>]>;
@@ -65,6 +65,7 @@ describe('ValidatorApiClient health checks', () => {
 
     expect(mockAxiosInstance.get).toHaveBeenCalledWith('http://localhost:3903/api/validator/readyz', {
       headers: { 'Content-Type': 'application/json' },
+      timeout: DEFAULT_HTTP_TIMEOUT_MS,
     });
   });
 
@@ -76,6 +77,21 @@ describe('ValidatorApiClient health checks', () => {
 
     expect(mockAxiosInstance.get).toHaveBeenCalledWith('http://localhost:3903/api/validator/livez', {
       headers: { 'Content-Type': 'application/json' },
+      timeout: DEFAULT_HTTP_TIMEOUT_MS,
+    });
+  });
+
+  it('forwards a caller AbortSignal from the generated wrapper to the transport', async () => {
+    const { client, mockAxiosInstance } = createClient();
+    mockAxiosInstance.get.mockResolvedValueOnce({ data: undefined });
+    const controller = new AbortController();
+
+    await expect(client.isReady({ signal: controller.signal })).resolves.toBeUndefined();
+
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('http://localhost:3903/api/validator/readyz', {
+      headers: { 'Content-Type': 'application/json' },
+      timeout: DEFAULT_HTTP_TIMEOUT_MS,
+      signal: controller.signal,
     });
   });
 

--- a/test/unit/core/client-timeout-config.test.ts
+++ b/test/unit/core/client-timeout-config.test.ts
@@ -1,0 +1,89 @@
+import axios from 'axios';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual<typeof import('axios')>('axios');
+  return {
+    ...actual,
+    create: jest.fn(() => ({
+      get: jest.fn(),
+      post: jest.fn(),
+      delete: jest.fn(),
+      patch: jest.fn(),
+    })),
+    isAxiosError: actual.isAxiosError,
+    isCancel: actual.isCancel,
+  };
+});
+
+import {
+  Canton,
+  CantonRuntime,
+  DEFAULT_HTTP_TIMEOUT_MS,
+  LedgerJsonApiClient,
+  type ApiConfig,
+  type ClientConfig,
+} from '../../../src';
+
+const auth: ApiConfig['auth'] = {
+  grantType: 'client_credentials',
+  clientId: 'client',
+  clientSecret: 'secret',
+};
+
+function createClientConfig(overrides: Partial<ClientConfig> = {}, apiTimeoutMs?: number): ClientConfig {
+  return {
+    network: 'localnet',
+    authUrl: 'https://auth.example',
+    ...overrides,
+    apis: {
+      LEDGER_JSON_API: {
+        apiUrl: 'https://ledger.example',
+        auth,
+        ...(apiTimeoutMs === undefined ? {} : { timeoutMs: apiTimeoutMs }),
+      },
+    },
+  };
+}
+
+function createdTimeouts(): number[] {
+  return (axios.create as jest.Mock).mock.calls.map(([config]) => (config as { timeout: number }).timeout);
+}
+
+describe('client timeout configuration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the default timeout when none is configured', () => {
+    new LedgerJsonApiClient(new CantonRuntime(createClientConfig()));
+
+    expect(createdTimeouts()).toEqual([DEFAULT_HTTP_TIMEOUT_MS]);
+  });
+
+  it('applies a client-wide timeout', () => {
+    new LedgerJsonApiClient(new CantonRuntime(createClientConfig({ timeoutMs: 30_000 })));
+
+    expect(createdTimeouts()).toEqual([30_000]);
+  });
+
+  it('prefers a per-API timeout over the client-wide timeout', () => {
+    new LedgerJsonApiClient(new CantonRuntime(createClientConfig({ timeoutMs: 30_000 }, 5_000)));
+
+    expect(createdTimeouts()).toEqual([5_000]);
+  });
+
+  it('propagates the Canton-level timeout to every service client', () => {
+    new Canton({
+      network: 'localnet',
+      authUrl: 'https://auth.example',
+      timeoutMs: 45_000,
+      apis: {
+        LEDGER_JSON_API: { apiUrl: 'https://ledger.example', auth },
+        VALIDATOR_API: { apiUrl: 'https://validator.example', auth },
+        SCAN_API: { apiUrl: 'https://scan.example', auth },
+      },
+    });
+
+    expect(createdTimeouts()).toEqual([45_000, 45_000, 45_000]);
+  });
+});

--- a/test/unit/core/http-client-hang.test.ts
+++ b/test/unit/core/http-client-hang.test.ts
@@ -1,0 +1,79 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { NetworkError } from '../../../src/core/errors';
+import { HttpClient } from '../../../src/core/http/HttpClient';
+
+/** Server that accepts the connection and then behaves like the Canton endpoint that caused the outage. */
+async function startServer(onRequest: http.RequestListener): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer(onRequest);
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => {
+          resolve();
+        });
+      }),
+  };
+}
+
+describe('HttpClient against a silent server', () => {
+  it('rejects instead of awaiting forever when the server never responds', async () => {
+    const server = await startServer(() => {
+      // Accept the request and never write a response.
+    });
+    const client = new HttpClient(undefined, undefined, { timeoutMs: 250 });
+    client.setRetryConfig({ maxRetries: 0, delayMs: 0 });
+
+    const startedAt = Date.now();
+    await expect(client.makeGetRequest(`${server.url}/v2/version`)).rejects.toThrow(NetworkError);
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+
+    await server.close();
+  });
+
+  it('reports the configured timeout in the error message', async () => {
+    const server = await startServer(() => {
+      // Accept the request and never write a response.
+    });
+    const client = new HttpClient(undefined, undefined, { timeoutMs: 10_000 });
+    client.setRetryConfig({ maxRetries: 0, delayMs: 0 });
+
+    await expect(client.makeGetRequest(`${server.url}/v2/version`, { timeoutMs: 250 })).rejects.toThrow(
+      /Request timed out after 250ms without response data/u
+    );
+
+    await server.close();
+  });
+
+  it('honors an AbortSignal deadline while the socket keeps trickling data', async () => {
+    // The inactivity timer never fires here because bytes keep arriving; only a hard deadline can stop this request.
+    const timers: Array<ReturnType<typeof setInterval>> = [];
+    const server = await startServer((_request, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.write('[');
+      timers.push(
+        setInterval(() => {
+          response.write(' ');
+        }, 20)
+      );
+    });
+    const client = new HttpClient(undefined, undefined, { timeoutMs: 60_000 });
+    client.setRetryConfig({ maxRetries: 0, delayMs: 0 });
+
+    const startedAt = Date.now();
+    await expect(
+      client.makeGetRequest(`${server.url}/v2/state/active-contracts`, {}, { signal: AbortSignal.timeout(300) })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+
+    for (const timer of timers) clearInterval(timer);
+    await server.close();
+  });
+});

--- a/test/unit/core/http-client-timeout.test.ts
+++ b/test/unit/core/http-client-timeout.test.ts
@@ -1,0 +1,126 @@
+import axios from 'axios';
+import { ConfigurationError, NetworkError } from '../../../src/core/errors';
+import { DEFAULT_HTTP_TIMEOUT_MS, HttpClient } from '../../../src/core/http/HttpClient';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual<typeof import('axios')>('axios');
+  return {
+    ...actual,
+    create: jest.fn(() => ({
+      get: jest.fn().mockResolvedValue({ data: {} }),
+      post: jest.fn().mockResolvedValue({ data: {} }),
+      delete: jest.fn().mockResolvedValue({ data: {} }),
+      patch: jest.fn().mockResolvedValue({ data: {} }),
+    })),
+    isAxiosError: actual.isAxiosError,
+    isCancel: actual.isCancel,
+  };
+});
+
+interface MockAxiosInstance {
+  readonly get: jest.Mock;
+  readonly post: jest.Mock;
+}
+
+function lastAxiosInstance(): MockAxiosInstance {
+  const { results } = (axios.create as jest.Mock).mock;
+  const lastResult = results[results.length - 1] as { value?: MockAxiosInstance } | undefined;
+  if (!lastResult?.value) throw new Error('Expected HttpClient to create an axios instance.');
+  return lastResult.value;
+}
+
+function createdTimeouts(): number[] {
+  return (axios.create as jest.Mock).mock.calls.map(([config]) => (config as { timeout: number }).timeout);
+}
+
+function createClient(timeoutMs?: number): HttpClient {
+  const client = new HttpClient(undefined, undefined, timeoutMs === undefined ? {} : { timeoutMs });
+  client.setRetryConfig({ maxRetries: 0, delayMs: 0 });
+  return client;
+}
+
+describe('HttpClient timeouts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies the default socket timeout to the axios instance', () => {
+    const client = createClient();
+
+    expect(createdTimeouts()).toEqual([DEFAULT_HTTP_TIMEOUT_MS]);
+    expect(client.getDefaultTimeoutMs()).toBe(DEFAULT_HTTP_TIMEOUT_MS);
+  });
+
+  it('defaults to a timeout larger than the Canton command tracking timeout', () => {
+    // Canton holds submit-and-wait responses open for up to CommandServiceConfig.DefaultDefaultTrackingTimeout (5min).
+    expect(DEFAULT_HTTP_TIMEOUT_MS).toBeGreaterThan(5 * 60 * 1000);
+  });
+
+  it('applies a client-level timeout override', async () => {
+    const client = createClient(1234);
+
+    expect(createdTimeouts()).toEqual([1234]);
+
+    await client.makeGetRequest('https://ledger.example/v2/version');
+
+    const [, config] = lastAxiosInstance().get.mock.calls[0] as [string, { timeout: number }];
+    expect(config.timeout).toBe(1234);
+  });
+
+  it('applies a per-request timeout override', async () => {
+    const client = createClient(1234);
+
+    await client.makeGetRequest('https://ledger.example/v2/version', { timeoutMs: 42 });
+
+    const [, config] = lastAxiosInstance().get.mock.calls[0] as [string, { timeout: number }];
+    expect(config.timeout).toBe(42);
+  });
+
+  it('falls back to the client timeout when a request does not override it', async () => {
+    const client = createClient();
+
+    await client.makePostRequest('https://ledger.example/v2/commands/submit', { commands: [] });
+
+    const [, , config] = lastAxiosInstance().post.mock.calls[0] as [string, unknown, { timeout: number }];
+    expect(config.timeout).toBe(DEFAULT_HTTP_TIMEOUT_MS);
+  });
+
+  it('allows a request to opt out of the timeout', async () => {
+    const client = createClient();
+
+    await client.makeGetRequest('https://ledger.example/v2/version', { timeoutMs: 0 });
+
+    const [, config] = lastAxiosInstance().get.mock.calls[0] as [string, { timeout: number }];
+    expect(config.timeout).toBe(0);
+  });
+
+  it('rejects invalid client timeouts', () => {
+    expect(() => new HttpClient(undefined, undefined, { timeoutMs: -1 })).toThrow(ConfigurationError);
+    expect(() => new HttpClient(undefined, undefined, { timeoutMs: Number.NaN })).toThrow(ConfigurationError);
+  });
+
+  it('rejects invalid per-request timeouts', async () => {
+    const client = createClient();
+
+    await expect(client.makeGetRequest('https://ledger.example/v2/version', { timeoutMs: -1 })).rejects.toThrow(
+      ConfigurationError
+    );
+  });
+
+  it('bounds a bearer token provider that never resolves', async () => {
+    const client = new HttpClient(
+      undefined,
+      async () =>
+        new Promise<string>(() => {
+          // A silent auth endpoint would otherwise suspend the request before it is dispatched.
+        }),
+      { timeoutMs: 50 }
+    );
+    client.setRetryConfig({ maxRetries: 0, delayMs: 0 });
+
+    await expect(
+      client.makeGetRequest('https://ledger.example/v2/version', { includeBearerToken: true })
+    ).rejects.toThrow(new NetworkError('Bearer token request timed out after 50ms'));
+    expect(lastAxiosInstance().get).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/core/websocket-client.test.ts
+++ b/test/unit/core/websocket-client.test.ts
@@ -422,6 +422,114 @@ describe('WebSocketClient', () => {
     expect(socket.close).toHaveBeenCalledWith(4000, 'Token refresh required');
   });
 
+  it('closes a socket that goes silent after the handshake when an idle timeout is set', async () => {
+    jest.useFakeTimers();
+    const logRequestResponse = jest.fn().mockResolvedValue(undefined);
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => ({ logRequestResponse }),
+    } as unknown as BaseClient;
+    const onError = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn(), onError },
+      { idleTimeoutMs: 30_000 }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('open');
+    await jest.advanceTimersByTimeAsync(29_000);
+    expect(socket.close).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(2_000);
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'WebSocket idle timeout: no message received for 30000ms' })
+    );
+    expect(socket.close).toHaveBeenCalledWith(4008, 'WebSocket idle timeout');
+  });
+
+  it('restarts the idle timeout on every inbound message', async () => {
+    jest.useFakeTimers();
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => undefined,
+    } as unknown as BaseClient;
+    const onError = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn(), onError },
+      { idleTimeoutMs: 30_000 }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('open');
+    for (let tick = 0; tick < 5; tick += 1) {
+      await jest.advanceTimersByTimeAsync(20_000);
+      socket.emit('message', Buffer.from(JSON.stringify({ contractEntry: { JsActiveContract: {} } })));
+    }
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(socket.close).not.toHaveBeenCalled();
+  });
+
+  it('waits indefinitely when no idle timeout is configured', async () => {
+    jest.useFakeTimers();
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => undefined,
+    } as unknown as BaseClient;
+    const onError = jest.fn();
+
+    await new WebSocketClient(client).connect(
+      '/v2/state/active-contracts',
+      { activeAtOffset: 42 },
+      { onMessage: jest.fn(), onError }
+    );
+    const socket = mockSockets[0];
+    if (!socket) throw new Error('Expected WebSocketClient to construct one socket.');
+
+    socket.emit('open');
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(socket.close).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid idle timeout', async () => {
+    const client = {
+      getApiUrl: () => 'https://ledger.example',
+      authenticate: jest.fn().mockResolvedValue('token'),
+      getTokenIssuedAt: () => null,
+      getTokenExpiryTime: () => null,
+      getLogger: () => undefined,
+    } as unknown as BaseClient;
+
+    await expect(
+      new WebSocketClient(client).connect(
+        '/v2/state/active-contracts',
+        { activeAtOffset: 42 },
+        { onMessage: jest.fn() },
+        { idleTimeoutMs: -1 }
+      )
+    ).rejects.toThrow('WebSocket idleTimeoutMs must be a non-negative finite number');
+  });
+
   it('isolates a rejected close callback after delivering the close event', async () => {
     const loggerError = jest.fn();
     const logRequestResponse = jest.fn().mockResolvedValue(undefined);

--- a/test/unit/operations/get-active-contracts.test.ts
+++ b/test/unit/operations/get-active-contracts.test.ts
@@ -64,8 +64,25 @@ describe('GetActiveContracts', () => {
           },
         },
       },
+      expect.any(Object),
       expect.any(Object)
     );
+  });
+
+  it('applies a default idle timeout so a silent snapshot stream cannot hang', async () => {
+    await new GetActiveContracts({} as never).execute({ parties: ['Alice'], activeAtOffset: 42 });
+
+    expect(mockConnect).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.any(Object), {
+      idleTimeoutMs: 600_000,
+    });
+  });
+
+  it('forwards a caller-supplied idle timeout', async () => {
+    await new GetActiveContracts({} as never).execute({ parties: ['Alice'], activeAtOffset: 42, idleTimeoutMs: 0 });
+
+    expect(mockConnect).toHaveBeenCalledWith(expect.any(String), expect.any(Object), expect.any(Object), {
+      idleTimeoutMs: 0,
+    });
   });
 
   it('rejects a null frame without treating it as a contract or Canton error', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`HttpClient` created its axios instance with `axios.create()` and no `timeout`. Axios defaults `timeout` to `0`, which is disabled — confirmed in the installed axios adapter, which calls `req.setTimeout(0)` and turns the socket timer off entirely. A Canton endpoint that accepts a TCP connection and then goes silent hangs the `await` forever.

This is the root cause of a 5-day Fairmint rewards outage: worker processes stayed `online` under PM2 while blocked on a request that could never complete. Every consumer of this SDK has the same exposure — for Fairmint that's 22 workers, only some of which have any hang detection of their own.

## Changes

All additive: new optional config fields, a new optional constructor argument, one new exported constant.

- **Default socket timeout of 600,000 ms** on the axios instance, overridable at three levels: `CantonConfig.timeoutMs` (client-wide), `apis[SERVICE].timeoutMs` (per service), and `RequestConfig.timeoutMs` (per request)
- **Timeout errors normalize to `NetworkError`** naming the configured timeout and the request, instead of an `ApiError` reading `HTTP undefined`
- **The bearer token fetch is bounded** by the same timeout, so a silent auth server fails the request rather than hanging it
- **WebSocket idle timeout** — `WebSocketOptions.idleTimeoutMs` is opt-in on `connect`; the timer starts on open, resets on every inbound message, and closes with code 4008. `getActiveContracts` defaults it to 600,000 ms and accepts an override (`0` restores unbounded waiting).

## Why 600,000 ms

A too-short floor on a mutation turns a slow-but-successful submission into an `UnknownMutationOutcomeError`, which is worse than a bounded hang. From the pinned `libs/splice` submodule at `61a5360`:

| Bound | Value | Source |
|---|---|---|
| Ledger API command tracking timeout | 5 min | `CommandServiceConfig.DefaultDefaultTrackingTimeout` |
| JSON API server request timeout | 20 s | `JsonApiConfig.defaultRequestTimeout` |
| Splice app pekko request timeout | 38 s | `application.conf` |
| Canton console request timeout | 40 s | `CantonConfig.requestTimeout` |

The longest legitimate silence on the wire is the command service holding a `submit-and-wait` response open for up to 5 minutes, so 10 minutes is 2x headroom over the slowest thing Canton can legitimately do.

Note this is a socket-**inactivity** timer (it resets on every byte received), not a total deadline, so a large ACS fetch or DAR upload that keeps streaming is unaffected. For a hard wall-clock deadline, pass `AbortSignal.timeout(ms)` as `options.signal` — generated methods already forward it.

## Scope notes

`subscribeToUpdates` and `subscribeToCompletions` stay unbounded on purpose: idle periods are normal on a long-lived subscription, and those callers hold a `WebSocketSubscription.close()`. Threading `WebSocketOptions` through the operation factory is the follow-up if opt-in idle timeouts are wanted there.

Generated wrappers needed no change — the generator already emits `(params, options?)` carrying `signal` for every REST operation. The three params-only methods are all WebSocket-backed and never touch axios.

## Test plan

- [x] 78 suites / 1034 tests pass; `npm run build` and `check:package-artifacts` pass
- [x] Hang proof: a real `http.createServer` that accepts the connection and never responds — the request rejects with `NetworkError` in under 5s instead of hanging
- [x] Inactivity vs deadline distinguished: against a server trickling a byte every 20ms, only `AbortSignal.timeout(300)` stops the request
- [x] `AbortSignal` verified reaching the axios config through a generated method
- [ ] Consumer bump: Fairmint/canton picks up the published patch

## Follow-ups found, not fixed here

The OAuth token request in `@hardlydifficult/rest-client` has no timeout of its own — the SDK's `await` on it is now bounded, but that package's socket is not. Separately, a connection-refused error still surfaces as `ApiError: HTTP undefined`; left alone to keep this change additive.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e070d944-5f75-41e4-8d9a-664660840ed5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e070d944-5f75-41e4-8d9a-664660840ed5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

